### PR TITLE
feat: STD-15 장소 정보 조회

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/exception/place/NotFoundPlaceException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/place/NotFoundPlaceException.java
@@ -1,0 +1,20 @@
+package com.tenten.studybadge.common.exception.place;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundPlaceException extends AbstractException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+    @Override
+    public String getErrorCode() {
+        return "NOT_FOUND_PLACE";
+    }
+    @Override
+    public String getMessage() {
+        return "존재하지 않는 장소입니다.";
+    }
+}

--- a/src/main/java/com/tenten/studybadge/place/controller/PlaceController.java
+++ b/src/main/java/com/tenten/studybadge/place/controller/PlaceController.java
@@ -1,5 +1,6 @@
 package com.tenten.studybadge.place.controller;
 
+import com.tenten.studybadge.place.dto.PlaceCreateResponse;
 import com.tenten.studybadge.place.dto.PlaceRequest;
 import com.tenten.studybadge.place.dto.PlaceResponse;
 import com.tenten.studybadge.place.service.PlaceService;
@@ -28,7 +29,7 @@ public class PlaceController {
   @Operation(summary = "장소 저장", description = "지도 api에서 선택한 장소 저장" ,security = @SecurityRequirement(name = "bearerToken"))
   @Parameter(name = "studyChannelId", description = "일정을 만드는 study channel의 id 값", required = true)
   @Parameter(name = "PlaceRequest", description = "저장할 장소 request", required = true )
-  public ResponseEntity<PlaceResponse> postPlace(
+  public ResponseEntity<PlaceCreateResponse> postPlace(
       @PathVariable Long studyChannelId,
       @Valid @RequestBody PlaceRequest placeRequest)  {
     return ResponseEntity.ok(placeService.postPlace(studyChannelId, placeRequest));

--- a/src/main/java/com/tenten/studybadge/place/controller/PlaceController.java
+++ b/src/main/java/com/tenten/studybadge/place/controller/PlaceController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,4 +34,12 @@ public class PlaceController {
     return ResponseEntity.ok(placeService.postPlace(studyChannelId, placeRequest));
   }
 
+
+  @GetMapping("/study-channels/{studyChannelId}/places/{placeId}")
+  @Operation(summary = "장소 정보 조회", description = "오프라인 일정의 장소 정보 조회" ,security = @SecurityRequirement(name = "bearerToken"))
+  @Parameter(name = "studyChannelId", description = "일정을 만드는 study channel의 id 값", required = true)
+  @Parameter(name = "placeId", description = "장소의 id 값", required = true)
+  public ResponseEntity<PlaceResponse> getPlace(@PathVariable Long studyChannelId, @PathVariable Long placeId)  {
+    return ResponseEntity.ok(placeService.getPlace(studyChannelId, placeId));
+  }
 }

--- a/src/main/java/com/tenten/studybadge/place/dto/PlaceCreateResponse.java
+++ b/src/main/java/com/tenten/studybadge/place/dto/PlaceCreateResponse.java
@@ -9,10 +9,6 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class PlaceResponse {
+public class PlaceCreateResponse {
   private long id;
-  private double lat;
-  private double lng;
-  private String placeName;
-  private String placeAddress;
 }

--- a/src/main/java/com/tenten/studybadge/place/service/PlaceService.java
+++ b/src/main/java/com/tenten/studybadge/place/service/PlaceService.java
@@ -5,6 +5,7 @@ import com.tenten.studybadge.common.exception.place.NotFoundPlaceException;
 import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelException;
 import com.tenten.studybadge.place.domain.entity.Place;
 import com.tenten.studybadge.place.domain.repository.PlaceRepository;
+import com.tenten.studybadge.place.dto.PlaceCreateResponse;
 import com.tenten.studybadge.place.dto.PlaceRequest;
 import com.tenten.studybadge.place.dto.PlaceResponse;
 import com.tenten.studybadge.study.channel.domain.repository.StudyChannelRepository;
@@ -18,7 +19,7 @@ public class PlaceService {
   private final PlaceRepository placeRepository;
   private final StudyChannelRepository studyChannelRepository;
 
-  public PlaceResponse postPlace(Long studyChannelId, PlaceRequest placeRequest) {
+  public PlaceCreateResponse postPlace(Long studyChannelId, PlaceRequest placeRequest) {
     studyChannelRepository.findById(studyChannelId)
         .orElseThrow(NotFoundStudyChannelException::new);
 
@@ -29,10 +30,10 @@ public class PlaceService {
       if (!place.getPlaceName().equals(placeRequest.getPlaceName())) {
         place.setPlaceName(placeRequest.getPlaceName());
       }
-      return new PlaceResponse(place.getId());
+      return new PlaceCreateResponse(place.getId());
     }
 
-    return new PlaceResponse(placeRepository.save(placeRequest.toEntity()).getId());
+    return new PlaceCreateResponse(placeRepository.save(placeRequest.toEntity()).getId());
   }
 
   public PlaceResponse getPlace(Long studyChannelId, Long placeId) {
@@ -42,6 +43,12 @@ public class PlaceService {
     Place place = placeRepository.findById(placeId)
         .orElseThrow(NotFoundPlaceException::new);
 
-    return new PlaceResponse(place.getId());
+    return PlaceResponse.builder()
+        .id(place.getId())
+        .lat(place.getLat())
+        .lng(place.getLng())
+        .placeName(place.getPlaceName())
+        .placeAddress(place.getPlaceAddress())
+        .build();
   }
 }

--- a/src/main/java/com/tenten/studybadge/place/service/PlaceService.java
+++ b/src/main/java/com/tenten/studybadge/place/service/PlaceService.java
@@ -1,6 +1,8 @@
 package com.tenten.studybadge.place.service;
 
 
+import com.tenten.studybadge.common.exception.member.NotFoundMemberException;
+import com.tenten.studybadge.common.exception.place.NotFoundPlaceException;
 import com.tenten.studybadge.place.domain.entity.Place;
 import com.tenten.studybadge.place.domain.repository.PlaceRepository;
 import com.tenten.studybadge.place.dto.PlaceRequest;
@@ -35,5 +37,17 @@ public class PlaceService {
     }
 
     return new PlaceResponse(placeRepository.save(placeRequest.toEntity()).getId());
+  }
+
+  public PlaceResponse getPlace(Long studyChannelId, Long placeId) {
+    // TODO studyChannel Exception 사용 예정
+    studyChannelRepository.findById(studyChannelId).orElseThrow(
+        (() -> new EntityNotFoundException(
+            "StudyChannel with id " + studyChannelId + " not found")));
+
+    Place place = placeRepository.findById(placeId)
+        .orElseThrow(NotFoundPlaceException::new);
+
+    return new PlaceResponse(place.getId());
   }
 }

--- a/src/main/java/com/tenten/studybadge/place/service/PlaceService.java
+++ b/src/main/java/com/tenten/studybadge/place/service/PlaceService.java
@@ -1,14 +1,13 @@
 package com.tenten.studybadge.place.service;
 
 
-import com.tenten.studybadge.common.exception.member.NotFoundMemberException;
 import com.tenten.studybadge.common.exception.place.NotFoundPlaceException;
+import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelException;
 import com.tenten.studybadge.place.domain.entity.Place;
 import com.tenten.studybadge.place.domain.repository.PlaceRepository;
 import com.tenten.studybadge.place.dto.PlaceRequest;
 import com.tenten.studybadge.place.dto.PlaceResponse;
 import com.tenten.studybadge.study.channel.domain.repository.StudyChannelRepository;
-import jakarta.persistence.EntityNotFoundException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,11 +19,8 @@ public class PlaceService {
   private final StudyChannelRepository studyChannelRepository;
 
   public PlaceResponse postPlace(Long studyChannelId, PlaceRequest placeRequest) {
-
-    // TODO studyChannel Exception 사용 예정
-    studyChannelRepository.findById(studyChannelId).orElseThrow(
-        (() -> new EntityNotFoundException(
-            "StudyChannel with id " + studyChannelId + " not found")));
+    studyChannelRepository.findById(studyChannelId)
+        .orElseThrow(NotFoundStudyChannelException::new);
 
     Optional<Place> placeByStudyChannelIdAndXAndY = placeRepository.findPlaceByLatAndLng(
         placeRequest.getLat(), placeRequest.getLng());
@@ -40,10 +36,8 @@ public class PlaceService {
   }
 
   public PlaceResponse getPlace(Long studyChannelId, Long placeId) {
-    // TODO studyChannel Exception 사용 예정
-    studyChannelRepository.findById(studyChannelId).orElseThrow(
-        (() -> new EntityNotFoundException(
-            "StudyChannel with id " + studyChannelId + " not found")));
+    studyChannelRepository.findById(studyChannelId)
+        .orElseThrow(NotFoundStudyChannelException::new);
 
     Place place = placeRepository.findById(placeId)
         .orElseThrow(NotFoundPlaceException::new);

--- a/src/test/java/com/tenten/studybadge/place/service/PlaceServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/place/service/PlaceServiceTest.java
@@ -3,11 +3,13 @@ package com.tenten.studybadge.place.service;
 import static com.tenten.studybadge.type.study.channel.Category.IT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
+import com.tenten.studybadge.common.exception.place.NotFoundPlaceException;
 import com.tenten.studybadge.place.domain.entity.Place;
 import com.tenten.studybadge.place.domain.repository.PlaceRepository;
 import com.tenten.studybadge.place.dto.PlaceRequest;
@@ -143,5 +145,36 @@ public class PlaceServiceTest {
 
     // then
     assertEquals(existingPlace.getPlaceName(), "Old Name");
+  }
+
+
+  @Test
+  @DisplayName("장소 조회 성공 테스트")
+  void getPlace_ShouldReturnPlaceResponse() {
+    // given
+    given(placeRepository.findById(1L)).willReturn(Optional.of(place));
+    given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
+
+    // when
+    PlaceResponse result = placeService.getPlace(1L, 1L);
+
+    // then
+    assertEquals(place.getId(), result.getId());
+
+  }
+
+  @Test
+  @DisplayName("장소 조회 실패 테스트")
+  void getPlace_ShouldThrowException_WhenPlaceNotFound() {
+    // given
+    given(placeRepository.findById(anyLong())).willReturn(Optional.empty());
+    given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
+
+    // when & then
+    NotFoundPlaceException exception = assertThrows(NotFoundPlaceException.class, () -> {
+      placeService.getPlace(1L, 1L);
+    });
+
+    assertEquals( "존재하지 않는 장소입니다.", exception.getMessage());
   }
 }

--- a/src/test/java/com/tenten/studybadge/place/service/PlaceServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/place/service/PlaceServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import com.tenten.studybadge.common.exception.place.NotFoundPlaceException;
 import com.tenten.studybadge.place.domain.entity.Place;
 import com.tenten.studybadge.place.domain.repository.PlaceRepository;
+import com.tenten.studybadge.place.dto.PlaceCreateResponse;
 import com.tenten.studybadge.place.dto.PlaceRequest;
 import com.tenten.studybadge.place.dto.PlaceResponse;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
@@ -108,7 +109,7 @@ public class PlaceServiceTest {
     given(placeRepository.save(any(Place.class))).willReturn(place);
 
     // when
-    PlaceResponse result = placeService.postPlace(1L, placeRequest);
+    PlaceCreateResponse result = placeService.postPlace(1L, placeRequest);
 
     // then
     verify(placeRepository).save(any(Place.class));
@@ -125,7 +126,7 @@ public class PlaceServiceTest {
     given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
 
     // when
-    PlaceResponse result = placeService.postPlace(1L, newNamePlaceRequest);
+    PlaceCreateResponse result = placeService.postPlace(1L, newNamePlaceRequest);
 
     // then
     assertEquals(existingPlace.getPlaceName(), "New Name");
@@ -141,7 +142,7 @@ public class PlaceServiceTest {
     given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
 
     // when
-    PlaceResponse result = placeService.postPlace(1L, sameNamePlaceRequest);
+    PlaceCreateResponse result = placeService.postPlace(1L, sameNamePlaceRequest);
 
     // then
     assertEquals(existingPlace.getPlaceName(), "Old Name");
@@ -160,7 +161,10 @@ public class PlaceServiceTest {
 
     // then
     assertEquals(place.getId(), result.getId());
-
+    assertEquals(place.getLat(), result.getLat());
+    assertEquals(place.getLng(), result.getLng());
+    assertEquals(place.getPlaceName(), result.getPlaceName());
+    assertEquals(place.getPlaceAddress(), result.getPlaceAddress());
   }
 
   @Test


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
- 오프라인 일정 조회시 클라이언트 측에서 지도에 장소를 보여줄때 필요한 장소 정보 조회 api 구현
- 특정 studyChannel id와 연관관계는 없으며, 클라이언트 측에서 지도를 보여줄 때 필요한 장소 정보들을 db에 저장
    - 만일 studyChannel이 방대해지고 장소를 저장하는 양이 많아지면 db 정리 필요 할듯하나 현재는 필요 없어서 따로 구현 안해놓은 상태입니다.

죄송합니다. 커밋 메시지 style이라고 해야하는데 Style로 잘못 썼으나 이미 push 해버려서 delete 없이 진행하겠습니다..
다음엔 소문자로 제대로 하겠습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
     - service test코드만 진행
    - controller test를  WebMvcTest으로 진행 했으나 현재 securiy적용되서 WithMockUser를 사용해도 에러가 나서 추후 추가할 예정.
- [X] API 테스트 