### PR TITLE
feat: STD-13 스터디 채널 참가 신청 취소 기능

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
         return http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests( requests -> requests
                         .requestMatchers("/api/members/sign-up", "/api/members/auth/**", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/api/members/login/**").permitAll()
-                        .requestMatchers("/api/study-channels/**", "/error").permitAll()
+                        .requestMatchers("/api/study-channels/**", "/error", "/api/participation/**").permitAll()
                 .requestMatchers("/api/members/logout", "api/study-channels/*/places",
                     "/api/study-channels/*/schedules").hasRole("USER"))
 

--- a/src/main/java/com/tenten/studybadge/common/exception/participation/NotFoundParticipationException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/participation/NotFoundParticipationException.java
@@ -1,0 +1,28 @@
+package com.tenten.studybadge.common.exception.participation;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class NotFoundParticipationException extends AbstractException {
+
+    private static final String ERROR_CODE = "NOT_FOUND_PARTICIPATION";
+    private static final String ERROR_MESSAGE = "존재하지 않는 참가 신청입니다.";
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return BAD_REQUEST;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public String getMessage() {
+        return ERROR_MESSAGE;
+    }
+
+}

--- a/src/main/java/com/tenten/studybadge/common/exception/participation/NotFoundParticipationException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/participation/NotFoundParticipationException.java
@@ -3,7 +3,7 @@ package com.tenten.studybadge.common.exception.participation;
 import com.tenten.studybadge.common.exception.basic.AbstractException;
 import org.springframework.http.HttpStatus;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 public class NotFoundParticipationException extends AbstractException {
 
@@ -12,7 +12,7 @@ public class NotFoundParticipationException extends AbstractException {
 
     @Override
     public HttpStatus getHttpStatus() {
-        return BAD_REQUEST;
+        return NOT_FOUND;
     }
 
     @Override

--- a/src/main/java/com/tenten/studybadge/common/exception/participation/OtherMemberParticipationCancelException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/participation/OtherMemberParticipationCancelException.java
@@ -1,0 +1,28 @@
+package com.tenten.studybadge.common.exception.participation;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class OtherMemberParticipationCancelException extends AbstractException {
+
+    private static final String ERROR_CODE = "OTHER_MEMBER_PARTICIPATION_CANCEL";
+    private static final String ERROR_MESSAGE = "다른 회원의 참가 신청을 취소할 수 없습니다.";
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return BAD_REQUEST;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public String getMessage() {
+        return ERROR_MESSAGE;
+    }
+
+}

--- a/src/main/java/com/tenten/studybadge/participation/controller/StudyChannelParticipationController.java
+++ b/src/main/java/com/tenten/studybadge/participation/controller/StudyChannelParticipationController.java
@@ -3,6 +3,7 @@ package com.tenten.studybadge.participation.controller;
 import com.tenten.studybadge.participation.service.StudyChannelParticipationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,6 +18,13 @@ public class StudyChannelParticipationController {
     public ResponseEntity<Void> applyParticipation(@PathVariable("studyChannelId") Long studyChannelId) {
         Long memberId = 1L;
         studyChannelParticipationService.apply(studyChannelId, memberId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/api/participation/{participationId}")
+    public ResponseEntity<Void> cancelParticipation(@PathVariable("participationId") Long participationId) {
+        Long memberId = 1L;
+        studyChannelParticipationService.cancel(participationId, memberId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/tenten/studybadge/participation/domain/entity/Participation.java
+++ b/src/main/java/com/tenten/studybadge/participation/domain/entity/Participation.java
@@ -1,6 +1,7 @@
 package com.tenten.studybadge.participation.domain.entity;
 
 import com.tenten.studybadge.common.BaseEntity;
+import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
 import com.tenten.studybadge.type.participation.ParticipationStatus;
 import jakarta.persistence.*;
@@ -23,21 +24,23 @@ public class Participation extends BaseEntity {
     @JoinColumn(name = "study_channel_id")
     private StudyChannel studyChannel;
 
-    private Long memberId;
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 
     @Enumerated(EnumType.STRING)
     private ParticipationStatus participationStatus;
 
-    public static Participation create(Long memberId, StudyChannel studyChannel) {
+    public static Participation create(Member member, StudyChannel studyChannel) {
         return Participation.builder()
-                .memberId(memberId)
+                .member(member)
                 .studyChannel(studyChannel)
                 .participationStatus(ParticipationStatus.APPROVE_WAITING)
                 .build();
     }
 
-    public boolean isCreatedBy(Long memberId) {
-        return memberId.equals(this.memberId);
+    public boolean isCreatedBy(Member member) {
+        return member.getId().equals(this.member.getId());
     }
 
     public void cancel() {

--- a/src/main/java/com/tenten/studybadge/participation/domain/entity/Participation.java
+++ b/src/main/java/com/tenten/studybadge/participation/domain/entity/Participation.java
@@ -36,4 +36,12 @@ public class Participation extends BaseEntity {
                 .build();
     }
 
+    public boolean isCreatedBy(Long memberId) {
+        return memberId.equals(this.memberId);
+    }
+
+    public void cancel() {
+        this.participationStatus = ParticipationStatus.CANCELED;
+    }
+
 }

--- a/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
+++ b/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
@@ -27,7 +27,6 @@ public class StudyChannelParticipationService {
 
     // TODO 1) 탈퇴 당한 회원인가?
     //      2) 참가 거절 당한 회원인가?
-    @Transactional
     public void apply(Long studyChannelId, Long memberId) {
 
         Member member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);

--- a/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
+++ b/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
@@ -1,6 +1,8 @@
 package com.tenten.studybadge.participation.service;
 
 import com.tenten.studybadge.common.exception.participation.AlreadyAppliedParticipationException;
+import com.tenten.studybadge.common.exception.participation.NotFoundParticipationException;
+import com.tenten.studybadge.common.exception.participation.OtherMemberParticipationCancelException;
 import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelException;
 import com.tenten.studybadge.common.exception.studychannel.AlreadyStudyMemberException;
 import com.tenten.studybadge.common.exception.studychannel.RecruitmentCompletedStudyChannelException;
@@ -43,6 +45,17 @@ public class StudyChannelParticipationService {
 
         participationRepository.save(participation);
 
+    }
+
+    // TODO 이미 승인/거절된 참가 신청을 취소할 경우 예외 처리
+    @Transactional
+    public void cancel(Long participationId, Long memberId) {
+        // TODO 존재하는 회원 여부 검증
+        Participation participation = participationRepository.findById(participationId).orElseThrow(NotFoundParticipationException::new);
+        if (!participation.isCreatedBy(memberId)) {
+            throw new OtherMemberParticipationCancelException();
+        }
+        participation.cancel();
     }
 
 }

--- a/src/test/java/com/tenten/studybadge/participation/service/StudyChannelParticipationServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/participation/service/StudyChannelParticipationServiceTest.java
@@ -1,6 +1,7 @@
 package com.tenten.studybadge.participation.service;
 
 import com.tenten.studybadge.common.exception.participation.AlreadyAppliedParticipationException;
+import com.tenten.studybadge.common.exception.participation.OtherMemberParticipationCancelException;
 import com.tenten.studybadge.common.exception.studychannel.AlreadyStudyMemberException;
 import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelException;
 import com.tenten.studybadge.common.exception.studychannel.RecruitmentCompletedStudyChannelException;
@@ -14,6 +15,7 @@ import com.tenten.studybadge.study.member.domain.entity.StudyMember;
 import com.tenten.studybadge.type.participation.ParticipationStatus;
 import com.tenten.studybadge.type.study.channel.RecruitmentStatus;
 import com.tenten.studybadge.type.study.member.StudyMemberRole;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -169,6 +171,50 @@ class StudyChannelParticipationServiceTest {
             // when & then
             assertThatThrownBy(() -> studyChannelParticipationService.apply(studyChannel.getId(), 1L))
                     .isExactlyInstanceOf(RecruitmentCompletedStudyChannelException.class);
+        }
+
+    }
+
+    @DisplayName("스터디 채널 참가 취소 테스트]")
+    @Nested
+    class CancelStudyChannelParticipationTest {
+
+        @DisplayName("정상적으로 참가 신청을 취소한다.")
+        @Test
+        void success_cancelStudyChannelParticipation() {
+
+            //given
+            Participation participation = Participation.builder()
+                    .id(1L)
+                    .memberId(1L)
+                    .participationStatus(ParticipationStatus.APPROVE_WAITING)
+                    .build();
+
+            given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
+
+            //when
+            studyChannelParticipationService.cancel(1L, 1L);
+
+            //then
+            assertThat(participation.getParticipationStatus()).isEqualTo(ParticipationStatus.CANCELED);
+        }
+
+        @DisplayName("다른 회원의 참가 신청을 취소하려는 경우 예외가 발생한다.")
+        @Test
+        void fail_cancelOtherMemberParticipation() {
+
+            //given
+            Participation participation = Participation.builder()
+                    .id(1L)
+                    .memberId(1L)
+                    .participationStatus(ParticipationStatus.APPROVE_WAITING)
+                    .build();
+
+            given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
+
+            //when & then
+            Assertions.assertThatThrownBy(() -> studyChannelParticipationService.cancel(1L, 2L))
+                    .isExactlyInstanceOf(OtherMemberParticipationCancelException.class);
         }
 
     }

--- a/src/test/java/com/tenten/studybadge/participation/service/StudyChannelParticipationServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/participation/service/StudyChannelParticipationServiceTest.java
@@ -6,6 +6,7 @@ import com.tenten.studybadge.common.exception.studychannel.AlreadyStudyMemberExc
 import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelException;
 import com.tenten.studybadge.common.exception.studychannel.RecruitmentCompletedStudyChannelException;
 import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.member.domain.repository.MemberRepository;
 import com.tenten.studybadge.participation.domain.entity.Participation;
 import com.tenten.studybadge.participation.domain.repository.ParticipationRepository;
 import com.tenten.studybadge.study.channel.domain.entity.Recruitment;
@@ -31,8 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class StudyChannelParticipationServiceTest {
@@ -45,6 +45,9 @@ class StudyChannelParticipationServiceTest {
 
     @Mock
     private ParticipationRepository participationRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
 
     @DisplayName("[스터디 채널 참가 신청 테스트]")
     @Nested
@@ -64,8 +67,9 @@ class StudyChannelParticipationServiceTest {
                             .recruitmentStatus(RecruitmentStatus.RECRUITING)
                             .build())
                     .build();
-            studyChannelRepository.save(studyChannel);
+            Member member = Member.builder().id(1L).build();
 
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
             given(studyChannelRepository.findById(anyLong())).willReturn(Optional.of(studyChannel));
             given(participationRepository.existsByMemberIdAndStudyChannelId(anyLong(), anyLong())).willReturn(false);
 
@@ -89,6 +93,8 @@ class StudyChannelParticipationServiceTest {
         void fail_notFoundStudyChannel() {
 
             // given
+            Member member = mock(Member.class);
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
             given(studyChannelRepository.findById(anyLong())).willReturn(Optional.empty());
 
             // when & then
@@ -110,6 +116,8 @@ class StudyChannelParticipationServiceTest {
                             .recruitmentStatus(RecruitmentStatus.RECRUITING).
                             build())
                     .build();
+            Member member = mock(Member.class);
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
             given(studyChannelRepository.findById(anyLong())).willReturn(Optional.of(studyChannel));
             given(participationRepository.existsByMemberIdAndStudyChannelId(anyLong(), anyLong())).willReturn(true);
 
@@ -144,7 +152,7 @@ class StudyChannelParticipationServiceTest {
                     .studyMemberRole(StudyMemberRole.STUDY_MEMBER)
                     .build();
             studyChannel.getMembers().add(studyMember);
-
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
             given(studyChannelRepository.findById(anyLong())).willReturn(Optional.of(studyChannel));
 
             // when & then
@@ -166,6 +174,8 @@ class StudyChannelParticipationServiceTest {
                             .recruitmentStatus(RecruitmentStatus.RECRUIT_COMPLETED)
                             .build())
                     .build();
+            Member member = mock(Member.class);
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
             given(studyChannelRepository.findById(anyLong())).willReturn(Optional.of(studyChannel));
 
             // when & then
@@ -184,12 +194,13 @@ class StudyChannelParticipationServiceTest {
         void success_cancelStudyChannelParticipation() {
 
             //given
+            Member member = Member.builder().id(1L).build();
             Participation participation = Participation.builder()
                     .id(1L)
-                    .memberId(1L)
+                    .member(member)
                     .participationStatus(ParticipationStatus.APPROVE_WAITING)
                     .build();
-
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
             given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
 
             //when
@@ -204,12 +215,14 @@ class StudyChannelParticipationServiceTest {
         void fail_cancelOtherMemberParticipation() {
 
             //given
+            Member member = Member.builder().id(1L).build();
+            Member other = Member.builder().id(2L).build();
             Participation participation = Participation.builder()
                     .id(1L)
-                    .memberId(1L)
+                    .member(member)
                     .participationStatus(ParticipationStatus.APPROVE_WAITING)
                     .build();
-
+            given(memberRepository.findById(2L)).willReturn(Optional.of(other));
             given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
 
             //when & then


### PR DESCRIPTION
### 변경사항

**AS-IS** 
  
* 회원의 존재여부를 판단하지 않고 기능을 수행하도록 구현.

**TO-BE**

* 회원 기능이 개발되었기 때문에 회원 존재 여부를 판단하는 로직을 추가했습니다.

[추가된 기능]
* 스터디 채널에 참가 신청을 했던 걸 취소하는 기능을 구현했습니다.
* 참가 취소를 진행할 때 발생되는 예외 상황을 처리하도록 구현했습니다.
  * 만약 다른 회원의 참가 신청을 취소하려고 할 경우 예외 발생(OtherMemberParticipationCancelException) 
  * 존재하지 않는 참가 신청을 경우 예외 발생(NotFoundParticipationException)

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
  - 컨트롤러 관련 테스트는 아직 구현하지 못했습니다.
- [x] API 테스트 