### PR TITLE
feat: STD-17 일정 조회

### DIFF
--- a/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
@@ -50,9 +50,9 @@ public class ScheduleController {
   @Parameter(name = "studyChannelId", description = "일정을 만드는 study channel의 id 값", required = true)
   @Parameter(name = "year", description = "일정의 year 값", required = true)
   @Parameter(name = "month", description = "일정의 month 값", required = true)
-  public ResponseEntity<List<ScheduleResponse>> getSchedules(
+  public ResponseEntity<List<ScheduleResponse>> getSchedulesWithFormula(
       @PathVariable Long studyChannelId,
       @RequestParam int year, @RequestParam int month) {
-    return ResponseEntity.ok(scheduleService.getSchedulesInStudyChannelForYearAndMonth(studyChannelId, year, month));
+    return ResponseEntity.ok(scheduleService.getSchedulesInStudyChannelForYearAndMonth( studyChannelId, year, month));
   }
 }

--- a/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
@@ -1,15 +1,18 @@
 package com.tenten.studybadge.schedule.controller;
 
 import com.tenten.studybadge.schedule.dto.ScheduleCreateRequest;
+import com.tenten.studybadge.schedule.dto.ScheduleResponse;
 import com.tenten.studybadge.schedule.service.ScheduleService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,7 +27,7 @@ public class ScheduleController {
   private final ScheduleService scheduleService;
 
   @PostMapping("/study-channels/{studyChannelId}/schedules")
-  @Operation(summary = "장소 저장", description = "지도 api에서 선택한 장소 저장" ,security = @SecurityRequirement(name = "bearerToken"))
+  @Operation(summary = "일정 저장", description = "특정 스터디 채널의 일정을 저장하는 api" ,security = @SecurityRequirement(name = "bearerToken"))
   @Parameter(name = "studyChannelId", description = "일정을 만드는 study channel의 id 값", required = true)
   @Parameter(name = "ScheduleRequest", description = "일정 등록 request, type의 값이 single, repeat에 따라 단일 일정 / 반복 일정 등록으로 나뉜다.", required = true )
   public ResponseEntity<Void> postSchedule(
@@ -32,5 +35,12 @@ public class ScheduleController {
       @Valid @RequestBody ScheduleCreateRequest scheduleCreateRequest)  {
     scheduleService.postSchedule(scheduleCreateRequest, studyChannelId);
     return ResponseEntity.status(HttpStatus.CREATED).build();
+  }
+
+  @Operation(summary = "스터디 채널에 존재하는 일정 전체 조회", description = "특정 스터디 채널에 존재하는 일정 전체 조회 api" ,security = @SecurityRequirement(name = "bearerToken"))
+  @Parameter(name = "studyChannelId", description = "일정을 만드는 study channel의 id 값", required = true)
+  @GetMapping("/study-channels/{studyChannelId}/schedules")
+  public ResponseEntity<List<ScheduleResponse>> getSchedules(@PathVariable Long studyChannelId) {
+    return ResponseEntity.ok(scheduleService.getSchedulesInStudyChannel(studyChannelId));
   }
 }

--- a/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
@@ -37,9 +37,9 @@ public class ScheduleController {
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
+  @GetMapping("/study-channels/{studyChannelId}/schedules")
   @Operation(summary = "스터디 채널에 존재하는 일정 전체 조회", description = "특정 스터디 채널에 존재하는 일정 전체 조회 api" ,security = @SecurityRequirement(name = "bearerToken"))
   @Parameter(name = "studyChannelId", description = "일정을 만드는 study channel의 id 값", required = true)
-  @GetMapping("/study-channels/{studyChannelId}/schedules")
   public ResponseEntity<List<ScheduleResponse>> getSchedules(@PathVariable Long studyChannelId) {
     return ResponseEntity.ok(scheduleService.getSchedulesInStudyChannel(studyChannelId));
   }

--- a/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -42,5 +43,16 @@ public class ScheduleController {
   @Parameter(name = "studyChannelId", description = "일정을 만드는 study channel의 id 값", required = true)
   public ResponseEntity<List<ScheduleResponse>> getSchedules(@PathVariable Long studyChannelId) {
     return ResponseEntity.ok(scheduleService.getSchedulesInStudyChannel(studyChannelId));
+  }
+
+  @GetMapping("/study-channels/{studyChannelId}/schedules/date")
+  @Operation(summary = "스터디 채널에 존재하는 일정 year, month 기준 전체 조회", description = "특정 스터디 채널에 존재하는 일정들을 year과 month 기준으로 전체 조회 api" ,security = @SecurityRequirement(name = "bearerToken"))
+  @Parameter(name = "studyChannelId", description = "일정을 만드는 study channel의 id 값", required = true)
+  @Parameter(name = "year", description = "일정의 year 값", required = true)
+  @Parameter(name = "month", description = "일정의 month 값", required = true)
+  public ResponseEntity<List<ScheduleResponse>> getSchedules(
+      @PathVariable Long studyChannelId,
+      @RequestParam int year, @RequestParam int month) {
+    return ResponseEntity.ok(scheduleService.getSchedulesInStudyChannelForYearAndMonth(studyChannelId, year, month));
   }
 }

--- a/src/main/java/com/tenten/studybadge/schedule/domain/Schedule.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/Schedule.java
@@ -5,10 +5,8 @@ import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @MappedSuperclass
 public abstract class Schedule extends BaseEntity {
   protected String scheduleName;

--- a/src/main/java/com/tenten/studybadge/schedule/domain/entity/RepeatSchedule.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/entity/RepeatSchedule.java
@@ -25,13 +25,16 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Formula;
 
 @Entity
 @Getter
 @DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(indexes = @Index(name = "idx_study_channel_id", columnList = "study_channel_id"))
+@Table(indexes = {
+    @Index(name = "idx_study_channel_id", columnList = "study_channel_id"),
+    @Index(name = "idx_schedule_year_month", columnList = "scheduleYear, scheduleMonth")})
 public class RepeatSchedule extends Schedule {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -49,6 +52,12 @@ public class RepeatSchedule extends Schedule {
   @ManyToOne
   @JoinColumn(name = "study_channel_id", nullable = false)
   private StudyChannel studyChannel;
+
+  @Formula("YEAR(schedule_date)")
+  private int scheduleYear;
+
+  @Formula("MONTH(schedule_date)")
+  private int scheduleMonth;
 
   @Builder(builderMethodName = "withoutIdBuilder")
   public RepeatSchedule(String scheduleName, String scheduleContent, LocalDate scheduleDate, LocalTime scheduleStartTime,

--- a/src/main/java/com/tenten/studybadge/schedule/domain/entity/RepeatSchedule.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/entity/RepeatSchedule.java
@@ -15,6 +15,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,7 +26,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @Entity
 @Getter
 @DynamicUpdate
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class RepeatSchedule extends Schedule {
   @Id

--- a/src/main/java/com/tenten/studybadge/schedule/domain/entity/RepeatSchedule.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/entity/RepeatSchedule.java
@@ -2,6 +2,7 @@ package com.tenten.studybadge.schedule.domain.entity;
 
 
 import com.tenten.studybadge.schedule.domain.Schedule;
+import com.tenten.studybadge.schedule.dto.ScheduleResponse;
 import com.tenten.studybadge.type.schedule.RepeatCycle;
 import com.tenten.studybadge.type.schedule.RepeatSituation;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
@@ -11,8 +12,10 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import lombok.AccessLevel;
@@ -28,6 +31,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(indexes = @Index(name = "idx_study_channel_id", columnList = "study_channel_id"))
 public class RepeatSchedule extends Schedule {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -79,5 +83,22 @@ public class RepeatSchedule extends Schedule {
     this.repeatEndDate = repeatEndDate;
     this.placeId = placeId;
     this.studyChannel = studyChannel;
+  }
+
+  public ScheduleResponse toResponse() {
+    return ScheduleResponse.builder()
+        .id(this.getId())
+        .scheduleName(this.getScheduleName())
+        .scheduleContent(this.getScheduleContent())
+        .scheduleDate(this.getScheduleDate())
+        .scheduleStartTime(this.getScheduleStartTime())
+        .scheduleEndTime(this.getScheduleEndTime())
+        .isRepeated(this.isRepeated())
+        .repeatCycle(this.getRepeatCycle())
+        .repeatSituation(this.getRepeatSituation())
+        .repeatEndDate(this.getRepeatEndDate())
+        .placeId(this.getPlaceId())
+        .studyChannelId(this.getStudyChannel().getId())
+        .build();
   }
 }

--- a/src/main/java/com/tenten/studybadge/schedule/domain/entity/RepeatSchedule.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/entity/RepeatSchedule.java
@@ -3,9 +3,9 @@ package com.tenten.studybadge.schedule.domain.entity;
 
 import com.tenten.studybadge.schedule.domain.Schedule;
 import com.tenten.studybadge.schedule.dto.ScheduleResponse;
+import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
 import com.tenten.studybadge.type.schedule.RepeatCycle;
 import com.tenten.studybadge.type.schedule.RepeatSituation;
-import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -25,16 +25,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
-import org.hibernate.annotations.Formula;
 
 @Entity
 @Getter
 @DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(indexes = {
-    @Index(name = "idx_study_channel_id", columnList = "study_channel_id"),
-    @Index(name = "idx_schedule_year_month", columnList = "scheduleYear, scheduleMonth")})
+@Table(indexes = @Index(name = "idx_study_channel_id", columnList = "study_channel_id"))
 public class RepeatSchedule extends Schedule {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -52,12 +49,6 @@ public class RepeatSchedule extends Schedule {
   @ManyToOne
   @JoinColumn(name = "study_channel_id", nullable = false)
   private StudyChannel studyChannel;
-
-  @Formula("YEAR(schedule_date)")
-  private int scheduleYear;
-
-  @Formula("MONTH(schedule_date)")
-  private int scheduleMonth;
 
   @Builder(builderMethodName = "withoutIdBuilder")
   public RepeatSchedule(String scheduleName, String scheduleContent, LocalDate scheduleDate, LocalTime scheduleStartTime,

--- a/src/main/java/com/tenten/studybadge/schedule/domain/entity/SingleSchedule.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/entity/SingleSchedule.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,7 +22,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @Entity
 @Getter
 @DynamicUpdate
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class SingleSchedule extends Schedule {
   @Id

--- a/src/main/java/com/tenten/studybadge/schedule/domain/entity/SingleSchedule.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/entity/SingleSchedule.java
@@ -21,13 +21,16 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Formula;
 
 @Entity
 @Getter
 @DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(indexes = @Index(name = "idx_study_channel_id", columnList = "study_channel_id"))
+@Table(indexes = {
+    @Index(name = "idx_study_channel_id", columnList = "study_channel_id"),
+    @Index(name = "idx_schedule_year_month", columnList = "scheduleYear, scheduleMonth")})
 public class SingleSchedule extends Schedule {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,6 +43,12 @@ public class SingleSchedule extends Schedule {
   @ManyToOne
   @JoinColumn(name = "study_channel_id", nullable = false)
   private StudyChannel studyChannel;
+
+  @Formula("YEAR(schedule_date)")
+  private int scheduleYear;
+
+  @Formula("MONTH(schedule_date)")
+  private int scheduleMonth;
 
   @Builder(builderMethodName = "withoutIdBuilder")
   public SingleSchedule(String scheduleName, String scheduleContent, LocalDate scheduleDate, LocalTime scheduleStartTime,

--- a/src/main/java/com/tenten/studybadge/schedule/domain/entity/SingleSchedule.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/entity/SingleSchedule.java
@@ -21,16 +21,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
-import org.hibernate.annotations.Formula;
 
 @Entity
 @Getter
 @DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(indexes = {
-    @Index(name = "idx_study_channel_id", columnList = "study_channel_id"),
-    @Index(name = "idx_schedule_year_month", columnList = "scheduleYear, scheduleMonth")})
+@Table(indexes = @Index(name = "idx_study_channel_id", columnList = "study_channel_id"))
 public class SingleSchedule extends Schedule {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -44,11 +41,9 @@ public class SingleSchedule extends Schedule {
   @JoinColumn(name = "study_channel_id", nullable = false)
   private StudyChannel studyChannel;
 
-  @Formula("YEAR(schedule_date)")
-  private int scheduleYear;
-
-  @Formula("MONTH(schedule_date)")
-  private int scheduleMonth;
+//  // TODO 단일 일정에만 실제 year, month 필드를 두고 인덱스를 만들지 고민
+//  private int scheduleYear;
+//  private int scheduleMonth;
 
   @Builder(builderMethodName = "withoutIdBuilder")
   public SingleSchedule(String scheduleName, String scheduleContent, LocalDate scheduleDate, LocalTime scheduleStartTime,

--- a/src/main/java/com/tenten/studybadge/schedule/domain/entity/SingleSchedule.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/entity/SingleSchedule.java
@@ -2,13 +2,16 @@ package com.tenten.studybadge.schedule.domain.entity;
 
 
 import com.tenten.studybadge.schedule.domain.Schedule;
+import com.tenten.studybadge.schedule.dto.ScheduleResponse;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import lombok.AccessLevel;
@@ -24,6 +27,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(indexes = @Index(name = "idx_study_channel_id", columnList = "study_channel_id"))
 public class SingleSchedule extends Schedule {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -64,4 +68,19 @@ public class SingleSchedule extends Schedule {
     this.studyChannel = studyChannel;
   }
 
+  public ScheduleResponse toResponse() {
+    return ScheduleResponse.builder()
+        .id(this.getId())
+        .scheduleName(this.getScheduleName())
+        .scheduleContent(this.getScheduleContent())
+        .scheduleDate(this.getScheduleDate())
+        .scheduleStartTime(this.getScheduleStartTime())
+        .scheduleEndTime(this.getScheduleEndTime())
+        .isRepeated(this.isRepeated())
+        .repeatCycle(null)
+        .repeatSituation(null)
+        .placeId(this.getPlaceId())
+        .studyChannelId(this.getStudyChannel().getId())
+        .build();
+  }
 }

--- a/src/main/java/com/tenten/studybadge/schedule/domain/repository/RepeatScheduleRepository.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/repository/RepeatScheduleRepository.java
@@ -1,11 +1,9 @@
 package com.tenten.studybadge.schedule.domain.repository;
 
 import com.tenten.studybadge.schedule.domain.entity.RepeatSchedule;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RepeatScheduleRepository extends JpaRepository<RepeatSchedule, Long>,
-    ScheduleRepository<RepeatSchedule> {
+public interface RepeatScheduleRepository extends ScheduleRepository<RepeatSchedule> {
 
 }

--- a/src/main/java/com/tenten/studybadge/schedule/domain/repository/RepeatScheduleRepository.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/repository/RepeatScheduleRepository.java
@@ -1,9 +1,15 @@
 package com.tenten.studybadge.schedule.domain.repository;
 
 import com.tenten.studybadge.schedule.domain.entity.RepeatSchedule;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RepeatScheduleRepository extends ScheduleRepository<RepeatSchedule> {
 
+  @Query("SELECT rs FROM RepeatSchedule rs WHERE rs.studyChannel.id = :studyChannelId AND " +
+      "(:date BETWEEN rs.scheduleDate AND rs.repeatEndDate)")
+  List<RepeatSchedule> findAllByStudyChannelIdAndDate(Long studyChannelId, LocalDate date);
 }

--- a/src/main/java/com/tenten/studybadge/schedule/domain/repository/ScheduleRepository.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/repository/ScheduleRepository.java
@@ -2,12 +2,16 @@ package com.tenten.studybadge.schedule.domain.repository;
 
 import com.tenten.studybadge.schedule.domain.Schedule;
 import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.NoRepositoryBean;
 
-
-public interface ScheduleRepository<T extends Schedule> {
-  T save(T entity);
+@NoRepositoryBean
+public interface ScheduleRepository<T extends Schedule> extends JpaRepository<T, Long> {
 
   @Query("SELECT s FROM #{#entityName} s WHERE s.studyChannel.id = :studyChannelId")
   List<T> findAllByStudyChannelId(Long studyChannelId);
+
+  @Query("SELECT s FROM #{#entityName} s WHERE s.studyChannel.id = :studyChannelId AND s.scheduleYear = :year AND s.scheduleMonth = :month")
+  List<T> findAllByStudyChannelIdAndScheduleYearAndMonth(Long studyChannelId, int year, int month);
 }

--- a/src/main/java/com/tenten/studybadge/schedule/domain/repository/ScheduleRepository.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/repository/ScheduleRepository.java
@@ -12,6 +12,4 @@ public interface ScheduleRepository<T extends Schedule> extends JpaRepository<T,
   @Query("SELECT s FROM #{#entityName} s WHERE s.studyChannel.id = :studyChannelId")
   List<T> findAllByStudyChannelId(Long studyChannelId);
 
-  @Query("SELECT s FROM #{#entityName} s WHERE s.studyChannel.id = :studyChannelId AND s.scheduleYear = :year AND s.scheduleMonth = :month")
-  List<T> findAllByStudyChannelIdAndScheduleYearAndMonth(Long studyChannelId, int year, int month);
 }

--- a/src/main/java/com/tenten/studybadge/schedule/domain/repository/ScheduleRepository.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/repository/ScheduleRepository.java
@@ -1,8 +1,13 @@
 package com.tenten.studybadge.schedule.domain.repository;
 
 import com.tenten.studybadge.schedule.domain.Schedule;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 
 
 public interface ScheduleRepository<T extends Schedule> {
   T save(T entity);
+
+  @Query("SELECT s FROM #{#entityName} s WHERE s.studyChannel.id = :studyChannelId")
+  List<T> findAllByStudyChannelId(Long studyChannelId);
 }

--- a/src/main/java/com/tenten/studybadge/schedule/domain/repository/SingleScheduleRepository.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/repository/SingleScheduleRepository.java
@@ -2,11 +2,9 @@ package com.tenten.studybadge.schedule.domain.repository;
 
 
 import com.tenten.studybadge.schedule.domain.entity.SingleSchedule;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface SingleScheduleRepository extends JpaRepository<SingleSchedule, Long>,
-    ScheduleRepository<SingleSchedule> {
+public interface SingleScheduleRepository extends ScheduleRepository<SingleSchedule> {
 
 }

--- a/src/main/java/com/tenten/studybadge/schedule/domain/repository/SingleScheduleRepository.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/repository/SingleScheduleRepository.java
@@ -2,9 +2,13 @@ package com.tenten.studybadge.schedule.domain.repository;
 
 
 import com.tenten.studybadge.schedule.domain.entity.SingleSchedule;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SingleScheduleRepository extends ScheduleRepository<SingleSchedule> {
-
+  @Query("SELECT ss FROM SingleSchedule ss WHERE ss.studyChannel.id = :studyChannelId AND ss.scheduleDate BETWEEN :startDate AND :endDate")
+  List<SingleSchedule> findAllByStudyChannelIdAndDateRange(Long studyChannelId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
+++ b/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
@@ -4,13 +4,15 @@ import com.tenten.studybadge.common.exception.schedule.IllegalArgumentForSchedul
 import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelException;
 import com.tenten.studybadge.schedule.domain.entity.RepeatSchedule;
 import com.tenten.studybadge.schedule.domain.entity.SingleSchedule;
-import com.tenten.studybadge.schedule.domain.repository.ScheduleRepository;
+import com.tenten.studybadge.schedule.domain.repository.RepeatScheduleRepository;
+import com.tenten.studybadge.schedule.domain.repository.SingleScheduleRepository;
 import com.tenten.studybadge.schedule.dto.RepeatScheduleCreateRequest;
 import com.tenten.studybadge.schedule.dto.ScheduleCreateRequest;
 import com.tenten.studybadge.schedule.dto.ScheduleResponse;
 import com.tenten.studybadge.schedule.dto.SingleScheduleCreateRequest;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
 import com.tenten.studybadge.study.channel.domain.repository.StudyChannelRepository;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -20,8 +22,8 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class ScheduleService {
-  private final ScheduleRepository<SingleSchedule> singleScheduleRepository;
-  private final ScheduleRepository<RepeatSchedule> repeatScheduleRepository;
+  private final SingleScheduleRepository singleScheduleRepository;
+  private final RepeatScheduleRepository repeatScheduleRepository;
   private final StudyChannelRepository studyChannelRepository;
 
   public void postSchedule(ScheduleCreateRequest scheduleCreateRequest, Long studyChannelId) {
@@ -93,14 +95,17 @@ public class ScheduleService {
         .orElseThrow(NotFoundStudyChannelException::new);
 
     List<ScheduleResponse> scheduleResponses = new ArrayList<>();
-    List<ScheduleResponse> singleScheduleResponses = singleScheduleRepository.findAllByStudyChannelIdAndScheduleYearAndMonth(
-            studyChannelId, year, month)
+
+    LocalDate selectMonthFirstDate = LocalDate.of(year, month, 1);
+    LocalDate selectMonthLastDate = selectMonthFirstDate.withDayOfMonth(selectMonthFirstDate.lengthOfMonth());
+    List<ScheduleResponse> singleScheduleResponses = singleScheduleRepository.findAllByStudyChannelIdAndDateRange(
+            studyChannelId,selectMonthFirstDate, selectMonthLastDate)
         .stream()
         .map(SingleSchedule::toResponse)
         .collect(Collectors.toList());
 
-    List<ScheduleResponse> repeatScheduleResponses = repeatScheduleRepository.findAllByStudyChannelIdAndScheduleYearAndMonth(
-            studyChannelId, year, month)
+    List<ScheduleResponse> repeatScheduleResponses = repeatScheduleRepository.findAllByStudyChannelIdAndDate(
+            studyChannelId, selectMonthFirstDate)
         .stream()
         .map(RepeatSchedule::toResponse)
         .collect(Collectors.toList());

--- a/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
+++ b/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
@@ -7,9 +7,14 @@ import com.tenten.studybadge.schedule.domain.entity.SingleSchedule;
 import com.tenten.studybadge.schedule.domain.repository.ScheduleRepository;
 import com.tenten.studybadge.schedule.dto.RepeatScheduleCreateRequest;
 import com.tenten.studybadge.schedule.dto.ScheduleCreateRequest;
+import com.tenten.studybadge.schedule.dto.ScheduleResponse;
 import com.tenten.studybadge.schedule.dto.SingleScheduleCreateRequest;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
 import com.tenten.studybadge.study.channel.domain.repository.StudyChannelRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -59,5 +64,28 @@ public class ScheduleService {
     } else {
       throw new IllegalArgumentForScheduleRequestException();
     }
+  }
+
+  public List<ScheduleResponse> getSchedulesInStudyChannel(Long studyChannelId) {
+    StudyChannel studyChannel = studyChannelRepository.findById(studyChannelId)
+        .orElseThrow(NotFoundStudyChannelException::new);
+
+    List<ScheduleResponse> scheduleResponses = new ArrayList<>();
+    List<ScheduleResponse> singleScheduleResponses = singleScheduleRepository.findAllByStudyChannelId(
+            studyChannelId)
+        .stream()
+        .map(SingleSchedule::toResponse)
+        .collect(Collectors.toList());
+
+    List<ScheduleResponse> repeatScheduleResponses = repeatScheduleRepository.findAllByStudyChannelId(
+            studyChannelId)
+        .stream()
+        .map(RepeatSchedule::toResponse)
+        .collect(Collectors.toList());
+
+    scheduleResponses.addAll(singleScheduleResponses);
+    scheduleResponses.addAll(repeatScheduleResponses);
+
+    return scheduleResponses;
   }
 }

--- a/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
+++ b/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
@@ -11,7 +11,6 @@ import com.tenten.studybadge.schedule.dto.ScheduleResponse;
 import com.tenten.studybadge.schedule.dto.SingleScheduleCreateRequest;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
 import com.tenten.studybadge.study.channel.domain.repository.StudyChannelRepository;
-import jakarta.persistence.EntityNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -86,6 +85,28 @@ public class ScheduleService {
     scheduleResponses.addAll(singleScheduleResponses);
     scheduleResponses.addAll(repeatScheduleResponses);
 
+    return scheduleResponses;
+  }
+
+  public List<ScheduleResponse> getSchedulesInStudyChannelForYearAndMonth(Long studyChannelId, int year, int month) {
+    StudyChannel studyChannel = studyChannelRepository.findById(studyChannelId)
+        .orElseThrow(NotFoundStudyChannelException::new);
+
+    List<ScheduleResponse> scheduleResponses = new ArrayList<>();
+    List<ScheduleResponse> singleScheduleResponses = singleScheduleRepository.findAllByStudyChannelIdAndScheduleYearAndMonth(
+            studyChannelId, year, month)
+        .stream()
+        .map(SingleSchedule::toResponse)
+        .collect(Collectors.toList());
+
+    List<ScheduleResponse> repeatScheduleResponses = repeatScheduleRepository.findAllByStudyChannelIdAndScheduleYearAndMonth(
+            studyChannelId, year, month)
+        .stream()
+        .map(RepeatSchedule::toResponse)
+        .collect(Collectors.toList());
+
+    scheduleResponses.addAll(singleScheduleResponses);
+    scheduleResponses.addAll(repeatScheduleResponses);
     return scheduleResponses;
   }
 }

--- a/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
@@ -1,14 +1,19 @@
 package com.tenten.studybadge.schedule.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.tenten.studybadge.common.exception.studychannel.InvalidStudyDurationException;
+import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelException;
 import com.tenten.studybadge.schedule.domain.entity.RepeatSchedule;
 import com.tenten.studybadge.schedule.domain.entity.SingleSchedule;
 import com.tenten.studybadge.schedule.domain.repository.ScheduleRepository;
 import com.tenten.studybadge.schedule.dto.RepeatScheduleCreateRequest;
+import com.tenten.studybadge.schedule.dto.ScheduleResponse;
 import com.tenten.studybadge.schedule.dto.SingleScheduleCreateRequest;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
 import com.tenten.studybadge.study.channel.domain.repository.StudyChannelRepository;
@@ -16,6 +21,8 @@ import com.tenten.studybadge.type.schedule.RepeatCycle;
 import com.tenten.studybadge.type.schedule.RepeatSituation;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -206,5 +213,43 @@ class ScheduleServiceTest {
     // then
     verify(repeatScheduleRepository, times(1)).save(any(RepeatSchedule.class));
     verify(singleScheduleRepository, times(0)).save(any(SingleSchedule.class));
+  }
+
+
+  @Test
+  @DisplayName("스터디 채널 내의 일정 전체 조회 성공")
+  public void success_testGetSchedulesInStudyChannel() {
+    // given
+    given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
+    given(singleScheduleRepository.findAllByStudyChannelId(1L))
+        .willReturn(Arrays.asList(singleScheduleWithoutPlace));
+    given(repeatScheduleRepository.findAllByStudyChannelId(1L))
+        .willReturn(Arrays.asList(repeatScheduleWithoutPlace));
+
+    // when
+    List<ScheduleResponse> scheduleResponses = scheduleService.getSchedulesInStudyChannel(1L);
+
+    // then
+    assertEquals(2, scheduleResponses.size());
+    verify(studyChannelRepository, times(1)).findById(1L);
+    verify(singleScheduleRepository, times(1)).findAllByStudyChannelId(1L);
+    verify(repeatScheduleRepository, times(1)).findAllByStudyChannelId(1L);
+  }
+
+  @Test
+  @DisplayName("스터디 채널 내의 일정 전체 조회 실패: study channel이 존재하지 않을 때")
+  public void fail_testGetSchedulesInStudyChannel() {
+    // given
+    given(studyChannelRepository.findById(1L)).willReturn(Optional.empty());
+
+    // when & then
+    assertThrows(NotFoundStudyChannelException.class, () -> {
+      scheduleService.getSchedulesInStudyChannel(1L);
+    });
+
+    // then
+    verify(studyChannelRepository, times(1)).findById(1L);
+    verify(singleScheduleRepository, times(0)).findAllByStudyChannelId(1L);
+    verify(repeatScheduleRepository, times(0)).findAllByStudyChannelId(1L);
   }
 }

--- a/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
@@ -237,6 +237,31 @@ class ScheduleServiceTest {
   }
 
   @Test
+  @DisplayName("스터디 채널 내의 일정 yyyy.mm 기준 전체 조회 성공")
+  public void success_testGetSchedulesInStudyChannelByYearAndMonth() {
+    // given
+    given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
+    given(singleScheduleRepository.findAllByStudyChannelIdAndScheduleYearAndMonth(
+        1L, 2024, 7))
+        .willReturn(Arrays.asList(singleScheduleWithoutPlace));
+    given(repeatScheduleRepository.findAllByStudyChannelIdAndScheduleYearAndMonth(
+        1L, 2024, 7))
+        .willReturn(Arrays.asList(repeatScheduleWithoutPlace));
+
+    // when
+    List<ScheduleResponse> scheduleResponses = scheduleService.getSchedulesInStudyChannelForYearAndMonth(
+        1L, 2024, 7);
+
+    // then
+    assertEquals(2, scheduleResponses.size());
+    verify(studyChannelRepository, times(1)).findById(1L);
+    verify(singleScheduleRepository, times(1)).findAllByStudyChannelIdAndScheduleYearAndMonth(
+        1L, 2024, 7);
+    verify(repeatScheduleRepository, times(1)).findAllByStudyChannelIdAndScheduleYearAndMonth(
+        1L, 2024, 7);
+  }
+
+  @Test
   @DisplayName("스터디 채널 내의 일정 전체 조회 실패: study channel이 존재하지 않을 때")
   public void fail_testGetSchedulesInStudyChannel() {
     // given


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- scheduleService내에서 단일 일정 repository, 반복 일정 repository를 나름 DIP 원칙을 준수하고 싶어서 이렇게 구현했었습니다. 
``` java
    @Service
    @RequiredArgsConstructor
    public class ScheduleService {
      private final ScheduleRepository<SingleSchedule> singleScheduleRepository;
      private final ScheduleRepository<RepeatSchedule> repeatScheduleRepository;
```
- RepeatSchedule, SingleSchedule에 기본 인덱스 외에는 인덱스를 설정하지 않았습니다.
- ScheduleRepository를 다음과 같이 설정해놨습니다.
``` java
public interface ScheduleRepository<T extends Schedule> {
  T save(T entity);
}
```

``` java
@Repository
public interface RepeatScheduleRepository extends JpaRepository<RepeatSchedule, Long>,
    ScheduleRepository<RepeatSchedule> {

}
```

``` java
@Repository
public interface SingleScheduleRepository extends JpaRepository<SingleSchedule, Long>,
    ScheduleRepository<SingleSchedule> {

}
```

**TO-BE**
- scheduleService내에서 단일 일정 repository, 반복 일정 repository를  직접적으로 의존하는 것으로 변경했습니다. 
``` java
    @Service
    @RequiredArgsConstructor
    public class ScheduleService {
      private final SingleScheduleRepository singleScheduleRepository;
      private final RepeatScheduleRepository repeatScheduleRepository;
```
- 스터디 채널내의 일정 전체 조회
    - RepeatSchedule, SingleSchedule에 스터디 채널 id를 인덱스로 설정했습니다.
    
    ``` java
    @Table(indexes = @Index(name = "idx_study_channel_id", columnList = "study_channel_id"))
    public class SingleSchedule extends Schedule {
      @Id
      @GeneratedValue(strategy = GenerationType.IDENTITY)
      private long id;
      private boolean isRepeated;
      @Setter
      private Long placeId;
    
      @Setter
      @ManyToOne
      @JoinColumn(name = "study_channel_id", nullable = false)
      private StudyChannel studyChannel; 
      }
    ```

- 스터디 채널내의 특정 year, month 전체 조회
    - Hibernate에서 제공하는 기능인 @Formula 어노테이션을 이용하여 읽기 전용으로 엔티티 내의 가상의 열을 활용할까 하려다 없애는 것으로 진행했습니다.
     - 단일 일정의 경우 특정 year, month 필드를 두어 인덱스로 만들지는 고민 중 입니다.
    -  ScheduleRepository를 다음과 같이 변경했습니다.
``` java
    @NoRepositoryBean
    public interface ScheduleRepository<T extends Schedule> extends JpaRepository<T, Long> {
    
      @Query("SELECT s FROM #{#entityName} s WHERE s.studyChannel.id = :studyChannelId")
      List<T> findAllByStudyChannelId(Long studyChannelId);
    }
```
``` java
  @Repository
    public interface RepeatScheduleRepository extends ScheduleRepository<RepeatSchedule> {
        @Query("SELECT rs FROM RepeatSchedule rs WHERE rs.studyChannel.id = :studyChannelId AND " +
        "YEAR(rs.repeatEndDate) = :year AND MONTH(rs.repeatEndDate) >= :month")
        List<RepeatSchedule> findAllByStudyChannelIdAndScheduleYearAndMonthWithFormulaAndEndDateAfter(Long studyChannelId, int year, int month);
    } 
  ```

``` java
  @Repository
    public interface SingleScheduleRepository extends ScheduleRepository<SingleSchedule> {
        @Query("SELECT ss FROM SingleSchedule ss WHERE ss.studyChannel.id = :studyChannelId AND ss.scheduleDate BETWEEN :startDate AND :endDate")
      List<SingleSchedule> findAllByStudyChannelIdAndDateRange(Long studyChannelId, LocalDate startDate, LocalDate endDate);
  }
  ```

- 멘토님의 답변으로 to / from메서드의 방향성에 대해 이해했습니다.
    - to기준으로 변환 메서드를 생성했기에 toResponse 메서드로 생성했습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
    - 현재 service test 코드만 진행했습니다.
- [X] API 테스트 