### PR TITLE
feat: STD-2 토큰 재발급, 쿠키 수정

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
@@ -1,18 +1,30 @@
 package com.tenten.studybadge.common.config;
 
+import com.tenten.studybadge.common.jwt.JwtTokenFilter;
+import com.tenten.studybadge.common.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate redisTemplate;
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -25,13 +37,22 @@ public class SecurityConfig {
                         .requestMatchers("/api/members/sign-up", "/api/members/auth/**", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/api/members/login/**").permitAll()
                         .requestMatchers("/api/study-channels/**", "/error", "/api/participation/**").permitAll()
                 .requestMatchers("/api/members/logout", "api/study-channels/*/places",
-                    "/api/study-channels/*/schedules").hasRole("USER"))
+                    "/api/study-channels/*/schedules", "/api/token/re-issue").hasRole("USER"))
 
 
                 .headers(headers -> headers // h2-console 페이지 접속을 위한 설정
                         .frameOptions(HeadersConfigurer.FrameOptionsConfig::disable)
                         .contentSecurityPolicy(csp -> csp
                                 .policyDirectives("frame-ancestors 'self'")))
+
+                .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(
+                        SessionCreationPolicy.STATELESS))
+
+                .addFilterBefore(new JwtTokenFilter(jwtTokenProvider, redisTemplate), UsernamePasswordAuthenticationFilter.class)
                 .build();
+    }
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig) throws Exception {
+        return authConfig.getAuthenticationManager();
     }
 }

--- a/src/main/java/com/tenten/studybadge/common/constant/TokenConstant.java
+++ b/src/main/java/com/tenten/studybadge/common/constant/TokenConstant.java
@@ -22,7 +22,12 @@ public class TokenConstant {
 
     public static final String REFRESH_TOKEN_FORMAT = "RefreshToken: %s : %s";
 
+    public static final String REFRESH_TOKEN = "refreshToken";
+
     public static final long ACCESS_TOKEN_EXPIRES_IN = TimeUnit.HOURS.toMillis(1);
 
     public static final long REFRESH_TOKEN_EXPIRES_IN = TimeUnit.DAYS.toMillis(14);
+
+    public static final long REFRESH_TOKEN_EXPIRES_IN_COOKIE = TimeUnit.DAYS.toSeconds(14);
+
 }

--- a/src/main/java/com/tenten/studybadge/common/jwt/JwtTokenCreator.java
+++ b/src/main/java/com/tenten/studybadge/common/jwt/JwtTokenCreator.java
@@ -48,12 +48,14 @@ public class JwtTokenCreator {
 
         String accessToken = Jwts.builder()
                 .setClaims(accessTokenClaims)
+                .setIssuedAt(Date.from(now))
                 .setSubject(username)
                 .setExpiration(accessTokenExpiresIn)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
         String refreshToken = Jwts.builder()
                 .setClaims(refreshTokenClaims)
+                .setIssuedAt(Date.from(now))
                 .setExpiration(refreshTokenExpiresIn)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
@@ -62,5 +64,23 @@ public class JwtTokenCreator {
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
+    }
+
+    public String reissue(String email, MemberRole role, Platform platform) {
+
+        Claims claims = Jwts.claims().setSubject(email);
+        claims.put(PLATFORM, platform);
+        List<String> roles = Arrays.asList(ROLE_PREFIX + role.name());
+        claims.put(ROLE, roles);
+
+        Instant now = Instant.now();
+        Date accessTokenExpiresIn = Date.from(now.plusMillis(ACCESS_TOKEN_EXPIRES_IN));
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(Date.from(now))
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
     }
 }

--- a/src/main/java/com/tenten/studybadge/common/token/controller/TokenController.java
+++ b/src/main/java/com/tenten/studybadge/common/token/controller/TokenController.java
@@ -1,14 +1,11 @@
 package com.tenten.studybadge.common.token.controller;
 
 import com.tenten.studybadge.common.token.service.TokenService;
-import com.tenten.studybadge.common.utils.CookieUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/tenten/studybadge/common/token/controller/TokenController.java
+++ b/src/main/java/com/tenten/studybadge/common/token/controller/TokenController.java
@@ -1,0 +1,38 @@
+package com.tenten.studybadge.common.token.controller;
+
+import com.tenten.studybadge.common.token.service.TokenService;
+import com.tenten.studybadge.common.utils.CookieUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.tenten.studybadge.common.constant.TokenConstant.AUTHORIZATION;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/token")
+@Tag(name = "Token API", description = "Token API")
+public class TokenController {
+
+    private final TokenService tokenService;
+    @Operation(summary = "토큰 재발급", description = "토큰 재발급", security = @SecurityRequirement(name = "bearerToken"))
+    @PostMapping("/re-issue")
+    public ResponseEntity<String> reissue(@RequestHeader(AUTHORIZATION) String token) {
+
+        String response = tokenService.reissue(token);
+        ResponseCookie addCookie = CookieUtils.addCookie(response);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, addCookie.toString())
+                .body(response);
+    }
+}

--- a/src/main/java/com/tenten/studybadge/common/token/controller/TokenController.java
+++ b/src/main/java/com/tenten/studybadge/common/token/controller/TokenController.java
@@ -10,10 +10,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.tenten.studybadge.common.constant.TokenConstant.AUTHORIZATION;
 
@@ -26,13 +23,13 @@ public class TokenController {
     private final TokenService tokenService;
     @Operation(summary = "토큰 재발급", description = "토큰 재발급", security = @SecurityRequirement(name = "bearerToken"))
     @PostMapping("/re-issue")
-    public ResponseEntity<String> reissue(@RequestHeader(AUTHORIZATION) String token) {
+    public ResponseEntity<String> reissue(@RequestHeader(AUTHORIZATION) String accessToken,
+                                          @CookieValue(value = "refreshToken", defaultValue = "") String refreshToken) {
 
-        String response = tokenService.reissue(token);
-        ResponseCookie addCookie = CookieUtils.addCookie(response);
+        String response = tokenService.reissue(accessToken, refreshToken);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .header(HttpHeaders.SET_COOKIE, addCookie.toString())
+                .header("Authorization", "Bearer " + response)
                 .body(response);
     }
 }

--- a/src/main/java/com/tenten/studybadge/common/token/controller/TokenController.java
+++ b/src/main/java/com/tenten/studybadge/common/token/controller/TokenController.java
@@ -20,13 +20,12 @@ public class TokenController {
     private final TokenService tokenService;
     @Operation(summary = "토큰 재발급", description = "토큰 재발급", security = @SecurityRequirement(name = "bearerToken"))
     @PostMapping("/re-issue")
-    public ResponseEntity<String> reissue(@RequestHeader(AUTHORIZATION) String accessToken,
-                                          @CookieValue(value = "refreshToken", defaultValue = "") String refreshToken) {
+    public ResponseEntity<String> reissue(@CookieValue(value = "refreshToken", defaultValue = "") String refreshToken) {
 
-        String response = tokenService.reissue(accessToken, refreshToken);
+        String newAccessToken = tokenService.reissue(refreshToken);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .header("Authorization", "Bearer " + response)
-                .body(response);
+                .header("Authorization", "Bearer " + newAccessToken)
+                .body(newAccessToken);
     }
 }

--- a/src/main/java/com/tenten/studybadge/common/token/service/TokenService.java
+++ b/src/main/java/com/tenten/studybadge/common/token/service/TokenService.java
@@ -1,24 +1,31 @@
 package com.tenten.studybadge.common.token.service;
 
+import com.tenten.studybadge.common.exception.InvalidTokenException;
+import com.tenten.studybadge.common.exception.member.NotFoundMemberException;
 import com.tenten.studybadge.common.jwt.JwtTokenCreator;
+import com.tenten.studybadge.common.jwt.JwtTokenProvider;
+import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.member.domain.repository.MemberRepository;
 import com.tenten.studybadge.member.domain.type.MemberRole;
 import com.tenten.studybadge.common.token.dto.TokenDto;
 import com.tenten.studybadge.type.member.Platform;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.concurrent.TimeUnit;
 
-import static com.tenten.studybadge.common.constant.TokenConstant.REFRESH_TOKEN_EXPIRES_IN;
-import static com.tenten.studybadge.common.constant.TokenConstant.REFRESH_TOKEN_FORMAT;
+import static com.tenten.studybadge.common.constant.TokenConstant.*;
 
 @Service
 @RequiredArgsConstructor
 public class TokenService {
 
     private final JwtTokenCreator jwtTokenCreator;
+    private final JwtTokenProvider jwtTokenProvider;
     private final RedisTemplate redisTemplate;
+    private final MemberRepository memberRepository;
 
 
     public TokenDto create(String email, MemberRole role, Platform platform) {
@@ -36,5 +43,31 @@ public class TokenService {
                 TimeUnit.MILLISECONDS);
 
         return token;
+    }
+
+    public String reissue(String refreshToken) {
+
+        if (refreshToken.startsWith(BEARER)) {
+            refreshToken = refreshToken.substring(7);
+        } else {
+            throw new InvalidTokenException();
+        }
+
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new InvalidTokenException();
+        }
+
+        Claims refreshTokenClaims = jwtTokenProvider.parseClaims(refreshToken);
+        String email = refreshTokenClaims.getSubject();
+        Platform platform = jwtTokenProvider.getPlatform(refreshToken);
+
+        String storedRefreshToken = (String) redisTemplate.opsForValue().get(String.format(REFRESH_TOKEN_FORMAT, email, platform));
+        if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
+            throw new InvalidTokenException();
+        }
+
+        Member member = memberRepository.findByEmailAndPlatform(email, platform).orElseThrow(NotFoundMemberException::new);
+
+        return jwtTokenCreator.reissue(member.getEmail(), member.getRole(), platform);
     }
 }

--- a/src/main/java/com/tenten/studybadge/common/token/service/TokenService.java
+++ b/src/main/java/com/tenten/studybadge/common/token/service/TokenService.java
@@ -45,22 +45,7 @@ public class TokenService {
         return token;
     }
 
-    public String reissue(String accessToken, String refreshToken) {
-
-        if (accessToken.startsWith(BEARER)) {
-            accessToken = accessToken.substring(7);
-        } else {
-            throw new InvalidTokenException();
-        }
-
-        if (!jwtTokenProvider.validateToken(accessToken)) {
-            throw new InvalidTokenException();
-        }
-
-        long accessTokenExpiration = jwtTokenProvider.getExpiration(accessToken);
-        if (accessTokenExpiration >= 0) {
-            throw new InvalidTokenException();
-        }
+    public String reissue(String refreshToken) {
 
         if (!jwtTokenProvider.validateToken(refreshToken)) {
             throw new InvalidTokenException();

--- a/src/main/java/com/tenten/studybadge/common/utils/CookieUtils.java
+++ b/src/main/java/com/tenten/studybadge/common/utils/CookieUtils.java
@@ -1,19 +1,22 @@
 package com.tenten.studybadge.common.utils;
 
+import org.springframework.boot.web.server.Cookie;
 import org.springframework.http.ResponseCookie;
 
-public class CookieUtils {
+import static com.tenten.studybadge.common.constant.TokenConstant.REFRESH_TOKEN;
+import static com.tenten.studybadge.common.constant.TokenConstant.REFRESH_TOKEN_EXPIRES_IN_COOKIE;
 
-    private static final String ACCESS_TOKEN = "accessToken";
+public class CookieUtils {
     private static final String DOMAIN = "localhost";
     private static final String PATH = "/";
 
     public static ResponseCookie addCookie(String value) {
 
-        return ResponseCookie.from(ACCESS_TOKEN, value)
+        return ResponseCookie.from(REFRESH_TOKEN, value)
                 .httpOnly(true)
                 .domain(DOMAIN)
-                .maxAge(3600)
+                .maxAge(REFRESH_TOKEN_EXPIRES_IN_COOKIE)
+                .sameSite(Cookie.SameSite.NONE.attributeValue())
                 .secure(true)
                 .path(PATH)
                 .build();
@@ -21,10 +24,11 @@ public class CookieUtils {
 
     public static ResponseCookie deleteCookie(String value) {
 
-        return ResponseCookie.from(ACCESS_TOKEN, value)
+        return ResponseCookie.from(REFRESH_TOKEN, value)
                 .httpOnly(true)
                 .domain(DOMAIN)
                 .maxAge(0)
+                .sameSite(Cookie.SameSite.NONE.attributeValue())
                 .path(PATH)
                 .build();
     }

--- a/src/main/java/com/tenten/studybadge/common/utils/CookieUtils.java
+++ b/src/main/java/com/tenten/studybadge/common/utils/CookieUtils.java
@@ -1,0 +1,31 @@
+package com.tenten.studybadge.common.utils;
+
+import org.springframework.http.ResponseCookie;
+
+public class CookieUtils {
+
+    private static final String ACCESS_TOKEN = "accessToken";
+    private static final String DOMAIN = "localhost";
+    private static final String PATH = "/";
+
+    public static ResponseCookie addCookie(String value) {
+
+        return ResponseCookie.from(ACCESS_TOKEN, value)
+                .httpOnly(true)
+                .domain(DOMAIN)
+                .maxAge(3600)
+                .secure(true)
+                .path(PATH)
+                .build();
+    }
+
+    public static ResponseCookie deleteCookie(String value) {
+
+        return ResponseCookie.from(ACCESS_TOKEN, value)
+                .httpOnly(true)
+                .domain(DOMAIN)
+                .maxAge(0)
+                .path(PATH)
+                .build();
+    }
+}

--- a/src/main/java/com/tenten/studybadge/member/controller/MemberController.java
+++ b/src/main/java/com/tenten/studybadge/member/controller/MemberController.java
@@ -56,10 +56,12 @@ public class MemberController {
 
         TokenCreateDto createDto = memberService.login(loginRequest, LOCAL);
         TokenDto tokenDto = tokenService.create(createDto.getEmail(), createDto.getRole(), LOCAL);
-        ResponseCookie addCookie = CookieUtils.addCookie(tokenDto.getAccessToken());
+        ResponseCookie addCookie = CookieUtils.addCookie(tokenDto.getRefreshToken());
 
         return ResponseEntity.status(HttpStatus.OK)
-                .header(HttpHeaders.SET_COOKIE, addCookie.toString()).body(tokenDto);
+                .header(HttpHeaders.SET_COOKIE, addCookie.toString())
+                .header("Authorization", "Bearer " + tokenDto.getAccessToken())
+                .body(tokenDto);
     }
     @Operation(summary = "로그아웃", description = "로그아웃" , security = @SecurityRequirement(name = "bearerToken"))
     @PostMapping("/logout")

--- a/src/main/java/com/tenten/studybadge/member/controller/MemberController.java
+++ b/src/main/java/com/tenten/studybadge/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.tenten.studybadge.member.controller;
 
 import com.tenten.studybadge.common.token.dto.TokenCreateDto;
 import com.tenten.studybadge.common.token.dto.TokenDto;
+import com.tenten.studybadge.common.utils.CookieUtils;
 import com.tenten.studybadge.member.dto.*;
 import com.tenten.studybadge.member.service.MemberService;
 import com.tenten.studybadge.common.token.service.TokenService;
@@ -9,10 +10,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.Cookie;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -54,30 +56,19 @@ public class MemberController {
 
         TokenCreateDto createDto = memberService.login(loginRequest, LOCAL);
         TokenDto tokenDto = tokenService.create(createDto.getEmail(), createDto.getRole(), LOCAL);
-
-        Cookie cookie = new Cookie("accessToken", tokenDto.getAccessToken());
-        cookie.setHttpOnly(true);
-        cookie.setDomain("localhost");
-        cookie.setMaxAge(3600);
-        cookie.setSecure(true);
-        cookie.setPath("/");
+        ResponseCookie addCookie = CookieUtils.addCookie(tokenDto.getAccessToken());
 
         return ResponseEntity.status(HttpStatus.OK)
-                .header("set-cookie", String.valueOf(cookie)).body(tokenDto);
+                .header(HttpHeaders.SET_COOKIE, addCookie.toString()).body(tokenDto);
     }
     @Operation(summary = "로그아웃", description = "로그아웃" , security = @SecurityRequirement(name = "bearerToken"))
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(@RequestHeader(AUTHORIZATION) String token) {
 
         memberService.logout(token);
-
-        Cookie cookie = new Cookie("accessToken", null);
-        cookie.setHttpOnly(true);
-        cookie.setDomain("localhost");
-        cookie.setMaxAge(0);
-        cookie.setPath("/");
+        ResponseCookie deleteCookie = CookieUtils.deleteCookie(null);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .header("set-cookie", String.valueOf(cookie)).build();
+                .header(HttpHeaders.SET_COOKIE, deleteCookie.toString()).build();
     }
 }


### PR DESCRIPTION
**AS-IS**
반복적인 쿠키 관련 코드 CookieUtils로 분리 -> MemberController 쿠키관련 코드 수정
민호님이 충돌 해결 도중 SecurityConfig 코드내용 일부 삭제 되서 다시 추가했습니다.

**TO-BE**
- 토큰 재발급 추가
 - 로그인 시 -> accessToken(헤더), refreshToken(쿠키)
 - 만료되어 재발급 시 -> 새로운 accessToken(헤더) 

토큰에 대한 보안을 고려하여 수정하였습니다.

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 