### PR TITLE
feat: STD-14 참가 신청 거절 기능 

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/exception/participation/NotAuthorizedRejectException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/participation/NotAuthorizedRejectException.java
@@ -1,0 +1,28 @@
+package com.tenten.studybadge.common.exception.participation;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class NotAuthorizedRejectException extends AbstractException {
+
+    private static final String ERROR_CODE = "NOT_AUTHORIZED_REJECT";
+    private static final String ERROR_MESSAGE = "거절은 해당 스터디의 리더만 가능합니다.";
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return BAD_REQUEST;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public String getMessage() {
+        return ERROR_MESSAGE;
+    }
+
+}

--- a/src/main/java/com/tenten/studybadge/participation/controller/StudyChannelParticipationController.java
+++ b/src/main/java/com/tenten/studybadge/participation/controller/StudyChannelParticipationController.java
@@ -48,4 +48,17 @@ public class StudyChannelParticipationController {
         studyChannelParticipationService.approve(studyChannelId, participationId, memberId);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/api/study-channels/{studyChannelId}/participation/{participationId}/reject")
+    @Operation(summary = "참가 신청 거절", description = "참가 신청을 거절하는 기능", security = @SecurityRequirement(name = "BearerToken"))
+    @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
+    @Parameter(name = "participationId", description = "참가 신청 ID", required = true)
+    public ResponseEntity<Void> rejectParticipation(
+            @PathVariable("studyChannelId") Long studyChannelId,
+            @PathVariable("participationId") Long participationId) {
+        Long memberId = 2L;
+        studyChannelParticipationService.reject(studyChannelId, participationId, memberId);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/com/tenten/studybadge/participation/domain/entity/Participation.java
+++ b/src/main/java/com/tenten/studybadge/participation/domain/entity/Participation.java
@@ -51,4 +51,7 @@ public class Participation extends BaseEntity {
         this.participationStatus = ParticipationStatus.APPROVED;
     }
 
+    public void reject() {
+        this.participationStatus = ParticipationStatus.REJECTED;
+    }
 }

--- a/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
+++ b/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
@@ -68,7 +68,7 @@ public class StudyChannelParticipationService {
         Participation participation = participationRepository.findById(participationId).orElseThrow(NotFoundParticipationException::new);
         StudyChannel studyChannel = participation.getStudyChannel();
 
-        if (!participation.getStudyChannel().getId().equals(studyChannelId)) {
+        if (!studyChannel.getId().equals(studyChannelId)) {
              throw new OtherStudyChannelParticipationException();
         }
         if (!studyChannel.isLeader(member)){

--- a/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
+++ b/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
@@ -81,4 +81,25 @@ public class StudyChannelParticipationService {
         studyChannel.addMember(participation.getMember());
 
     }
+
+    public void reject(Long studyChannelId, Long participationId, Long memberId) {
+
+        Member member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
+        Participation participation = participationRepository.findById(participationId).orElseThrow(NotFoundParticipationException::new);
+        StudyChannel studyChannel = participation.getStudyChannel();
+
+        if (!studyChannel.getId().equals(studyChannelId)) {
+            throw new OtherStudyChannelParticipationException();
+        }
+        if (!studyChannel.isLeader(member)){
+            throw new NotAuthorizedRejectException();
+        }
+        if (!participation.getParticipationStatus().equals(ParticipationStatus.APPROVE_WAITING)) {
+            throw new InvalidApprovalStatusException();
+        }
+        participation.reject();
+
+        participationRepository.save(participation);
+    }
+
 }


### PR DESCRIPTION
### 변경사항

**AS-IS**

**TO-BE**

* 스터디 리더가 **참가 신청을 거절**하는 기능입니다.

* 참가 신청을 거절할 때 아래 조건을 만족하지 못하면 예외를 발생
  * 만약 다른 스터디 채널의 참가 신청을 승인하려고 할 경우 예외가 발생
  * 해당 스터디 채널의 리더가 아닌데 거절하려고 할 경우 예외가 발생
  * 참가 신청 상태가 승인 대기중이 아닌 경우에는 예외가 발생
  
참가 신청을 거절할 경우 **참가 신청의 상태는 REJECTED**(거절됨) 이 됩니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 