### PR TITLE
feat: STD-18 일정 수정 (반 -> 단)

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/exception/schedule/OutRangeScheduleException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/schedule/OutRangeScheduleException.java
@@ -1,0 +1,22 @@
+package com.tenten.studybadge.common.exception.schedule;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class OutRangeScheduleException extends AbstractException {
+    private static final String ERROR_CODE = "OUT_RANGE_REPEAT_SCHEDULE_SITUATION";
+    private static final String ERROR_MESSAGE = "해당 반복 일정의 속한 날짜가 아닙니다.";
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+    @Override
+    public String getMessage() {
+        return ERROR_MESSAGE ;
+    }
+}

--- a/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
@@ -27,57 +27,57 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api")
 @Tag(name = "Schedule API", description = "특정 study channel의 일정을 등록, 조회, 수정, 삭제할 수 있는 API")
 public class ScheduleController {
-  private final ScheduleService scheduleService;
+    private final ScheduleService scheduleService;
 
-  @PostMapping("/study-channels/{studyChannelId}/schedules")
-  @Operation(summary = "일정 저장", description = "특정 스터디 채널의 일정을 저장하는 api" ,security = @SecurityRequirement(name = "bearerToken"))
-  @Parameter(name = "studyChannelId", description = "일정을 만드는 study channel의 id 값", required = true)
-  @Parameter(name = "ScheduleRequest", description = "일정 등록 request, type의 값이 single, repeat에 따라 단일 일정 / 반복 일정 등록으로 나뉜다.", required = true )
-  public ResponseEntity<Void> postSchedule(
-      @PathVariable Long studyChannelId,
-      @Valid @RequestBody ScheduleCreateRequest scheduleCreateRequest)  {
-    scheduleService.postSchedule(scheduleCreateRequest, studyChannelId);
-    return ResponseEntity.status(HttpStatus.CREATED).build();
-  }
+    @PostMapping("/study-channels/{studyChannelId}/schedules")
+    @Operation(summary = "일정 저장", description = "특정 스터디 채널의 일정을 저장하는 api" ,security = @SecurityRequirement(name = "bearerToken"))
+    @Parameter(name = "studyChannelId", description = "일정을 만드는 study channel의 id 값", required = true)
+    @Parameter(name = "ScheduleRequest", description = "일정 등록 request, type의 값이 single, repeat에 따라 단일 일정 / 반복 일정 등록으로 나뉜다.", required = true )
+    public ResponseEntity<Void> postSchedule(
+        @PathVariable Long studyChannelId,
+        @Valid @RequestBody ScheduleCreateRequest scheduleCreateRequest)  {
+        scheduleService.postSchedule(scheduleCreateRequest, studyChannelId);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
 
-  @GetMapping("/study-channels/{studyChannelId}/schedules")
-  @Operation(summary = "스터디 채널에 존재하는 일정 전체 조회", description = "특정 스터디 채널에 존재하는 일정 전체 조회 api" ,security = @SecurityRequirement(name = "bearerToken"))
-  @Parameter(name = "studyChannelId", description = "일정을 만드는 study channel의 id 값", required = true)
-  public ResponseEntity<List<ScheduleResponse>> getSchedules(@PathVariable Long studyChannelId) {
-    return ResponseEntity.ok(scheduleService.getSchedulesInStudyChannel(studyChannelId));
-  }
+    @GetMapping("/study-channels/{studyChannelId}/schedules")
+    @Operation(summary = "스터디 채널에 존재하는 일정 전체 조회", description = "특정 스터디 채널에 존재하는 일정 전체 조회 api" ,security = @SecurityRequirement(name = "bearerToken"))
+    @Parameter(name = "studyChannelId", description = "일정을 만드는 study channel의 id 값", required = true)
+    public ResponseEntity<List<ScheduleResponse>> getSchedules(@PathVariable Long studyChannelId) {
+        return ResponseEntity.ok(scheduleService.getSchedulesInStudyChannel(studyChannelId));
+    }
 
-  @GetMapping("/study-channels/{studyChannelId}/schedules/date")
-  @Operation(summary = "스터디 채널에 존재하는 일정 year, month 기준 전체 조회", description = "특정 스터디 채널에 존재하는 일정들을 year과 month 기준으로 전체 조회 api" ,security = @SecurityRequirement(name = "bearerToken"))
-  @Parameter(name = "studyChannelId", description = "일정을 만드는 study channel의 id 값", required = true)
-  @Parameter(name = "year", description = "일정의 year 값", required = true)
-  @Parameter(name = "month", description = "일정의 month 값", required = true)
-  public ResponseEntity<List<ScheduleResponse>> getSchedulesWithFormula(
-      @PathVariable Long studyChannelId,
-      @RequestParam int year, @RequestParam int month) {
-    return ResponseEntity.ok(scheduleService.getSchedulesInStudyChannelForYearAndMonth( studyChannelId, year, month));
-  }
+    @GetMapping("/study-channels/{studyChannelId}/schedules/date")
+    @Operation(summary = "스터디 채널에 존재하는 일정 year, month 기준 전체 조회", description = "특정 스터디 채널에 존재하는 일정들을 year과 month 기준으로 전체 조회 api" ,security = @SecurityRequirement(name = "bearerToken"))
+    @Parameter(name = "studyChannelId", description = "일정을 만드는 study channel의 id 값", required = true)
+    @Parameter(name = "year", description = "일정의 year 값", required = true)
+    @Parameter(name = "month", description = "일정의 month 값", required = true)
+    public ResponseEntity<List<ScheduleResponse>> getSchedulesWithFormula(
+        @PathVariable Long studyChannelId,
+        @RequestParam int year, @RequestParam int month) {
+        return ResponseEntity.ok(scheduleService.getSchedulesInStudyChannelForYearAndMonth( studyChannelId, year, month));
+    }
 
-  @PutMapping("/study-channels/{studyChannelId}/schedules")
-  @Operation(summary = "단일 일정 -> any 일정 | 반복 일정 -> 반복 일정으로 수정", description = "특정 스터디 채널의 일정을 수정할 때 [단일 -> any | 반복 -> 반복]일정으로 수정할 경우 수정 api" ,security = @SecurityRequirement(name = "bearerToken"))
-  @Parameter(name = "studyChannelId", description = "일정이 존재하는 study channel의 id 값", required = true)
-  @Parameter(name = "ScheduleEditRequest", description = "일정 수정 request, type의 값이 single, repeat에 따라 단일 일정 / 반복 일정 등록으로 나뉜다.", required = true )
-  public ResponseEntity<Void> putSchedule(
-      @PathVariable Long studyChannelId,
-      @Valid @RequestBody ScheduleEditRequest scheduleEditRequest)  {
-    scheduleService.putSchedule(studyChannelId, scheduleEditRequest);
-    return ResponseEntity.ok().build();
-  }
+    @PutMapping("/study-channels/{studyChannelId}/schedules")
+    @Operation(summary = "단일 일정 -> any 일정 | 반복 일정 -> 반복 일정으로 수정", description = "특정 스터디 채널의 일정을 수정할 때 [단일 -> any | 반복 -> 반복]일정으로 수정할 경우 수정 api" ,security = @SecurityRequirement(name = "bearerToken"))
+    @Parameter(name = "studyChannelId", description = "일정이 존재하는 study channel의 id 값", required = true)
+    @Parameter(name = "ScheduleEditRequest", description = "일정 수정 request, type의 값이 single, repeat에 따라 단일 일정 / 반복 일정 등록으로 나뉜다.", required = true )
+    public ResponseEntity<Void> putSchedule(
+        @PathVariable Long studyChannelId,
+        @Valid @RequestBody ScheduleEditRequest scheduleEditRequest)  {
+      scheduleService.putSchedule(studyChannelId, scheduleEditRequest);
+        return ResponseEntity.ok().build();
+    }
 
-  @PutMapping("/study-channels/{studyChannelId}/schedules/isAfterEvent")
-  @Operation(summary = "반복 일정 -> 단일 일정으로 수정", description = "특정 스터디 채널의 일정을 수정할 때 반복 일정에서 단일 일정으로 수정할 경우 수정하는 api" ,security = @SecurityRequirement(name = "bearerToken"))
-  @Parameter(name = "studyChannelId", description = "일정이 존재하는 study channel의 id 값", required = true)
-  @Parameter(name = "ScheduleEditRequest", description = "일정 등록 request, type의 값이 single, repeat에 따라 단일 일정 / 반복 일정 등록으로 나뉜다.", required = true )
-  public ResponseEntity<Void> putRepeatScheduleWithAfterEventSame(
-      @PathVariable Long studyChannelId,
-      @RequestParam("Same") Boolean isAfterEventSame,
-      @Valid @RequestBody ScheduleEditRequest scheduleEditRequest)  {
-    scheduleService.putRepeatScheduleWithAfterEventSame(studyChannelId, isAfterEventSame, scheduleEditRequest);
-    return ResponseEntity.ok().build();
-  }
+    @PutMapping("/study-channels/{studyChannelId}/schedules/isAfterEvent")
+    @Operation(summary = "반복 일정 -> 단일 일정으로 수정", description = "특정 스터디 채널의 일정을 수정할 때 반복 일정에서 단일 일정으로 수정할 경우 수정하는 api" ,security = @SecurityRequirement(name = "bearerToken"))
+    @Parameter(name = "studyChannelId", description = "일정이 존재하는 study channel의 id 값", required = true)
+    @Parameter(name = "ScheduleEditRequest", description = "일정 등록 request, type의 값이 single, repeat에 따라 단일 일정 / 반복 일정 등록으로 나뉜다.", required = true )
+    public ResponseEntity<Void> putRepeatScheduleWithAfterEventSame(
+        @PathVariable Long studyChannelId,
+        @RequestParam("Same") Boolean isAfterEventSame,
+        @Valid @RequestBody ScheduleEditRequest scheduleEditRequest)  {
+        scheduleService.putRepeatScheduleWithAfterEventSame(studyChannelId, isAfterEventSame, scheduleEditRequest);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
@@ -59,6 +59,9 @@ public class ScheduleController {
   }
 
   @PutMapping("/study-channels/{studyChannelId}/schedules")
+  @Operation(summary = "단일 일정 -> any 일정 | 반복 일정 -> 반복 일정으로 수정", description = "특정 스터디 채널의 일정을 수정할 때 [단일 -> any | 반복 -> 반복]일정으로 수정할 경우 수정 api" ,security = @SecurityRequirement(name = "bearerToken"))
+  @Parameter(name = "studyChannelId", description = "일정이 존재하는 study channel의 id 값", required = true)
+  @Parameter(name = "ScheduleEditRequest", description = "일정 수정 request, type의 값이 single, repeat에 따라 단일 일정 / 반복 일정 등록으로 나뉜다.", required = true )
   public ResponseEntity<Void> putSchedule(
       @PathVariable Long studyChannelId,
       @Valid @RequestBody ScheduleEditRequest scheduleEditRequest)  {
@@ -67,6 +70,9 @@ public class ScheduleController {
   }
 
   @PutMapping("/study-channels/{studyChannelId}/schedules/isAfterEvent")
+  @Operation(summary = "반복 일정 -> 단일 일정으로 수정", description = "특정 스터디 채널의 일정을 수정할 때 반복 일정에서 단일 일정으로 수정할 경우 수정하는 api" ,security = @SecurityRequirement(name = "bearerToken"))
+  @Parameter(name = "studyChannelId", description = "일정이 존재하는 study channel의 id 값", required = true)
+  @Parameter(name = "ScheduleEditRequest", description = "일정 등록 request, type의 값이 single, repeat에 따라 단일 일정 / 반복 일정 등록으로 나뉜다.", required = true )
   public ResponseEntity<Void> putRepeatScheduleWithAfterEventSame(
       @PathVariable Long studyChannelId,
       @RequestParam("Same") Boolean isAfterEventSame,

--- a/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
@@ -65,4 +65,13 @@ public class ScheduleController {
     scheduleService.putSchedule(studyChannelId, scheduleEditRequest);
     return ResponseEntity.ok().build();
   }
+
+  @PutMapping("/study-channels/{studyChannelId}/schedules/isAfterEvent")
+  public ResponseEntity<Void> putRepeatScheduleWithAfterEventSame(
+      @PathVariable Long studyChannelId,
+      @RequestParam("Same") Boolean isAfterEventSame,
+      @Valid @RequestBody ScheduleEditRequest scheduleEditRequest)  {
+    scheduleService.putRepeatScheduleWithAfterEventSame(studyChannelId, isAfterEventSame, scheduleEditRequest);
+    return ResponseEntity.ok().build();
+  }
 }

--- a/src/main/java/com/tenten/studybadge/schedule/domain/Schedule.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/Schedule.java
@@ -9,9 +9,9 @@ import lombok.Getter;
 @Getter
 @MappedSuperclass
 public abstract class Schedule extends BaseEntity {
-  protected String scheduleName;
-  protected String scheduleContent;
-  protected LocalDate scheduleDate;
-  protected LocalTime scheduleStartTime;
-  protected LocalTime scheduleEndTime;
+    protected String scheduleName;
+    protected String scheduleContent;
+    protected LocalDate scheduleDate;
+    protected LocalTime scheduleStartTime;
+    protected LocalTime scheduleEndTime;
 }

--- a/src/main/java/com/tenten/studybadge/schedule/domain/entity/RepeatSchedule.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/entity/RepeatSchedule.java
@@ -32,7 +32,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(indexes = @Index(name = "idx_study_channel_id", columnList = "study_channel_id"))
+@Table(indexes = @Index(name = "idx_study_channel_id_repeat", columnList = "study_channel_id"))
 public class RepeatSchedule extends Schedule {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/tenten/studybadge/schedule/domain/entity/RepeatSchedule.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/entity/RepeatSchedule.java
@@ -42,6 +42,7 @@ public class RepeatSchedule extends Schedule {
   private RepeatCycle repeatCycle;
   @Enumerated(EnumType.STRING)
   private RepeatSituation repeatSituation;
+  @Setter
   private LocalDate repeatEndDate;
   @Setter
   private Long placeId;
@@ -51,6 +52,9 @@ public class RepeatSchedule extends Schedule {
   @JoinColumn(name = "study_channel_id", nullable = false)
   private StudyChannel studyChannel;
 
+  public void setRepeatStartDate(LocalDate startDate) {
+    this.scheduleDate = startDate;
+  }
   @Builder(builderMethodName = "withoutIdBuilder")
   public RepeatSchedule(String scheduleName, String scheduleContent, LocalDate scheduleDate, LocalTime scheduleStartTime,
       LocalTime scheduleEndTime, boolean isRepeated, RepeatCycle repeatCycle, RepeatSituation repeatSituation,

--- a/src/main/java/com/tenten/studybadge/schedule/domain/entity/RepeatSchedule.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/entity/RepeatSchedule.java
@@ -34,71 +34,71 @@ import org.hibernate.annotations.DynamicUpdate;
 @AllArgsConstructor
 @Table(indexes = @Index(name = "idx_study_channel_id", columnList = "study_channel_id"))
 public class RepeatSchedule extends Schedule {
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private long id;
-  private boolean isRepeated;
-  @Enumerated(EnumType.STRING)
-  private RepeatCycle repeatCycle;
-  @Enumerated(EnumType.STRING)
-  private RepeatSituation repeatSituation;
-  @Setter
-  private LocalDate repeatEndDate;
-  @Setter
-  private Long placeId;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    private boolean isRepeated;
+    @Enumerated(EnumType.STRING)
+    private RepeatCycle repeatCycle;
+    @Enumerated(EnumType.STRING)
+    private RepeatSituation repeatSituation;
+    @Setter
+    private LocalDate repeatEndDate;
+    @Setter
+    private Long placeId;
 
-  @Setter
-  @ManyToOne
-  @JoinColumn(name = "study_channel_id", nullable = false)
-  private StudyChannel studyChannel;
+    @Setter
+    @ManyToOne
+    @JoinColumn(name = "study_channel_id", nullable = false)
+    private StudyChannel studyChannel;
 
-  public void setRepeatStartDate(LocalDate startDate) {
-    this.scheduleDate = startDate;
-  }
-  @Builder(builderMethodName = "withoutIdBuilder")
-  public RepeatSchedule(String scheduleName, String scheduleContent, LocalDate scheduleDate, LocalTime scheduleStartTime,
-      LocalTime scheduleEndTime, boolean isRepeated, RepeatCycle repeatCycle, RepeatSituation repeatSituation,
-      LocalDate repeatEndDate, Long placeId, StudyChannel studyChannel) {
-    this.scheduleName = scheduleName;
-    this.scheduleContent = scheduleContent;
-    this.scheduleDate = scheduleDate;
-    this.scheduleStartTime = scheduleStartTime;
-    this.scheduleEndTime = scheduleEndTime;
-    this.isRepeated = isRepeated;
-    this.repeatCycle = repeatCycle;
-    this.repeatSituation = repeatSituation;
-    this.repeatEndDate = repeatEndDate;
-    this.placeId = placeId;
-    this.studyChannel = studyChannel;
-  }
+    public void setRepeatStartDate(LocalDate startDate) {
+      this.scheduleDate = startDate;
+    }
+    @Builder(builderMethodName = "withoutIdBuilder")
+    public RepeatSchedule(String scheduleName, String scheduleContent, LocalDate scheduleDate, LocalTime scheduleStartTime,
+        LocalTime scheduleEndTime, boolean isRepeated, RepeatCycle repeatCycle, RepeatSituation repeatSituation,
+        LocalDate repeatEndDate, Long placeId, StudyChannel studyChannel) {
+        this.scheduleName = scheduleName;
+        this.scheduleContent = scheduleContent;
+        this.scheduleDate = scheduleDate;
+        this.scheduleStartTime = scheduleStartTime;
+        this.scheduleEndTime = scheduleEndTime;
+        this.isRepeated = isRepeated;
+        this.repeatCycle = repeatCycle;
+        this.repeatSituation = repeatSituation;
+        this.repeatEndDate = repeatEndDate;
+        this.placeId = placeId;
+        this.studyChannel = studyChannel;
+    }
 
-  public void updateRepeatSchedule(RepeatScheduleEditRequest scheduleEditRequest) {
-    this.scheduleName = scheduleEditRequest.getScheduleName();
-    this.scheduleContent = scheduleEditRequest.getScheduleContent();
-    this.scheduleDate = scheduleEditRequest.getSelectedDate();
-    this.scheduleStartTime = scheduleEditRequest.getScheduleStartTime();
-    this.scheduleEndTime = scheduleEditRequest.getScheduleEndTime();
-    this.isRepeated = true;
-    this.repeatCycle = scheduleEditRequest.getRepeatCycle();
-    this.repeatSituation = scheduleEditRequest.getRepeatSituation();
-    this.repeatEndDate = scheduleEditRequest.getRepeatEndDate();
-    this.placeId = scheduleEditRequest.getPlaceId();
-  }
+    public void updateRepeatSchedule(RepeatScheduleEditRequest scheduleEditRequest) {
+        this.scheduleName = scheduleEditRequest.getScheduleName();
+        this.scheduleContent = scheduleEditRequest.getScheduleContent();
+        this.scheduleDate = scheduleEditRequest.getSelectedDate();
+        this.scheduleStartTime = scheduleEditRequest.getScheduleStartTime();
+        this.scheduleEndTime = scheduleEditRequest.getScheduleEndTime();
+        this.isRepeated = true;
+        this.repeatCycle = scheduleEditRequest.getRepeatCycle();
+        this.repeatSituation = scheduleEditRequest.getRepeatSituation();
+        this.repeatEndDate = scheduleEditRequest.getRepeatEndDate();
+        this.placeId = scheduleEditRequest.getPlaceId();
+    }
 
-  public ScheduleResponse toResponse() {
-    return ScheduleResponse.builder()
-        .id(this.getId())
-        .scheduleName(this.getScheduleName())
-        .scheduleContent(this.getScheduleContent())
-        .scheduleDate(this.getScheduleDate())
-        .scheduleStartTime(this.getScheduleStartTime())
-        .scheduleEndTime(this.getScheduleEndTime())
-        .isRepeated(this.isRepeated())
-        .repeatCycle(this.getRepeatCycle())
-        .repeatSituation(this.getRepeatSituation())
-        .repeatEndDate(this.getRepeatEndDate())
-        .placeId(this.getPlaceId())
-        .studyChannelId(this.getStudyChannel().getId())
-        .build();
-  }
+    public ScheduleResponse toResponse() {
+        return ScheduleResponse.builder()
+            .id(this.getId())
+            .scheduleName(this.getScheduleName())
+            .scheduleContent(this.getScheduleContent())
+            .scheduleDate(this.getScheduleDate())
+            .scheduleStartTime(this.getScheduleStartTime())
+            .scheduleEndTime(this.getScheduleEndTime())
+            .isRepeated(this.isRepeated())
+            .repeatCycle(this.getRepeatCycle())
+            .repeatSituation(this.getRepeatSituation())
+            .repeatEndDate(this.getRepeatEndDate())
+            .placeId(this.getPlaceId())
+            .studyChannelId(this.getStudyChannel().getId())
+            .build();
+    }
 }

--- a/src/main/java/com/tenten/studybadge/schedule/domain/entity/SingleSchedule.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/entity/SingleSchedule.java
@@ -2,7 +2,6 @@ package com.tenten.studybadge.schedule.domain.entity;
 
 
 import com.tenten.studybadge.schedule.domain.Schedule;
-import com.tenten.studybadge.schedule.dto.RepeatScheduleEditRequest;
 import com.tenten.studybadge.schedule.dto.ScheduleResponse;
 import com.tenten.studybadge.schedule.dto.SingleScheduleEditRequest;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;

--- a/src/main/java/com/tenten/studybadge/schedule/domain/entity/SingleSchedule.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/entity/SingleSchedule.java
@@ -31,58 +31,58 @@ import org.hibernate.annotations.DynamicUpdate;
 @AllArgsConstructor
 @Table(indexes = @Index(name = "idx_study_channel_id", columnList = "study_channel_id"))
 public class SingleSchedule extends Schedule {
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private long id;
-  private boolean isRepeated;
-  @Setter
-  private Long placeId;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    private boolean isRepeated;
+    @Setter
+    private Long placeId;
 
-  @Setter
-  @ManyToOne
-  @JoinColumn(name = "study_channel_id", nullable = false)
-  private StudyChannel studyChannel;
+    @Setter
+    @ManyToOne
+    @JoinColumn(name = "study_channel_id", nullable = false)
+    private StudyChannel studyChannel;
 
-//  // TODO 단일 일정에만 실제 year, month 필드를 두고 인덱스를 만들지 고민
-//  private int scheduleYear;
-//  private int scheduleMonth;
+  //  // TODO 단일 일정에만 실제 year, month 필드를 두고 인덱스를 만들지 고민
+  //  private int scheduleYear;
+  //  private int scheduleMonth;
 
-  @Builder(builderMethodName = "withoutIdBuilder")
-  public SingleSchedule(String scheduleName, String scheduleContent, LocalDate scheduleDate, LocalTime scheduleStartTime,
-      LocalTime scheduleEndTime, boolean isRepeated, Long placeId, StudyChannel studyChannel) {
-    this.scheduleName = scheduleName;
-    this.scheduleContent = scheduleContent;
-    this.scheduleDate = scheduleDate;
-    this.scheduleStartTime = scheduleStartTime;
-    this.scheduleEndTime = scheduleEndTime;
-    this.isRepeated = isRepeated;
-    this.placeId = placeId;
-    this.studyChannel = studyChannel;
-  }
+    @Builder(builderMethodName = "withoutIdBuilder")
+    public SingleSchedule(String scheduleName, String scheduleContent, LocalDate scheduleDate, LocalTime scheduleStartTime,
+        LocalTime scheduleEndTime, boolean isRepeated, Long placeId, StudyChannel studyChannel) {
+        this.scheduleName = scheduleName;
+        this.scheduleContent = scheduleContent;
+        this.scheduleDate = scheduleDate;
+        this.scheduleStartTime = scheduleStartTime;
+        this.scheduleEndTime = scheduleEndTime;
+        this.isRepeated = isRepeated;
+        this.placeId = placeId;
+        this.studyChannel = studyChannel;
+    }
 
-  public void updateSingleSchedule(SingleScheduleEditRequest scheduleEditRequest) {
-    this.scheduleName = scheduleEditRequest.getScheduleName();
-    this.scheduleContent = scheduleEditRequest.getScheduleContent();
-    this.scheduleDate = scheduleEditRequest.getSelectedDate();
-    this.scheduleStartTime = scheduleEditRequest.getScheduleStartTime();
-    this.scheduleEndTime = scheduleEditRequest.getScheduleEndTime();
-    this.isRepeated = false;
-    this.placeId = scheduleEditRequest.getPlaceId();
-  }
+    public void updateSingleSchedule(SingleScheduleEditRequest scheduleEditRequest) {
+        this.scheduleName = scheduleEditRequest.getScheduleName();
+        this.scheduleContent = scheduleEditRequest.getScheduleContent();
+        this.scheduleDate = scheduleEditRequest.getSelectedDate();
+        this.scheduleStartTime = scheduleEditRequest.getScheduleStartTime();
+        this.scheduleEndTime = scheduleEditRequest.getScheduleEndTime();
+        this.isRepeated = false;
+        this.placeId = scheduleEditRequest.getPlaceId();
+    }
 
-  public ScheduleResponse toResponse() {
-    return ScheduleResponse.builder()
-        .id(this.getId())
-        .scheduleName(this.getScheduleName())
-        .scheduleContent(this.getScheduleContent())
-        .scheduleDate(this.getScheduleDate())
-        .scheduleStartTime(this.getScheduleStartTime())
-        .scheduleEndTime(this.getScheduleEndTime())
-        .isRepeated(this.isRepeated())
-        .repeatCycle(null)
-        .repeatSituation(null)
-        .placeId(this.getPlaceId())
-        .studyChannelId(this.getStudyChannel().getId())
-        .build();
-  }
+    public ScheduleResponse toResponse() {
+        return ScheduleResponse.builder()
+            .id(this.getId())
+            .scheduleName(this.getScheduleName())
+            .scheduleContent(this.getScheduleContent())
+            .scheduleDate(this.getScheduleDate())
+            .scheduleStartTime(this.getScheduleStartTime())
+            .scheduleEndTime(this.getScheduleEndTime())
+            .isRepeated(this.isRepeated())
+            .repeatCycle(null)
+            .repeatSituation(null)
+            .placeId(this.getPlaceId())
+            .studyChannelId(this.getStudyChannel().getId())
+            .build();
+    }
 }

--- a/src/main/java/com/tenten/studybadge/schedule/domain/entity/SingleSchedule.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/entity/SingleSchedule.java
@@ -29,7 +29,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(indexes = @Index(name = "idx_study_channel_id", columnList = "study_channel_id"))
+@Table(indexes = @Index(name = "idx_study_channel_id_repeat", columnList = "study_channel_id"))
 public class SingleSchedule extends Schedule {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/tenten/studybadge/schedule/domain/repository/RepeatScheduleRepository.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/repository/RepeatScheduleRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface RepeatScheduleRepository extends ScheduleRepository<RepeatSchedule> {
 
-  @Query("SELECT rs FROM RepeatSchedule rs WHERE rs.studyChannel.id = :studyChannelId AND " +
-      "(:date BETWEEN rs.scheduleDate AND rs.repeatEndDate)")
-  List<RepeatSchedule> findAllByStudyChannelIdAndDate(Long studyChannelId, LocalDate date);
+    @Query("SELECT rs FROM RepeatSchedule rs WHERE rs.studyChannel.id = :studyChannelId AND " +
+        "(:date BETWEEN rs.scheduleDate AND rs.repeatEndDate)")
+    List<RepeatSchedule> findAllByStudyChannelIdAndDate(Long studyChannelId, LocalDate date);
 }

--- a/src/main/java/com/tenten/studybadge/schedule/domain/repository/ScheduleRepository.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/repository/ScheduleRepository.java
@@ -8,8 +8,7 @@ import org.springframework.data.repository.NoRepositoryBean;
 
 @NoRepositoryBean
 public interface ScheduleRepository<T extends Schedule> extends JpaRepository<T, Long> {
-
-  @Query("SELECT s FROM #{#entityName} s WHERE s.studyChannel.id = :studyChannelId")
-  List<T> findAllByStudyChannelId(Long studyChannelId);
+    @Query("SELECT s FROM #{#entityName} s WHERE s.studyChannel.id = :studyChannelId")
+    List<T> findAllByStudyChannelId(Long studyChannelId);
 
 }

--- a/src/main/java/com/tenten/studybadge/schedule/domain/repository/SingleScheduleRepository.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/repository/SingleScheduleRepository.java
@@ -9,6 +9,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SingleScheduleRepository extends ScheduleRepository<SingleSchedule> {
-  @Query("SELECT ss FROM SingleSchedule ss WHERE ss.studyChannel.id = :studyChannelId AND ss.scheduleDate BETWEEN :startDate AND :endDate")
-  List<SingleSchedule> findAllByStudyChannelIdAndDateRange(Long studyChannelId, LocalDate startDate, LocalDate endDate);
+    @Query("SELECT ss FROM SingleSchedule ss WHERE ss.studyChannel.id = :studyChannelId AND ss.scheduleDate BETWEEN :startDate AND :endDate")
+    List<SingleSchedule> findAllByStudyChannelIdAndDateRange(Long studyChannelId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/tenten/studybadge/schedule/dto/RepeatScheduleCreateRequest.java
+++ b/src/main/java/com/tenten/studybadge/schedule/dto/RepeatScheduleCreateRequest.java
@@ -15,23 +15,23 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class RepeatScheduleCreateRequest extends ScheduleCreateRequest {
-  private RepeatCycle repeatCycle;
-  @JsonDeserialize(using = RepeatSituationNumberDeserializer.class)
-  private RepeatSituation repeatSituation;
-  private LocalDate repeatEndDate;
+    private RepeatCycle repeatCycle;
+    @JsonDeserialize(using = RepeatSituationNumberDeserializer.class)
+    private RepeatSituation repeatSituation;
+    private LocalDate repeatEndDate;
 
-  public RepeatScheduleCreateRequest(String scheduleName, String scheduleContent,
-      LocalDate startDate, LocalTime startTime, LocalTime endTime,
-      RepeatCycle repeatCycle, RepeatSituation repeatSituation, LocalDate repeatEndDate,
-      Long placeId) {
-    this.scheduleName = scheduleName;
-    this.scheduleContent = scheduleContent;
-    this.scheduleDate = startDate;
-    this.scheduleStartTime = startTime;
-    this.scheduleEndTime = endTime;
-    this.placeId = placeId;
-    this.repeatCycle = repeatCycle;
-    this.repeatSituation = repeatSituation;
-    this.repeatEndDate = repeatEndDate;
-  }
+    public RepeatScheduleCreateRequest(String scheduleName, String scheduleContent,
+        LocalDate startDate, LocalTime startTime, LocalTime endTime,
+        RepeatCycle repeatCycle, RepeatSituation repeatSituation, LocalDate repeatEndDate,
+        Long placeId) {
+        this.scheduleName = scheduleName;
+        this.scheduleContent = scheduleContent;
+        this.scheduleDate = startDate;
+        this.scheduleStartTime = startTime;
+        this.scheduleEndTime = endTime;
+        this.placeId = placeId;
+        this.repeatCycle = repeatCycle;
+        this.repeatSituation = repeatSituation;
+        this.repeatEndDate = repeatEndDate;
+    }
 }

--- a/src/main/java/com/tenten/studybadge/schedule/dto/RepeatScheduleEditRequest.java
+++ b/src/main/java/com/tenten/studybadge/schedule/dto/RepeatScheduleEditRequest.java
@@ -14,9 +14,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class RepeatScheduleEditRequest extends ScheduleEditRequest{
-  private boolean isAfterEventSame;
+
   @NotNull(message = "일정 반복 주기는 필수입니다.")
   private RepeatCycle repeatCycle;
+  @NotNull(message = "일정 반복 상황은 필수입니다.")
   @JsonDeserialize(using = RepeatSituationNumberDeserializer.class)
   private RepeatSituation repeatSituation;
   @NotNull(message = "일정 반복 끝나는 날짜는 필수입니다.")
@@ -25,7 +26,6 @@ public class RepeatScheduleEditRequest extends ScheduleEditRequest{
   public RepeatScheduleEditRequest(Long scheduleId, ScheduleOriginType originType,
       String scheduleName, String scheduleContent,
       LocalDate selectedDate, LocalTime startTime, LocalTime endTime,
-      boolean isAfterEventSame,
       RepeatCycle repeatCycle, RepeatSituation repeatSituation, LocalDate repeatEndDate,
       Long placeId) {
     this.scheduleId = scheduleId;
@@ -35,7 +35,6 @@ public class RepeatScheduleEditRequest extends ScheduleEditRequest{
     this.selectedDate = selectedDate;
     this.scheduleStartTime = startTime;
     this.scheduleEndTime = endTime;
-    this.isAfterEventSame = isAfterEventSame;
     this.repeatCycle = repeatCycle;
     this.repeatSituation = repeatSituation;
     this.repeatEndDate = repeatEndDate;

--- a/src/main/java/com/tenten/studybadge/schedule/dto/RepeatScheduleEditRequest.java
+++ b/src/main/java/com/tenten/studybadge/schedule/dto/RepeatScheduleEditRequest.java
@@ -15,29 +15,29 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class RepeatScheduleEditRequest extends ScheduleEditRequest{
 
-  @NotNull(message = "일정 반복 주기는 필수입니다.")
-  private RepeatCycle repeatCycle;
-  @NotNull(message = "일정 반복 상황은 필수입니다.")
-  @JsonDeserialize(using = RepeatSituationNumberDeserializer.class)
-  private RepeatSituation repeatSituation;
-  @NotNull(message = "일정 반복 끝나는 날짜는 필수입니다.")
-  private LocalDate repeatEndDate;
+    @NotNull(message = "일정 반복 주기는 필수입니다.")
+    private RepeatCycle repeatCycle;
+    @NotNull(message = "일정 반복 상황은 필수입니다.")
+    @JsonDeserialize(using = RepeatSituationNumberDeserializer.class)
+    private RepeatSituation repeatSituation;
+    @NotNull(message = "일정 반복 끝나는 날짜는 필수입니다.")
+    private LocalDate repeatEndDate;
 
-  public RepeatScheduleEditRequest(Long scheduleId, ScheduleOriginType originType,
-      String scheduleName, String scheduleContent,
-      LocalDate selectedDate, LocalTime startTime, LocalTime endTime,
-      RepeatCycle repeatCycle, RepeatSituation repeatSituation, LocalDate repeatEndDate,
-      Long placeId) {
-    this.scheduleId = scheduleId;
-    this.originType = originType;
-    this.scheduleName = scheduleName;
-    this.scheduleContent = scheduleContent;
-    this.selectedDate = selectedDate;
-    this.scheduleStartTime = startTime;
-    this.scheduleEndTime = endTime;
-    this.repeatCycle = repeatCycle;
-    this.repeatSituation = repeatSituation;
-    this.repeatEndDate = repeatEndDate;
-    this.placeId = placeId;
-  }
+    public RepeatScheduleEditRequest(Long scheduleId, ScheduleOriginType originType,
+        String scheduleName, String scheduleContent,
+        LocalDate selectedDate, LocalTime startTime, LocalTime endTime,
+        RepeatCycle repeatCycle, RepeatSituation repeatSituation, LocalDate repeatEndDate,
+        Long placeId) {
+        this.scheduleId = scheduleId;
+        this.originType = originType;
+        this.scheduleName = scheduleName;
+        this.scheduleContent = scheduleContent;
+        this.selectedDate = selectedDate;
+        this.scheduleStartTime = startTime;
+        this.scheduleEndTime = endTime;
+        this.repeatCycle = repeatCycle;
+        this.repeatSituation = repeatSituation;
+        this.repeatEndDate = repeatEndDate;
+        this.placeId = placeId;
+    }
 }

--- a/src/main/java/com/tenten/studybadge/schedule/dto/ScheduleCreateRequest.java
+++ b/src/main/java/com/tenten/studybadge/schedule/dto/ScheduleCreateRequest.java
@@ -20,16 +20,16 @@ import lombok.Setter;
     @JsonSubTypes.Type(value = RepeatScheduleCreateRequest.class, name = "repeat")
 })
 public abstract class ScheduleCreateRequest {
-  @NotBlank(message = "일정 이름은 필수입니다.")
-  protected String scheduleName;
-  @NotBlank(message = "일정 내용은 필수입니다.")
-  protected String scheduleContent;
-  @NotNull(message = "일정 날짜는 필수입니다.")
-  protected LocalDate scheduleDate;
-  @NotNull(message = "일정 시작 시간은 필수입니다.")
-  protected LocalTime scheduleStartTime;
-  @NotNull(message = "일정 끝 시간은 필수입니다.")
-  protected LocalTime scheduleEndTime;
-  @Setter
-  protected Long placeId;
+    @NotBlank(message = "일정 이름은 필수입니다.")
+    protected String scheduleName;
+    @NotBlank(message = "일정 내용은 필수입니다.")
+    protected String scheduleContent;
+    @NotNull(message = "일정 날짜는 필수입니다.")
+    protected LocalDate scheduleDate;
+    @NotNull(message = "일정 시작 시간은 필수입니다.")
+    protected LocalTime scheduleStartTime;
+    @NotNull(message = "일정 끝 시간은 필수입니다.")
+    protected LocalTime scheduleEndTime;
+    @Setter
+    protected Long placeId;
 }

--- a/src/main/java/com/tenten/studybadge/schedule/dto/ScheduleEditRequest.java
+++ b/src/main/java/com/tenten/studybadge/schedule/dto/ScheduleEditRequest.java
@@ -24,21 +24,21 @@ import lombok.Setter;
     @JsonSubTypes.Type(value = RepeatScheduleEditRequest.class, name = "repeat")
 })
 public abstract class ScheduleEditRequest {
-  @NotNull(message = "수정할 일정 id는 필수입니다.")
-  protected long scheduleId;
-  @NotNull(message = "기존 일정 타입은 필수입니다.")
-  @JsonDeserialize(using = ScheduleOriginTypeDeserializer.class)
-  protected ScheduleOriginType originType;
-  @NotBlank(message = "일정 이름은 필수입니다.")
-  protected String scheduleName;
-  @NotBlank(message = "일정 내용은 필수입니다.")
-  protected String scheduleContent;
-  @NotNull(message = "수정할 일정 날짜는 필수입니다.")
-  protected LocalDate selectedDate;
-  @NotNull(message = "일정 시작 시간은 필수입니다.")
-  protected LocalTime scheduleStartTime;
-  @NotNull(message = "일정 끝 시간은 필수입니다.")
-  protected LocalTime scheduleEndTime;
-  @Setter
-  protected Long placeId;
+    @NotNull(message = "수정할 일정 id는 필수입니다.")
+    protected long scheduleId;
+    @NotNull(message = "기존 일정 타입은 필수입니다.")
+    @JsonDeserialize(using = ScheduleOriginTypeDeserializer.class)
+    protected ScheduleOriginType originType;
+    @NotBlank(message = "일정 이름은 필수입니다.")
+    protected String scheduleName;
+    @NotBlank(message = "일정 내용은 필수입니다.")
+    protected String scheduleContent;
+    @NotNull(message = "수정할 일정 날짜는 필수입니다.")
+    protected LocalDate selectedDate;
+    @NotNull(message = "일정 시작 시간은 필수입니다.")
+    protected LocalTime scheduleStartTime;
+    @NotNull(message = "일정 끝 시간은 필수입니다.")
+    protected LocalTime scheduleEndTime;
+    @Setter
+    protected Long placeId;
 }

--- a/src/main/java/com/tenten/studybadge/schedule/dto/ScheduleResponse.java
+++ b/src/main/java/com/tenten/studybadge/schedule/dto/ScheduleResponse.java
@@ -14,16 +14,16 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ScheduleResponse {
-  private long id;
-  private long studyChannelId;
-  private String scheduleName;
-  private String scheduleContent;
-  private LocalDate scheduleDate;
-  private LocalTime scheduleStartTime;
-  private LocalTime scheduleEndTime;
-  private boolean isRepeated;
-  private RepeatCycle repeatCycle;
-  private RepeatSituation repeatSituation;
-  private LocalDate repeatEndDate;
-  private Long placeId;
+    private long id;
+    private long studyChannelId;
+    private String scheduleName;
+    private String scheduleContent;
+    private LocalDate scheduleDate;
+    private LocalTime scheduleStartTime;
+    private LocalTime scheduleEndTime;
+    private boolean isRepeated;
+    private RepeatCycle repeatCycle;
+    private RepeatSituation repeatSituation;
+    private LocalDate repeatEndDate;
+    private Long placeId;
 }

--- a/src/main/java/com/tenten/studybadge/schedule/dto/SingleScheduleCreateRequest.java
+++ b/src/main/java/com/tenten/studybadge/schedule/dto/SingleScheduleCreateRequest.java
@@ -8,14 +8,14 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class SingleScheduleCreateRequest extends ScheduleCreateRequest {
-  public SingleScheduleCreateRequest(String scheduleName, String scheduleContent,
-      LocalDate startDate, LocalTime startTime, LocalTime endTime,
-      Long placeId) {
-    this.scheduleName = scheduleName;
-    this.scheduleContent = scheduleContent;
-    this.scheduleDate = startDate;
-    this.scheduleStartTime = startTime;
-    this.scheduleEndTime = endTime;
-    this.placeId = placeId;
-  }
+    public SingleScheduleCreateRequest(String scheduleName, String scheduleContent,
+        LocalDate startDate, LocalTime startTime, LocalTime endTime,
+        Long placeId) {
+        this.scheduleName = scheduleName;
+        this.scheduleContent = scheduleContent;
+        this.scheduleDate = startDate;
+        this.scheduleStartTime = startTime;
+        this.scheduleEndTime = endTime;
+        this.placeId = placeId;
+    }
 }

--- a/src/main/java/com/tenten/studybadge/schedule/dto/SingleScheduleEditRequest.java
+++ b/src/main/java/com/tenten/studybadge/schedule/dto/SingleScheduleEditRequest.java
@@ -10,17 +10,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class SingleScheduleEditRequest extends ScheduleEditRequest{
 
-  public SingleScheduleEditRequest(Long scheduleId, ScheduleOriginType originType,
-      String scheduleName, String scheduleContent,
-      LocalDate selectedDate, LocalTime startTime, LocalTime endTime,
-      Long placeId) {
-    this.scheduleId = scheduleId;
-    this.originType = originType;
-    this.scheduleName = scheduleName;
-    this.scheduleContent = scheduleContent;
-    this.selectedDate = selectedDate;
-    this.scheduleStartTime = startTime;
-    this.scheduleEndTime = endTime;
-    this.placeId = placeId;
-  }
+    public SingleScheduleEditRequest(Long scheduleId, ScheduleOriginType originType,
+        String scheduleName, String scheduleContent,
+        LocalDate selectedDate, LocalTime startTime, LocalTime endTime,
+        Long placeId) {
+        this.scheduleId = scheduleId;
+        this.originType = originType;
+        this.scheduleName = scheduleName;
+        this.scheduleContent = scheduleContent;
+        this.selectedDate = selectedDate;
+        this.scheduleStartTime = startTime;
+        this.scheduleEndTime = endTime;
+        this.placeId = placeId;
+    }
 }

--- a/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
+++ b/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
@@ -219,7 +219,7 @@ public class ScheduleService {
 
     LocalDate selectedDate = singleScheduleEditRequest.getSelectedDate();
     if (selectedDate.equals(repeatSchedule.getScheduleDate())) {
-      repeatScheduleRepository.deleteById(repeatSchedule.getId());
+      repeatScheduleRepository.deleteById(singleScheduleEditRequest.getScheduleId());
     } else if (isNextRepeatStartDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule.getScheduleDate())) {
         repeatScheduleRepository.deleteById(singleScheduleEditRequest.getScheduleId());
         singleScheduleRepository.save(SingleSchedule.withoutIdBuilder()
@@ -248,7 +248,7 @@ public class ScheduleService {
           .studyChannel(repeatSchedule.getStudyChannel())
           .placeId(repeatSchedule.getPlaceId())
           .build();
-      repeatScheduleRepository.deleteById(repeatSchedule.getId());
+      repeatScheduleRepository.deleteById(singleScheduleEditRequest.getScheduleId());
     }
 
     // 선택 날짜 single schedule

--- a/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
+++ b/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
@@ -31,251 +31,214 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class ScheduleService {
-  private final SingleScheduleRepository singleScheduleRepository;
-  private final RepeatScheduleRepository repeatScheduleRepository;
-  private final StudyChannelRepository studyChannelRepository;
+    private final SingleScheduleRepository singleScheduleRepository;
+    private final RepeatScheduleRepository repeatScheduleRepository;
+    private final StudyChannelRepository studyChannelRepository;
 
-  public void postSchedule(ScheduleCreateRequest scheduleCreateRequest, Long studyChannelId) {
-    StudyChannel studyChannel =  studyChannelRepository.findById(studyChannelId)
-        .orElseThrow(NotFoundStudyChannelException::new);
+    public void postSchedule(ScheduleCreateRequest scheduleCreateRequest, Long studyChannelId) {
+        StudyChannel studyChannel =  studyChannelRepository.findById(studyChannelId)
+            .orElseThrow(NotFoundStudyChannelException::new);
 
-    // type: repeat
-    if (scheduleCreateRequest instanceof RepeatScheduleCreateRequest) {
-      RepeatScheduleCreateRequest repeatRequest = (RepeatScheduleCreateRequest) scheduleCreateRequest;
+        // type: repeat
+        if (scheduleCreateRequest instanceof RepeatScheduleCreateRequest) {
+            RepeatScheduleCreateRequest repeatRequest = (RepeatScheduleCreateRequest) scheduleCreateRequest;
 
-      repeatScheduleRepository.save(RepeatSchedule.withoutIdBuilder()
-              .scheduleName(repeatRequest.getScheduleName())
-              .scheduleContent(repeatRequest.getScheduleContent())
-              .scheduleDate(repeatRequest.getScheduleDate())
-              .scheduleStartTime(repeatRequest.getScheduleStartTime())
-              .scheduleEndTime(repeatRequest.getScheduleEndTime())
-              .isRepeated(true)
-              .repeatCycle(repeatRequest.getRepeatCycle())
-              .repeatSituation(repeatRequest.getRepeatSituation())
-              .repeatEndDate(repeatRequest.getRepeatEndDate())
-              .studyChannel(studyChannel)
-              .placeId(repeatRequest.getPlaceId())
-          .build());
-    }
-    // type: single
-    else if (scheduleCreateRequest instanceof SingleScheduleCreateRequest) {
-      SingleScheduleCreateRequest singleRequest = (SingleScheduleCreateRequest) scheduleCreateRequest;
+            repeatScheduleRepository.save(RepeatSchedule.withoutIdBuilder()
+                    .scheduleName(repeatRequest.getScheduleName())
+                    .scheduleContent(repeatRequest.getScheduleContent())
+                    .scheduleDate(repeatRequest.getScheduleDate())
+                    .scheduleStartTime(repeatRequest.getScheduleStartTime())
+                    .scheduleEndTime(repeatRequest.getScheduleEndTime())
+                    .isRepeated(true)
+                    .repeatCycle(repeatRequest.getRepeatCycle())
+                    .repeatSituation(repeatRequest.getRepeatSituation())
+                    .repeatEndDate(repeatRequest.getRepeatEndDate())
+                    .studyChannel(studyChannel)
+                    .placeId(repeatRequest.getPlaceId())
+                .build());
+        }
+        // type: single
+        else if (scheduleCreateRequest instanceof SingleScheduleCreateRequest) {
+            SingleScheduleCreateRequest singleRequest = (SingleScheduleCreateRequest) scheduleCreateRequest;
 
-      singleScheduleRepository.save(SingleSchedule.withoutIdBuilder()
-          .scheduleName(singleRequest.getScheduleName())
-          .scheduleContent(singleRequest.getScheduleContent())
-          .scheduleDate(singleRequest.getScheduleDate())
-          .scheduleStartTime(singleRequest.getScheduleStartTime())
-          .scheduleEndTime(singleRequest.getScheduleEndTime())
-          .isRepeated(false)
-          .studyChannel(studyChannel)
-          .placeId(singleRequest.getPlaceId())
-          .build());
-    } else {
-      throw new IllegalArgumentForScheduleRequestException();
-    }
-  }
-
-  public List<ScheduleResponse> getSchedulesInStudyChannel(Long studyChannelId) {
-    StudyChannel studyChannel = studyChannelRepository.findById(studyChannelId)
-        .orElseThrow(NotFoundStudyChannelException::new);
-
-    List<ScheduleResponse> scheduleResponses = new ArrayList<>();
-    List<ScheduleResponse> singleScheduleResponses = singleScheduleRepository.findAllByStudyChannelId(
-            studyChannelId)
-        .stream()
-        .map(SingleSchedule::toResponse)
-        .collect(Collectors.toList());
-
-    List<ScheduleResponse> repeatScheduleResponses = repeatScheduleRepository.findAllByStudyChannelId(
-            studyChannelId)
-        .stream()
-        .map(RepeatSchedule::toResponse)
-        .collect(Collectors.toList());
-
-    scheduleResponses.addAll(singleScheduleResponses);
-    scheduleResponses.addAll(repeatScheduleResponses);
-
-    return scheduleResponses;
-  }
-
-  public List<ScheduleResponse> getSchedulesInStudyChannelForYearAndMonth(Long studyChannelId, int year, int month) {
-    StudyChannel studyChannel = studyChannelRepository.findById(studyChannelId)
-        .orElseThrow(NotFoundStudyChannelException::new);
-
-    List<ScheduleResponse> scheduleResponses = new ArrayList<>();
-
-    LocalDate selectMonthFirstDate = LocalDate.of(year, month, 1);
-    LocalDate selectMonthLastDate = selectMonthFirstDate.withDayOfMonth(selectMonthFirstDate.lengthOfMonth());
-    List<ScheduleResponse> singleScheduleResponses = singleScheduleRepository.findAllByStudyChannelIdAndDateRange(
-            studyChannelId,selectMonthFirstDate, selectMonthLastDate)
-        .stream()
-        .map(SingleSchedule::toResponse)
-        .collect(Collectors.toList());
-
-    List<ScheduleResponse> repeatScheduleResponses = repeatScheduleRepository.findAllByStudyChannelIdAndDate(
-            studyChannelId, selectMonthFirstDate)
-        .stream()
-        .map(RepeatSchedule::toResponse)
-        .collect(Collectors.toList());
-
-    scheduleResponses.addAll(singleScheduleResponses);
-    scheduleResponses.addAll(repeatScheduleResponses);
-    return scheduleResponses;
-  }
-
-  public void putSchedule(Long studyChannelId, ScheduleEditRequest scheduleEditRequest) {
-    StudyChannel studyChannel = studyChannelRepository.findById(studyChannelId)
-        .orElseThrow(NotFoundStudyChannelException::new);
-
-    if (scheduleEditRequest.getOriginType() == ScheduleOriginType.SINGLE) {
-      SingleSchedule singleSchedule = singleScheduleRepository.findById(
-              scheduleEditRequest.getScheduleId())
-          .orElseThrow(NotFoundSingleScheduleException::new);
-
-      if (scheduleEditRequest instanceof SingleScheduleEditRequest) {
-        putScheduleSingleToSingle(
-            singleSchedule, (SingleScheduleEditRequest) scheduleEditRequest);
-      } else if (scheduleEditRequest instanceof RepeatScheduleEditRequest) {
-        putScheduleSingleToRepeat(
-            singleSchedule, (RepeatScheduleEditRequest) scheduleEditRequest);
-      }
-    } else if (scheduleEditRequest.getOriginType() == ScheduleOriginType.REPEAT) {
-      RepeatSchedule repeatSchedule = repeatScheduleRepository.findById(
-              scheduleEditRequest.getScheduleId())
-          .orElseThrow(NotFoundRepeatScheduleException::new);
-
-      if (scheduleEditRequest instanceof RepeatScheduleEditRequest) {
-        putScheduleRepeatToRepeat(
-            repeatSchedule, (RepeatScheduleEditRequest) scheduleEditRequest);
-      }
-    } else {
-      throw new IllegalArgumentForScheduleRequestException();
-    }
-  }
-
-  public void putScheduleSingleToSingle(SingleSchedule singleSchedule, SingleScheduleEditRequest singleScheduleEditRequest) {
-      singleSchedule.updateSingleSchedule(singleScheduleEditRequest);
-      singleScheduleRepository.save(singleSchedule);
-  }
-
-  public void putScheduleSingleToRepeat(SingleSchedule singleSchedule, RepeatScheduleEditRequest repeatScheduleEditRequest) {
-
-    repeatScheduleRepository.save(RepeatSchedule.withoutIdBuilder()
-        .scheduleName(repeatScheduleEditRequest.getScheduleName())
-        .scheduleContent(repeatScheduleEditRequest.getScheduleContent())
-        .scheduleContent(repeatScheduleEditRequest.getScheduleContent())
-        .scheduleDate(repeatScheduleEditRequest.getSelectedDate())
-        .scheduleStartTime(repeatScheduleEditRequest.getScheduleStartTime())
-        .scheduleEndTime(repeatScheduleEditRequest.getScheduleEndTime())
-        .isRepeated(true)
-        .repeatEndDate(repeatScheduleEditRequest.getRepeatEndDate())
-        .repeatCycle(repeatScheduleEditRequest.getRepeatCycle())
-        .repeatSituation(repeatScheduleEditRequest.getRepeatSituation())
-        .studyChannel(singleSchedule.getStudyChannel())
-        .placeId(repeatScheduleEditRequest.getPlaceId())
-        .build());
-    singleScheduleRepository.deleteById(repeatScheduleEditRequest.getScheduleId());
-  }
-
-  public void putScheduleRepeatToRepeat(RepeatSchedule repeatSchedule, RepeatScheduleEditRequest repeatScheduleEditRequest) {
-
-    if (repeatSchedule.getRepeatCycle() != repeatScheduleEditRequest.getRepeatCycle()) {
-      throw new IllegalArgumentForRepeatScheduleEditRequestException();
+            singleScheduleRepository.save(SingleSchedule.withoutIdBuilder()
+                .scheduleName(singleRequest.getScheduleName())
+                .scheduleContent(singleRequest.getScheduleContent())
+                .scheduleDate(singleRequest.getScheduleDate())
+                .scheduleStartTime(singleRequest.getScheduleStartTime())
+                .scheduleEndTime(singleRequest.getScheduleEndTime())
+                .isRepeated(false)
+                .studyChannel(studyChannel)
+                .placeId(singleRequest.getPlaceId())
+                .build());
+        } else {
+            throw new IllegalArgumentForScheduleRequestException();
+        }
     }
 
-    repeatSchedule.updateRepeatSchedule(repeatScheduleEditRequest);
-    repeatScheduleRepository.save(repeatSchedule);
-  }
+    public List<ScheduleResponse> getSchedulesInStudyChannel(Long studyChannelId) {
+        StudyChannel studyChannel = studyChannelRepository.findById(studyChannelId)
+            .orElseThrow(NotFoundStudyChannelException::new);
 
-  public void putRepeatScheduleWithAfterEventSame(
-      Long studyChannelId, Boolean isAfterEventSame, ScheduleEditRequest scheduleEditRequest) {
+        List<ScheduleResponse> scheduleResponses = new ArrayList<>();
+        List<ScheduleResponse> singleScheduleResponses = singleScheduleRepository.findAllByStudyChannelId(
+                studyChannelId)
+            .stream()
+            .map(SingleSchedule::toResponse)
+            .collect(Collectors.toList());
 
-    StudyChannel studyChannel = studyChannelRepository.findById(studyChannelId)
-        .orElseThrow(NotFoundStudyChannelException::new);
+        List<ScheduleResponse> repeatScheduleResponses = repeatScheduleRepository.findAllByStudyChannelId(
+                studyChannelId)
+            .stream()
+            .map(RepeatSchedule::toResponse)
+            .collect(Collectors.toList());
 
-    RepeatSchedule repeatSchedule = repeatScheduleRepository.findById(
-            scheduleEditRequest.getScheduleId())
-        .orElseThrow(NotFoundRepeatScheduleException::new);
+        scheduleResponses.addAll(singleScheduleResponses);
+        scheduleResponses.addAll(repeatScheduleResponses);
 
-    if (isNotIncluded(scheduleEditRequest.getSelectedDate(), repeatSchedule.getScheduleDate(), repeatSchedule.getRepeatEndDate())) {
-      throw new OutRangeScheduleException();
+        return scheduleResponses;
     }
 
-    if (scheduleEditRequest.getOriginType() == ScheduleOriginType.REPEAT
-    && !isAfterEventSame) {
-      putScheduleRepeatToSingleAfterEventNo(repeatSchedule, (SingleScheduleEditRequest) scheduleEditRequest);
+    public List<ScheduleResponse> getSchedulesInStudyChannelForYearAndMonth(Long studyChannelId, int year, int month) {
+        StudyChannel studyChannel = studyChannelRepository.findById(studyChannelId)
+            .orElseThrow(NotFoundStudyChannelException::new);
 
-    } else if (scheduleEditRequest.getOriginType() == ScheduleOriginType.REPEAT
-        && isAfterEventSame) {
-      putScheduleRepeatToSingleAfterEventYes(repeatSchedule, (SingleScheduleEditRequest) scheduleEditRequest);
+        List<ScheduleResponse> scheduleResponses = new ArrayList<>();
 
-    } else {
-      throw new IllegalArgumentForScheduleRequestException();
+        LocalDate selectMonthFirstDate = LocalDate.of(year, month, 1);
+        LocalDate selectMonthLastDate = selectMonthFirstDate.withDayOfMonth(selectMonthFirstDate.lengthOfMonth());
+        List<ScheduleResponse> singleScheduleResponses = singleScheduleRepository.findAllByStudyChannelIdAndDateRange(
+                studyChannelId,selectMonthFirstDate, selectMonthLastDate)
+            .stream()
+            .map(SingleSchedule::toResponse)
+            .collect(Collectors.toList());
+
+        List<ScheduleResponse> repeatScheduleResponses = repeatScheduleRepository.findAllByStudyChannelIdAndDate(
+                studyChannelId, selectMonthFirstDate)
+            .stream()
+            .map(RepeatSchedule::toResponse)
+            .collect(Collectors.toList());
+
+        scheduleResponses.addAll(singleScheduleResponses);
+        scheduleResponses.addAll(repeatScheduleResponses);
+        return scheduleResponses;
     }
-  }
 
-  public void putScheduleRepeatToSingleAfterEventYes(RepeatSchedule repeatSchedule, SingleScheduleEditRequest singleScheduleEditRequest) {
+    public void putSchedule(Long studyChannelId, ScheduleEditRequest scheduleEditRequest) {
+        StudyChannel studyChannel = studyChannelRepository.findById(studyChannelId)
+            .orElseThrow(NotFoundStudyChannelException::new);
 
-    LocalDate selectedDate = singleScheduleEditRequest.getSelectedDate();
-    if (selectedDate.equals(repeatSchedule.getScheduleDate())) {
-      repeatScheduleRepository.deleteById(singleScheduleEditRequest.getScheduleId());
-    } else if (isNextRepeatStartDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule.getScheduleDate())) {
-        repeatScheduleRepository.deleteById(singleScheduleEditRequest.getScheduleId());
-        singleScheduleRepository.save(SingleSchedule.withoutIdBuilder()
-            .scheduleName(repeatSchedule.getScheduleName())
-            .scheduleContent(repeatSchedule.getScheduleContent())
-            .scheduleDate(repeatSchedule.getScheduleDate())
-            .scheduleStartTime(repeatSchedule.getScheduleStartTime())
-            .scheduleEndTime(repeatSchedule.getScheduleEndTime())
-            .studyChannel(repeatSchedule.getStudyChannel())
-            .placeId(repeatSchedule.getPlaceId())
-            .isRepeated(false)
+        if (scheduleEditRequest.getOriginType() == ScheduleOriginType.SINGLE) {
+            SingleSchedule singleSchedule = singleScheduleRepository.findById(
+                    scheduleEditRequest.getScheduleId())
+                .orElseThrow(NotFoundSingleScheduleException::new);
+
+            if (scheduleEditRequest instanceof SingleScheduleEditRequest) {
+                putScheduleSingleToSingle(
+                    singleSchedule, (SingleScheduleEditRequest) scheduleEditRequest);
+            } else if (scheduleEditRequest instanceof RepeatScheduleEditRequest) {
+                putScheduleSingleToRepeat(
+                    singleSchedule, (RepeatScheduleEditRequest) scheduleEditRequest);
+            }
+        } else if (scheduleEditRequest.getOriginType() == ScheduleOriginType.REPEAT) {
+            RepeatSchedule repeatSchedule = repeatScheduleRepository.findById(
+                    scheduleEditRequest.getScheduleId())
+                .orElseThrow(NotFoundRepeatScheduleException::new);
+
+            if (scheduleEditRequest instanceof RepeatScheduleEditRequest) {
+                putScheduleRepeatToRepeat(
+                    repeatSchedule, (RepeatScheduleEditRequest) scheduleEditRequest);
+            }
+        } else {
+            throw new IllegalArgumentForScheduleRequestException();
+        }
+    }
+
+    public void putScheduleSingleToSingle(SingleSchedule singleSchedule, SingleScheduleEditRequest singleScheduleEditRequest) {
+        singleSchedule.updateSingleSchedule(singleScheduleEditRequest);
+        singleScheduleRepository.save(singleSchedule);
+    }
+
+    public void putScheduleSingleToRepeat(SingleSchedule singleSchedule, RepeatScheduleEditRequest repeatScheduleEditRequest) {
+
+        repeatScheduleRepository.save(RepeatSchedule.withoutIdBuilder()
+            .scheduleName(repeatScheduleEditRequest.getScheduleName())
+            .scheduleContent(repeatScheduleEditRequest.getScheduleContent())
+            .scheduleContent(repeatScheduleEditRequest.getScheduleContent())
+            .scheduleDate(repeatScheduleEditRequest.getSelectedDate())
+            .scheduleStartTime(repeatScheduleEditRequest.getScheduleStartTime())
+            .scheduleEndTime(repeatScheduleEditRequest.getScheduleEndTime())
+            .isRepeated(true)
+            .repeatEndDate(repeatScheduleEditRequest.getRepeatEndDate())
+            .repeatCycle(repeatScheduleEditRequest.getRepeatCycle())
+            .repeatSituation(repeatScheduleEditRequest.getRepeatSituation())
+            .studyChannel(singleSchedule.getStudyChannel())
+            .placeId(repeatScheduleEditRequest.getPlaceId())
             .build());
-    } else {
-      changeRepeatEndDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule);
+        singleScheduleRepository.deleteById(repeatScheduleEditRequest.getScheduleId());
     }
 
-    // 만일 변경한 기존 반복 일정이 반복 시작 날짜와 끝나는 날짜가 같을 경우 단일 일정으로 변경한다.
-    if (repeatSchedule.getScheduleDate().equals(repeatSchedule.getRepeatEndDate())) {
-      SingleSchedule.withoutIdBuilder()
-          .scheduleName(repeatSchedule.getScheduleName())
-          .scheduleContent(repeatSchedule.getScheduleContent())
-          .scheduleDate(repeatSchedule.getScheduleDate())
-          .scheduleStartTime(repeatSchedule.getScheduleStartTime())
-          .scheduleEndTime(repeatSchedule.getScheduleEndTime())
-          .isRepeated(false)
-          .studyChannel(repeatSchedule.getStudyChannel())
-          .placeId(repeatSchedule.getPlaceId())
-          .build();
-      repeatScheduleRepository.deleteById(singleScheduleEditRequest.getScheduleId());
+    public void putScheduleRepeatToRepeat(RepeatSchedule repeatSchedule, RepeatScheduleEditRequest repeatScheduleEditRequest) {
+
+        if (repeatSchedule.getRepeatCycle() != repeatScheduleEditRequest.getRepeatCycle()) {
+            throw new IllegalArgumentForRepeatScheduleEditRequestException();
+        }
+
+        repeatSchedule.updateRepeatSchedule(repeatScheduleEditRequest);
+        repeatScheduleRepository.save(repeatSchedule);
     }
 
-    // 선택 날짜 single schedule
-    singleScheduleRepository.save(SingleSchedule.withoutIdBuilder()
-        .scheduleName(singleScheduleEditRequest.getScheduleName())
-        .scheduleContent(singleScheduleEditRequest.getScheduleContent())
-        .scheduleDate(selectedDate)
-        .scheduleStartTime(singleScheduleEditRequest.getScheduleStartTime())
-        .scheduleEndTime(singleScheduleEditRequest.getScheduleEndTime())
-        .isRepeated(false)
-        .studyChannel(repeatSchedule.getStudyChannel())
-        .placeId(singleScheduleEditRequest.getPlaceId())
-        .build());
-  }
+    public void putRepeatScheduleWithAfterEventSame(
+        Long studyChannelId, Boolean isAfterEventSame, ScheduleEditRequest scheduleEditRequest) {
 
-  public void putScheduleRepeatToSingleAfterEventNo(RepeatSchedule repeatSchedule, SingleScheduleEditRequest singleScheduleEditRequest) {
+        StudyChannel studyChannel = studyChannelRepository.findById(studyChannelId)
+            .orElseThrow(NotFoundStudyChannelException::new);
 
-    LocalDate selectedDate = singleScheduleEditRequest.getSelectedDate();
-    if (selectedDate.equals(repeatSchedule.getScheduleDate())) {
-      // 기존 반복 일정: scheduleDate = scheduleDate + (주기 1)으로 변경
-      changeRepeatStartDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule);
-    } else if (selectedDate.equals(repeatSchedule.getRepeatEndDate())) {
-      // 기존 반복 일정: endDate = endDate - (주기 1)으로 변경
-      changeRepeatEndDate(selectedDate,repeatSchedule.getRepeatCycle(), repeatSchedule);
-    } else if (isNextRepeatStartDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule.getScheduleDate())) {
-        singleScheduleRepository.save(
-            SingleSchedule.withoutIdBuilder()
+        RepeatSchedule repeatSchedule = repeatScheduleRepository.findById(
+                scheduleEditRequest.getScheduleId())
+            .orElseThrow(NotFoundRepeatScheduleException::new);
+
+        if (isNotIncluded(scheduleEditRequest.getSelectedDate(), repeatSchedule.getScheduleDate(), repeatSchedule.getRepeatEndDate())) {
+            throw new OutRangeScheduleException();
+        }
+
+        if (scheduleEditRequest.getOriginType() == ScheduleOriginType.REPEAT
+        && !isAfterEventSame) {
+            putScheduleRepeatToSingleAfterEventNo(repeatSchedule, (SingleScheduleEditRequest) scheduleEditRequest);
+
+        } else if (scheduleEditRequest.getOriginType() == ScheduleOriginType.REPEAT
+            && isAfterEventSame) {
+            putScheduleRepeatToSingleAfterEventYes(repeatSchedule, (SingleScheduleEditRequest) scheduleEditRequest);
+
+        } else {
+            throw new IllegalArgumentForScheduleRequestException();
+        }
+    }
+
+    public void putScheduleRepeatToSingleAfterEventYes(RepeatSchedule repeatSchedule, SingleScheduleEditRequest singleScheduleEditRequest) {
+
+        LocalDate selectedDate = singleScheduleEditRequest.getSelectedDate();
+        if (selectedDate.equals(repeatSchedule.getScheduleDate())) {
+            repeatScheduleRepository.deleteById(singleScheduleEditRequest.getScheduleId());
+        } else if (isNextRepeatStartDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule.getScheduleDate())) {
+            repeatScheduleRepository.deleteById(singleScheduleEditRequest.getScheduleId());
+            singleScheduleRepository.save(SingleSchedule.withoutIdBuilder()
+                .scheduleName(repeatSchedule.getScheduleName())
+                .scheduleContent(repeatSchedule.getScheduleContent())
+                .scheduleDate(repeatSchedule.getScheduleDate())
+                .scheduleStartTime(repeatSchedule.getScheduleStartTime())
+                .scheduleEndTime(repeatSchedule.getScheduleEndTime())
+                .studyChannel(repeatSchedule.getStudyChannel())
+                .placeId(repeatSchedule.getPlaceId())
+                .isRepeated(false)
+                .build());
+        } else {
+            changeRepeatEndDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule);
+        }
+
+        // 만일 변경한 기존 반복 일정이 반복 시작 날짜와 끝나는 날짜가 같을 경우 단일 일정으로 변경한다.
+        if (repeatSchedule.getScheduleDate().equals(repeatSchedule.getRepeatEndDate())) {
+            singleScheduleRepository.save(SingleSchedule.withoutIdBuilder()
                 .scheduleName(repeatSchedule.getScheduleName())
                 .scheduleContent(repeatSchedule.getScheduleContent())
                 .scheduleDate(repeatSchedule.getScheduleDate())
@@ -284,129 +247,171 @@ public class ScheduleService {
                 .isRepeated(false)
                 .studyChannel(repeatSchedule.getStudyChannel())
                 .placeId(repeatSchedule.getPlaceId())
-                .build()
-        );
-        changeRepeatStartDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule);
+                .build());
+            repeatScheduleRepository.deleteById(singleScheduleEditRequest.getScheduleId());
+        }
 
-    } else if (isFrontRepeatEndDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule.getRepeatEndDate())) {
-      singleScheduleRepository.save(
-          SingleSchedule.withoutIdBuilder()
-              .scheduleName(repeatSchedule.getScheduleName())
-              .scheduleContent(repeatSchedule.getScheduleContent())
-              .scheduleDate(repeatSchedule.getRepeatEndDate()) // 반복 마지막 날짜로 단일 일정이된다.
-              .scheduleStartTime(repeatSchedule.getScheduleStartTime())
-              .scheduleEndTime(repeatSchedule.getScheduleEndTime())
-              .isRepeated(false)
-              .studyChannel(repeatSchedule.getStudyChannel())
-              .placeId(repeatSchedule.getPlaceId())
-              .build()
-      );
-      changeRepeatEndDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule);
-
-    } else {
-      RepeatSchedule secondRepeatSchedule =  makeAfterCycleRepeatSchedule(selectedDate,  repeatSchedule);
-      changeRepeatEndDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule);
-
-      repeatScheduleRepository.save(secondRepeatSchedule);
+        // 선택 날짜 single schedule
+        singleScheduleRepository.save(SingleSchedule.withoutIdBuilder()
+            .scheduleName(singleScheduleEditRequest.getScheduleName())
+            .scheduleContent(singleScheduleEditRequest.getScheduleContent())
+            .scheduleDate(selectedDate)
+            .scheduleStartTime(singleScheduleEditRequest.getScheduleStartTime())
+            .scheduleEndTime(singleScheduleEditRequest.getScheduleEndTime())
+            .isRepeated(false)
+            .studyChannel(repeatSchedule.getStudyChannel())
+            .placeId(singleScheduleEditRequest.getPlaceId())
+            .build());
     }
 
-    // 선택 날짜 single schedule
-    singleScheduleRepository.save(SingleSchedule.withoutIdBuilder()
-        .scheduleName(singleScheduleEditRequest.getScheduleName())
-        .scheduleContent(singleScheduleEditRequest.getScheduleContent())
-        .scheduleDate(selectedDate)
-        .scheduleStartTime(singleScheduleEditRequest.getScheduleStartTime())
-        .scheduleEndTime(singleScheduleEditRequest.getScheduleEndTime())
-        .isRepeated(false)
-        .studyChannel(repeatSchedule.getStudyChannel())
-        .placeId(singleScheduleEditRequest.getPlaceId())
-        .build());
-  }
+    public void putScheduleRepeatToSingleAfterEventNo(RepeatSchedule repeatSchedule, SingleScheduleEditRequest singleScheduleEditRequest) {
 
-  private boolean isNotIncluded(LocalDate selectedDate, LocalDate repeatStartDate, LocalDate repeatEndDate) {
-    return (selectedDate.isAfter(repeatEndDate) || selectedDate.isBefore(repeatStartDate));
-  }
+        LocalDate selectedDate = singleScheduleEditRequest.getSelectedDate();
+        if (selectedDate.equals(repeatSchedule.getScheduleDate())) {
+            // 기존 반복 일정: scheduleDate = scheduleDate + (주기 1)으로 변경
+            changeRepeatStartDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule);
+        } else if (selectedDate.equals(repeatSchedule.getRepeatEndDate())) {
+            // 기존 반복 일정: endDate = endDate - (주기 1)으로 변경
+            changeRepeatEndDate(selectedDate,repeatSchedule.getRepeatCycle(), repeatSchedule);
+        } else if (isNextRepeatStartDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule.getScheduleDate())) {
+            singleScheduleRepository.save(
+                SingleSchedule.withoutIdBuilder()
+                    .scheduleName(repeatSchedule.getScheduleName())
+                    .scheduleContent(repeatSchedule.getScheduleContent())
+                    .scheduleDate(repeatSchedule.getScheduleDate())
+                    .scheduleStartTime(repeatSchedule.getScheduleStartTime())
+                    .scheduleEndTime(repeatSchedule.getScheduleEndTime())
+                    .isRepeated(false)
+                    .studyChannel(repeatSchedule.getStudyChannel())
+                    .placeId(repeatSchedule.getPlaceId())
+                    .build()
+            );
+            changeRepeatStartDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule);
 
-  private boolean isNextRepeatStartDate(LocalDate selectedDate, RepeatCycle repeatCycle, LocalDate repeatStartDate) {
-    switch (repeatCycle) {
-      case DAILY:
-        return selectedDate.minusDays(1).isEqual(repeatStartDate);
-      case WEEKLY:
-        return selectedDate.minusWeeks(1).isEqual(repeatStartDate);
-      case MONTHLY:
-        return selectedDate.minusMonths(1).isEqual(repeatStartDate);
-    }
-    return false;
-  }
+        } else if (isFrontRepeatEndDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule.getRepeatEndDate())) {
+            singleScheduleRepository.save(
+                SingleSchedule.withoutIdBuilder()
+                    .scheduleName(repeatSchedule.getScheduleName())
+                    .scheduleContent(repeatSchedule.getScheduleContent())
+                    .scheduleDate(repeatSchedule.getRepeatEndDate()) // 반복 마지막 날짜로 단일 일정이된다.
+                    .scheduleStartTime(repeatSchedule.getScheduleStartTime())
+                    .scheduleEndTime(repeatSchedule.getScheduleEndTime())
+                    .isRepeated(false)
+                    .studyChannel(repeatSchedule.getStudyChannel())
+                    .placeId(repeatSchedule.getPlaceId())
+                    .build()
+            );
+            changeRepeatEndDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule);
 
-  private boolean isFrontRepeatEndDate(LocalDate selectedDate, RepeatCycle repeatCycle, LocalDate repeatEndDate) {
-    switch (repeatCycle) {
-      case DAILY:
-        return selectedDate.plusDays(1).isEqual(repeatEndDate);
-      case WEEKLY:
-        return selectedDate.plusWeeks(1).isEqual(repeatEndDate);
-      case MONTHLY:
-        return selectedDate.plusMonths(1).isEqual(repeatEndDate);
-    }
-    return false;
-  }
+        } else {
+            RepeatSchedule secondRepeatSchedule =  makeAfterCycleRepeatSchedule(selectedDate,  repeatSchedule);
+            changeRepeatEndDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule);
 
-  private void changeRepeatStartDate(LocalDate selectedDate, RepeatCycle repeatCycle
-      , RepeatSchedule repeatSchedule) {
-    switch (repeatCycle) {
-      case DAILY:
-        repeatSchedule.setRepeatStartDate(selectedDate.plusDays(1));
-        break;
-      case WEEKLY:
-        repeatSchedule.setRepeatStartDate(selectedDate.plusWeeks(1));
-        break;
-      case MONTHLY:
-        repeatSchedule.setRepeatStartDate(selectedDate.plusMonths(1));
-        break;
-    }
-  }
+            repeatScheduleRepository.save(secondRepeatSchedule);
+        }
 
-  private void changeRepeatEndDate(LocalDate selectedDate, RepeatCycle repeatCycle
-      , RepeatSchedule repeatSchedule) {
-    switch (repeatCycle) {
-      case DAILY:
-        repeatSchedule.setRepeatEndDate(selectedDate.minusDays(1));
-        break;
-      case WEEKLY:
-        repeatSchedule.setRepeatEndDate(selectedDate.minusWeeks(1));
-        break;
-      case MONTHLY:
-        repeatSchedule.setRepeatEndDate(selectedDate.minusMonths(1));
-        break;
-    }
-  }
-
-  private RepeatSchedule makeAfterCycleRepeatSchedule(LocalDate selectedDate, RepeatSchedule existRepeatSchedule) {
-    LocalDate afterStartDate = null;
-
-    switch (existRepeatSchedule.getRepeatCycle()) {
-      case DAILY:
-        afterStartDate = selectedDate.plusDays(1);
-        break;
-      case WEEKLY:
-        afterStartDate = selectedDate.plusWeeks(1);
-        break;
-      case MONTHLY:
-        afterStartDate = selectedDate.plusMonths(1);
-        break;
+        // 선택 날짜 single schedule
+        singleScheduleRepository.save(SingleSchedule.withoutIdBuilder()
+            .scheduleName(singleScheduleEditRequest.getScheduleName())
+            .scheduleContent(singleScheduleEditRequest.getScheduleContent())
+            .scheduleDate(selectedDate)
+            .scheduleStartTime(singleScheduleEditRequest.getScheduleStartTime())
+            .scheduleEndTime(singleScheduleEditRequest.getScheduleEndTime())
+            .isRepeated(false)
+            .studyChannel(repeatSchedule.getStudyChannel())
+            .placeId(singleScheduleEditRequest.getPlaceId())
+            .build());
     }
 
-    return  RepeatSchedule.withoutIdBuilder()
-        .scheduleName(existRepeatSchedule.getScheduleName())
-        .scheduleContent(existRepeatSchedule.getScheduleContent())
-        .scheduleDate(afterStartDate)
-        .scheduleStartTime(existRepeatSchedule.getScheduleStartTime())
-        .scheduleEndTime(existRepeatSchedule.getScheduleEndTime())
-        .isRepeated(true)
-        .studyChannel(existRepeatSchedule.getStudyChannel())
-        .repeatSituation(existRepeatSchedule.getRepeatSituation())
-        .repeatCycle(existRepeatSchedule.getRepeatCycle())
-        .repeatEndDate(existRepeatSchedule.getRepeatEndDate())
-        .build();
-  }
+    private boolean isNotIncluded(LocalDate selectedDate, LocalDate repeatStartDate
+        , LocalDate repeatEndDate) {
+        return (selectedDate.isAfter(repeatEndDate) || selectedDate.isBefore(repeatStartDate));
+    }
+
+    private boolean isNextRepeatStartDate(LocalDate selectedDate, RepeatCycle repeatCycle
+        , LocalDate repeatStartDate) {
+        switch (repeatCycle) {
+            case DAILY:
+                return selectedDate.minusDays(1).isEqual(repeatStartDate);
+            case WEEKLY:
+                return selectedDate.minusWeeks(1).isEqual(repeatStartDate);
+            case MONTHLY:
+                return selectedDate.minusMonths(1).isEqual(repeatStartDate);
+        }
+        return false;
+    }
+
+    private boolean isFrontRepeatEndDate(LocalDate selectedDate, RepeatCycle repeatCycle
+        , LocalDate repeatEndDate) {
+        switch (repeatCycle) {
+            case DAILY:
+                return selectedDate.plusDays(1).isEqual(repeatEndDate);
+            case WEEKLY:
+                return selectedDate.plusWeeks(1).isEqual(repeatEndDate);
+            case MONTHLY:
+                return selectedDate.plusMonths(1).isEqual(repeatEndDate);
+        }
+        return false;
+    }
+
+    private void changeRepeatStartDate(LocalDate selectedDate, RepeatCycle repeatCycle
+        , RepeatSchedule repeatSchedule) {
+        switch (repeatCycle) {
+            case DAILY:
+                repeatSchedule.setRepeatStartDate(selectedDate.plusDays(1));
+                break;
+            case WEEKLY:
+                repeatSchedule.setRepeatStartDate(selectedDate.plusWeeks(1));
+                break;
+            case MONTHLY:
+                repeatSchedule.setRepeatStartDate(selectedDate.plusMonths(1));
+                break;
+        }
+        repeatScheduleRepository.save(repeatSchedule);
+    }
+
+    private void changeRepeatEndDate(LocalDate selectedDate, RepeatCycle repeatCycle
+        , RepeatSchedule repeatSchedule) {
+        switch (repeatCycle) {
+            case DAILY:
+                repeatSchedule.setRepeatEndDate(selectedDate.minusDays(1));
+                break;
+            case WEEKLY:
+                repeatSchedule.setRepeatEndDate(selectedDate.minusWeeks(1));
+                break;
+            case MONTHLY:
+                repeatSchedule.setRepeatEndDate(selectedDate.minusMonths(1));
+                break;
+        }
+        repeatScheduleRepository.save(repeatSchedule);
+    }
+
+    private RepeatSchedule makeAfterCycleRepeatSchedule(LocalDate selectedDate, RepeatSchedule existRepeatSchedule) {
+        LocalDate afterStartDate = null;
+
+        switch (existRepeatSchedule.getRepeatCycle()) {
+            case DAILY:
+                afterStartDate = selectedDate.plusDays(1);
+                break;
+            case WEEKLY:
+                afterStartDate = selectedDate.plusWeeks(1);
+                break;
+            case MONTHLY:
+                afterStartDate = selectedDate.plusMonths(1);
+                break;
+        }
+
+        return  RepeatSchedule.withoutIdBuilder()
+            .scheduleName(existRepeatSchedule.getScheduleName())
+            .scheduleContent(existRepeatSchedule.getScheduleContent())
+            .scheduleDate(afterStartDate)
+            .scheduleStartTime(existRepeatSchedule.getScheduleStartTime())
+            .scheduleEndTime(existRepeatSchedule.getScheduleEndTime())
+            .isRepeated(true)
+            .studyChannel(existRepeatSchedule.getStudyChannel())
+            .repeatSituation(existRepeatSchedule.getRepeatSituation())
+            .repeatCycle(existRepeatSchedule.getRepeatCycle())
+            .repeatEndDate(existRepeatSchedule.getRepeatEndDate())
+            .build();
+    }
 }

--- a/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
+++ b/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
@@ -232,9 +232,9 @@ public class ScheduleService {
             .placeId(repeatSchedule.getPlaceId())
             .isRepeated(false)
             .build());
+    } else {
+      changeRepeatEndDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule);
     }
-
-    changeRepeatEndDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule);
 
     // 만일 변경한 기존 반복 일정이 반복 시작 날짜와 끝나는 날짜가 같을 경우 단일 일정으로 변경한다.
     if (repeatSchedule.getScheduleDate().equals(repeatSchedule.getRepeatEndDate())) {

--- a/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
@@ -5,9 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.tenten.studybadge.common.exception.schedule.OutRangeScheduleException;
 import com.tenten.studybadge.common.exception.studychannel.InvalidStudyDurationException;
 import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelException;
 import com.tenten.studybadge.schedule.domain.entity.RepeatSchedule;
@@ -294,9 +296,9 @@ class ScheduleServiceTest {
     verify(repeatScheduleRepository, times(0)).findAllByStudyChannelId(1L);
   }
 
-  @DisplayName("일정 수정")
+  @DisplayName("일정 수정: 단일 -> any | 반복 -> 반복")
   @Nested
-  class ScheduleEditTest {
+  class ScheduleEditTest1 {
     @Test
     @DisplayName("단일 일정 -> 단일 일정 수정 성공")
     public void testPutSchedulesSingleToSingle() {
@@ -391,6 +393,214 @@ class ScheduleServiceTest {
       assertEquals(RepeatSituation.TUESDAY, savedSchedule.getRepeatSituation());
       assertEquals(LocalDate.of(2024, 12, 31), savedSchedule.getRepeatEndDate());
       assertNull( savedSchedule.getPlaceId());
+    }
+  }
+
+  @DisplayName("일정 수정: 반복 -> 단일")
+  @Nested
+  class ScheduleEditTest2 {
+
+    private RepeatSchedule repeatDailySchedule = RepeatSchedule.withoutIdBuilder()
+        .scheduleName("7월 1일 부터 15일까지 매일 반복 일정")
+          .scheduleContent("Content for repeat meeting")
+          .scheduleDate(LocalDate.of(2024, 7, 1))
+          .scheduleStartTime(LocalTime.of(10, 0))
+          .scheduleEndTime(LocalTime.of(11, 0))
+          .repeatCycle(RepeatCycle.DAILY)
+          .repeatSituation(RepeatSituation.EVERYDAY)
+          .repeatEndDate(LocalDate.of(2024, 7, 15))
+          .isRepeated(true)
+          .studyChannel(studyChannel)
+          .placeId(null)
+          .build();
+
+    @Test
+    @DisplayName("반복 일정 -> 단일 일정 변경 | 이후 이벤트 동일 O - 반복 일정 중간 날짜")
+    public void testPutRepeatScheduleWithAfterEventSameYes_MiddleDate() {
+      // given
+      SingleScheduleEditRequest singleScheduleEditRequest = new SingleScheduleEditRequest(
+          2L, ScheduleOriginType.REPEAT,
+          "반복 일정 중간에 단일 일정으로 수정", "반복 일정 중간에 단일 일정으로 수정 내용",
+          LocalDate.of(2024, 7, 6), LocalTime.of(12, 0), LocalTime.of(13, 0), null
+      );
+
+      given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
+      given(repeatScheduleRepository.findById(2L)).willReturn(Optional.of(repeatDailySchedule));
+
+      // when
+      scheduleService.putRepeatScheduleWithAfterEventSame(1L, true, singleScheduleEditRequest);
+
+      // then
+      ArgumentCaptor<SingleSchedule> singleCaptor = ArgumentCaptor.forClass(SingleSchedule.class);
+      verify(singleScheduleRepository, times(1)).save(singleCaptor.capture());
+      SingleSchedule savedSingleSchedule = singleCaptor.getValue();
+
+
+      assertEquals("반복 일정 중간에 단일 일정으로 수정", savedSingleSchedule.getScheduleName());
+      assertEquals("반복 일정 중간에 단일 일정으로 수정 내용", savedSingleSchedule.getScheduleContent());
+      assertEquals(LocalDate.of(2024, 7, 6), savedSingleSchedule.getScheduleDate());
+      assertEquals(LocalDate.of(2024, 7, 5), repeatDailySchedule.getRepeatEndDate());
+    }
+
+    @Test
+    @DisplayName("반복 일정 -> 단일 일정 변경 | 이후 이벤트 동일 O - 반복 일정 처음 날짜")
+    public void testPutRepeatScheduleWithAfterEventSameYes_FirstDate() {
+      // given
+      SingleScheduleEditRequest singleScheduleEditRequest = new SingleScheduleEditRequest(
+          2L, ScheduleOriginType.REPEAT,
+          "반복 일정 처음에 단일 일정으로 수정", "반복 일정 처음에 단일 일정으로 수정 내용",
+          LocalDate.of(2024, 7, 1), LocalTime.of(12, 0), LocalTime.of(13, 0), null
+      );
+
+      given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
+      given(repeatScheduleRepository.findById(2L)).willReturn(Optional.of(repeatDailySchedule));
+
+      // when
+      scheduleService.putRepeatScheduleWithAfterEventSame(1L, true, singleScheduleEditRequest);
+
+      // then
+      ArgumentCaptor<SingleSchedule> singleCaptor = ArgumentCaptor.forClass(SingleSchedule.class);
+      verify(singleScheduleRepository, times(1)).save(singleCaptor.capture());
+      SingleSchedule savedSingleSchedule = singleCaptor.getValue();
+
+
+      assertEquals("반복 일정 처음에 단일 일정으로 수정", savedSingleSchedule.getScheduleName());
+      assertEquals("반복 일정 처음에 단일 일정으로 수정 내용", savedSingleSchedule.getScheduleContent());
+      assertEquals(LocalDate.of(2024, 7, 1), savedSingleSchedule.getScheduleDate());
+
+      verify(repeatScheduleRepository, times(1)).deleteById(2L);
+    }
+
+    @Test
+    @DisplayName("반복 일정 -> 단일 일정 변경 | 이후 이벤트 동일 O - 반복 일정 마지막 날짜")
+    public void testPutRepeatScheduleWithAfterEventSameYes_LastDate() {
+      // given
+      SingleScheduleEditRequest singleScheduleEditRequest = new SingleScheduleEditRequest(
+          2L, ScheduleOriginType.REPEAT,
+          "반복 일정 마지막에 단일 일정으로 수정", "반복 일정 마지막에 단일 일정으로 수정 내용",
+          LocalDate.of(2024, 7, 15), LocalTime.of(12, 0), LocalTime.of(13, 0), null
+      );
+
+      given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
+      given(repeatScheduleRepository.findById(2L)).willReturn(Optional.of(repeatDailySchedule));
+
+      // when
+      scheduleService.putRepeatScheduleWithAfterEventSame(1L, true, singleScheduleEditRequest);
+
+      // then
+      ArgumentCaptor<SingleSchedule> singleCaptor = ArgumentCaptor.forClass(SingleSchedule.class);
+      verify(singleScheduleRepository, times(1)).save(singleCaptor.capture());
+      SingleSchedule savedSingleSchedule = singleCaptor.getValue();
+
+      assertEquals("반복 일정 마지막에 단일 일정으로 수정", savedSingleSchedule.getScheduleName());
+      assertEquals("반복 일정 마지막에 단일 일정으로 수정 내용", savedSingleSchedule.getScheduleContent());
+      assertEquals(LocalDate.of(2024, 7, 15), savedSingleSchedule.getScheduleDate());
+      assertEquals(LocalDate.of(2024, 7, 14), repeatDailySchedule.getRepeatEndDate());
+    }
+
+    @Test
+    @DisplayName("반복 일정 -> 단일 일정 변경 | 이후 이벤트 동일 X - 반복 일정 중간 날짜")
+    public void testPutRepeatScheduleWithAfterEventSameNo_MiddleDate() {
+      // given
+      SingleScheduleEditRequest singleScheduleEditRequest = new SingleScheduleEditRequest(
+          2L, ScheduleOriginType.REPEAT,
+          "반복 일정 중간에 단일 일정으로 수정", "반복 일정 중간에 단일 일정으로 수정 내용",
+          LocalDate.of(2024, 7, 6), LocalTime.of(12, 0), LocalTime.of(13, 0), null
+      );
+
+      given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
+      given(repeatScheduleRepository.findById(2L)).willReturn(Optional.of(repeatDailySchedule));
+
+      // when
+      scheduleService.putRepeatScheduleWithAfterEventSame(1L, false, singleScheduleEditRequest);
+
+      // then
+      ArgumentCaptor<SingleSchedule> singleCaptor = ArgumentCaptor.forClass(SingleSchedule.class);
+      verify(singleScheduleRepository, times(1)).save(singleCaptor.capture());
+      SingleSchedule savedSingleSchedule = singleCaptor.getValue();
+
+      ArgumentCaptor<RepeatSchedule> repeatCaptor = ArgumentCaptor.forClass(RepeatSchedule.class);
+      verify(repeatScheduleRepository, times(1)).save(repeatCaptor.capture());
+      RepeatSchedule savedRepeatSchedule = repeatCaptor.getValue();
+
+      assertEquals("반복 일정 중간에 단일 일정으로 수정", savedSingleSchedule.getScheduleName());
+      assertEquals("반복 일정 중간에 단일 일정으로 수정 내용", savedSingleSchedule.getScheduleContent());
+      assertEquals(LocalDate.of(2024, 7, 6), savedSingleSchedule.getScheduleDate());
+      assertEquals(LocalDate.of(2024, 7, 5), repeatDailySchedule.getRepeatEndDate());
+      assertEquals(LocalDate.of(2024, 7, 7), savedRepeatSchedule.getScheduleDate());
+    }
+
+    @Test
+    @DisplayName("반복 일정 -> 단일 일정 변경 | 이후 이벤트 동일 X - 반복 일정 처음 날짜")
+    public void testPutRepeatScheduleWithAfterEventSameNo_FirstDate() {
+      // given
+      SingleScheduleEditRequest singleScheduleEditRequest = new SingleScheduleEditRequest(
+          2L, ScheduleOriginType.REPEAT,
+          "반복 일정 처음에 단일 일정으로 수정", "반복 일정 처음에 단일 일정으로 수정 내용",
+          LocalDate.of(2024, 7, 1), LocalTime.of(12, 0), LocalTime.of(13, 0), null
+      );
+
+      given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
+      given(repeatScheduleRepository.findById(2L)).willReturn(Optional.of(repeatDailySchedule));
+
+      // when
+      scheduleService.putRepeatScheduleWithAfterEventSame(1L, false, singleScheduleEditRequest);
+
+      // then
+      ArgumentCaptor<SingleSchedule> singleCaptor = ArgumentCaptor.forClass(SingleSchedule.class);
+      verify(singleScheduleRepository, times(1)).save(singleCaptor.capture());
+      SingleSchedule savedSingleSchedule = singleCaptor.getValue();
+
+      assertEquals("반복 일정 처음에 단일 일정으로 수정", savedSingleSchedule.getScheduleName());
+      assertEquals("반복 일정 처음에 단일 일정으로 수정 내용", savedSingleSchedule.getScheduleContent());
+      assertEquals(LocalDate.of(2024, 7, 1), savedSingleSchedule.getScheduleDate());
+      assertEquals(LocalDate.of(2024, 7, 2), repeatDailySchedule.getScheduleDate());
+      assertEquals(LocalDate.of(2024, 7, 15), repeatDailySchedule.getRepeatEndDate());
+    }
+
+    @Test
+    @DisplayName("반복 일정 -> 단일 일정 변경 | 이후 이벤트 동일 X - 반복 일정 마지막 날짜")
+    public void testPutRepeatScheduleWithAfterEventSameNo_LastDate() {
+      // given
+      SingleScheduleEditRequest singleScheduleEditRequest = new SingleScheduleEditRequest(
+          2L, ScheduleOriginType.REPEAT,
+          "반복 일정 처음에 단일 일정으로 수정", "반복 일정 처음에 단일 일정으로 수정 내용",
+          LocalDate.of(2024, 7, 15), LocalTime.of(12, 0), LocalTime.of(13, 0), null
+      );
+
+      given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
+      given(repeatScheduleRepository.findById(2L)).willReturn(Optional.of(repeatDailySchedule));
+
+      // when
+      scheduleService.putRepeatScheduleWithAfterEventSame(1L, false, singleScheduleEditRequest);
+
+      // then
+      ArgumentCaptor<SingleSchedule> singleCaptor = ArgumentCaptor.forClass(SingleSchedule.class);
+      verify(singleScheduleRepository, times(1)).save(singleCaptor.capture());
+      SingleSchedule savedSingleSchedule = singleCaptor.getValue();
+
+      assertEquals("반복 일정 처음에 단일 일정으로 수정", savedSingleSchedule.getScheduleName());
+      assertEquals("반복 일정 처음에 단일 일정으로 수정 내용", savedSingleSchedule.getScheduleContent());
+      assertEquals(LocalDate.of(2024, 7, 15), savedSingleSchedule.getScheduleDate());
+      assertEquals(LocalDate.of(2024, 7, 14), repeatDailySchedule.getRepeatEndDate());
+    }
+
+    @Test
+    @DisplayName("반복 일정 -> 단일 일정 변경 후 이벤트 동일 여부 확인 - 범위 초과")
+    public void testPutRepeatScheduleWithAfterEventSameOutOfRange() {
+      // given
+      SingleScheduleEditRequest singleScheduleEditRequest = new SingleScheduleEditRequest(
+          2L, ScheduleOriginType.REPEAT, "Single Meeting Edit", "Content for single meeting Edit",
+          LocalDate.of(2025, 1, 1), LocalTime.of(12, 0), LocalTime.of(13, 0), null
+      );
+
+      given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
+      given(repeatScheduleRepository.findById(2L)).willReturn(Optional.of(repeatDailySchedule));
+
+      // when & then
+      assertThrows(OutRangeScheduleException.class, () -> {
+        scheduleService.putRepeatScheduleWithAfterEventSame(1L, true, singleScheduleEditRequest);
+      });
     }
 
   }

--- a/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
@@ -333,7 +333,7 @@ class ScheduleServiceTest {
       RepeatScheduleEditRequest repeatScheduleEditRequest = new RepeatScheduleEditRequest(
           1L, ScheduleOriginType.SINGLE, "Repeat Meeting", "Content for repeat meeting",
           LocalDate.of(2024, 7, 5), LocalTime.of(12, 0), LocalTime.of(13, 0),
-          false, RepeatCycle.WEEKLY, RepeatSituation.MONDAY, LocalDate.of(2024, 12, 31),
+          RepeatCycle.WEEKLY, RepeatSituation.MONDAY, LocalDate.of(2024, 12, 31),
           null
       );
 
@@ -368,7 +368,7 @@ class ScheduleServiceTest {
           2L, ScheduleOriginType.REPEAT,
           "Repeat Meeting Edit", "Content for repeat meeting Edit",
           LocalDate.of(2024,  8, 5), LocalTime.of(12, 0), LocalTime.of(13, 0),
-          false, RepeatCycle.WEEKLY, RepeatSituation.TUESDAY, LocalDate.of(2024, 12, 31),
+          RepeatCycle.WEEKLY, RepeatSituation.TUESDAY, LocalDate.of(2024, 12, 31),
           null
       );
       given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 단일 일정, 반복 일정 테이블에 같은 인덱스명을 부과하였었습니다.
- 기존에는 아래와 같은 수정만 존재했었습니다. 
    - 반복 일정 -> 반복 일정
    - 단일 일정 -> 단일 일정
    - 단일 일정 -> 반복 일정

**TO-BE**
- 단일 일정, 반복 일정 테이블에 다른 인덱스명으로 수정하였습니다.
- 반복 일정 -> 단일 일정 수정이 가능하도록 추가하였습니다.
    - 반복 일정에서 단일 일정으로 수정할 경우 수정을 위해 날짜 선택하면(selectedDate) '이후 일정들도 동일하게 적용하겠습니까?'  라는 것에 O, X에 따라 수정하는 루트가 달라집니다.

- 기존 일정: 반복 일정 → 수정 요청: 단일 일정
    - isAfterEventSame  = true : 이후 이벤트도 동일하게 수정 O
    - isAfterEventSame  = false : 이후 이벤트도 동일하게 수정 X
    

## isAfterEventSame  = false : 이후 이벤트도 동일하게 수정 X

ex > 2024.07.01(월) ~ 2024.07.15(월) 약 2주간 일정이 일간 매일 반복 일정일 때

- 선택한 수정 일정이 처음 날짜일 때 > selectedDate == scheduleDate
    - [기존 반복 일정.scheduleDate += repeatCycle],  새로운 단일 일정 저장
        - newSingleSchedule.scheduleDate == originRepeatSchedule.scheduleDate
        - originRepeatSchedule.scheduleData += repeayCycle에 따른 plusMonth/Weeks/Day
- 선택한 수정 일정이 마지막 날짜일 때 > selectedDate == scheduleRepeatEndDate
    - [기존 반복 일정.repeatEndDate -= repeatCycle], 새로운 단일 일정 저장
        - newSingleSchedule.scheduleDate == originRepeatSchedule.repeatEndDate
        - originRepeatSchedule.repeatEndDate -= repeayCycle에 따른 minusMonth/Weeks/Day
    
    선택한 수정 일정이 시작 날짜 or 마지막 날짜가 아닐 때
    
- 시작 날짜 바로 nextCycle일 때
    - 시작 날짜도 단일 일정
    - selectedDate도 단일 일정
    - originRepeatSchedule.repeatEndDate -= repeayCycle에 따른 minusMonth/Weeks/Day
- 끝나는 날짜 바로 전 frontCycle일 때
    - 끝나는 날짜도 단일 일정
    - selectedDate도 단일 일정
    - originRepeatSchedule.repeatEndDate -= repeayCycle에 따른 minusMonth/Weeks/Day
- 중간 일 때
    - 기존 반복 일정.repeatEndDate수정, selectedDate은 단일 일정, 새로운 반복 일정 저장
        - 반복 일정1 > 07.01 ~ 07.07
        - 단일 일정 > 07.08
        - 반복 일정2 > 07.09 ~ 07.15



## isAfterEventSame  = true : 이후 이벤트도 동일하게 수정 O

ex > 2024.07.01(월) ~ 2024.07.15(월) 약 2주간 일정이 일간 매일 반복 일정일 때

- 선택한 수정 일정이 처음 날짜일 때 > selectedDate == scheduleDate
    - 기존 반복 일정 삭제, 새로운 단일 일정 저장
        - newSingleSchedule.scheduleDate == originRepeatSchedule.scheduleDate
        - repeatRepository.deleteById([originRepeatSchedule.id](http://originrepeatschedule.id/));
- 선택한 수정 일정이 마지막 날짜일 때 > selectedDate == scheduleRepeatEndDate
    - [기존 반복 일정.repeatEndDate -= repeatCycle], 새로운 단일 일정 저장
        - newSingleSchedule.scheduleDate == originRepeatSchedule.repeatEndDate
        - originRepeatSchedule.repeatEndDate -= repeayCycle에 따른 minusMonth/Weeks/Day
    

선택한 수정 일정이 시작 날짜 or 마지막 날짜가 아닐때

- 시작 날짜 바로 nextCycle일 때
    - 시작 날짜도 단일 일정으로 새로 저장(기존 repeatSchedule의 name, content 그대로.. )
    - selectedDate도 단일 일정으로 새로 저장
    - repeatRepository.deleteById([originRepeatSchedule.id](http://originrepeatschedule.id/));
- 끝나는 날짜 바로 전 frontCycle일 때, 중간 일 때
    - selectedDate 단일 일정
    - originRepeatSchedule.repeatEndDate -= repeayCycle에 따른 minusMonth/Weeks/Day
        - 반복 일정1 > 07.01 ~ 07.07
        - 단일 일정 > 07.08 


### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
- [X] API 테스트 