### PR TITLE
feat: STD-19 일정 삭제

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/exception/schedule/NotEqualSingleScheduleDate.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/schedule/NotEqualSingleScheduleDate.java
@@ -1,0 +1,23 @@
+package com.tenten.studybadge.common.exception.schedule;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class NotEqualSingleScheduleDate extends AbstractException {
+
+  private static final String ERROR_CODE = "NOT_EQUAL_SINGLE_SCHEDULE_DATE";
+  private static final String ERROR_MESSAGE = "단일 일정의 일정 날짜와 같지 않습니다.";
+
+  @Override
+  public HttpStatus getHttpStatus() {
+    return HttpStatus.BAD_REQUEST;
+  }
+  @Override
+  public String getErrorCode() {
+    return ERROR_CODE;
+  }
+  @Override
+  public String getMessage() {
+    return ERROR_MESSAGE ;
+  }
+}

--- a/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
@@ -74,6 +74,7 @@ public class ScheduleController {
     @PutMapping("/study-channels/{studyChannelId}/schedules/isAfterEvent")
     @Operation(summary = "반복 일정 -> 단일 일정으로 수정", description = "특정 스터디 채널의 일정을 수정할 때 반복 일정에서 단일 일정으로 수정할 경우 수정하는 api" ,security = @SecurityRequirement(name = "bearerToken"))
     @Parameter(name = "studyChannelId", description = "일정이 존재하는 study channel의 id 값", required = true)
+    @Parameter(name = "Same", description = "이후 반복 일정도 동일하게 수정할 건지 Boolean 값", required = true)
     @Parameter(name = "ScheduleEditRequest", description = "일정 등록 request, type의 값이 single, repeat에 따라 단일 일정 / 반복 일정 등록으로 나뉜다.", required = true )
     public ResponseEntity<Void> putRepeatScheduleWithAfterEventSame(
         @PathVariable Long studyChannelId,
@@ -91,6 +92,19 @@ public class ScheduleController {
         @PathVariable Long studyChannelId,
         @Valid @RequestBody ScheduleDeleteRequest scheduleDeleteRequest) {
         scheduleService.deleteSingleSchedule(studyChannelId, scheduleDeleteRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/study-channels/{studyChannelId}/schedules/isAfterEvent")
+    @Operation(summary = "반복 일정 삭제", description = "단일 일정 삭제 api" ,security = @SecurityRequirement(name = "bearerToken"))
+    @Parameter(name = "studyChannelId", description = "일정이 존재하는 study channel의 id 값", required = true)
+    @Parameter(name = "Same", description = "이후 반복 일정도 동일하게 수정할 건지 Boolean 값", required = true)
+    @Parameter(name = "ScheduleDeleteRequest", description = "일정 삭제 request. 단일/반복 일정에 따라 api경로 자체를 변경했기 때문에 type필드는 없다", required = true )
+    public ResponseEntity<Void> deleteSingleSchedule(
+        @PathVariable Long studyChannelId,
+        @RequestParam("Same") Boolean isAfterEventSame,
+        @Valid @RequestBody ScheduleDeleteRequest scheduleDeleteRequest) {
+        scheduleService.deleteRepeatSchedule(studyChannelId, isAfterEventSame, scheduleDeleteRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
@@ -1,6 +1,7 @@
 package com.tenten.studybadge.schedule.controller;
 
 import com.tenten.studybadge.schedule.dto.ScheduleCreateRequest;
+import com.tenten.studybadge.schedule.dto.ScheduleDeleteRequest;
 import com.tenten.studybadge.schedule.dto.ScheduleEditRequest;
 import com.tenten.studybadge.schedule.dto.ScheduleResponse;
 import com.tenten.studybadge.schedule.service.ScheduleService;
@@ -13,6 +14,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -65,7 +67,7 @@ public class ScheduleController {
     public ResponseEntity<Void> putSchedule(
         @PathVariable Long studyChannelId,
         @Valid @RequestBody ScheduleEditRequest scheduleEditRequest)  {
-      scheduleService.putSchedule(studyChannelId, scheduleEditRequest);
+        scheduleService.putSchedule(studyChannelId, scheduleEditRequest);
         return ResponseEntity.ok().build();
     }
 
@@ -78,6 +80,17 @@ public class ScheduleController {
         @RequestParam("Same") Boolean isAfterEventSame,
         @Valid @RequestBody ScheduleEditRequest scheduleEditRequest)  {
         scheduleService.putRepeatScheduleWithAfterEventSame(studyChannelId, isAfterEventSame, scheduleEditRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/study-channels/{studyChannelId}/schedules")
+    @Operation(summary = "단일 일정 삭제", description = "단일 일정 삭제 api" ,security = @SecurityRequirement(name = "bearerToken"))
+    @Parameter(name = "studyChannelId", description = "일정이 존재하는 study channel의 id 값", required = true)
+    @Parameter(name = "ScheduleDeleteRequest", description = "일정 삭제 request. 단일/반복 일정에 따라 api경로 자체를 변경했기 때문에 type필드는 없다", required = true )
+    public ResponseEntity<Void> deleteSingleSchedule(
+        @PathVariable Long studyChannelId,
+        @Valid @RequestBody ScheduleDeleteRequest scheduleDeleteRequest) {
+        scheduleService.deleteSingleSchedule(studyChannelId, scheduleDeleteRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/tenten/studybadge/schedule/dto/ScheduleDeleteRequest.java
+++ b/src/main/java/com/tenten/studybadge/schedule/dto/ScheduleDeleteRequest.java
@@ -1,0 +1,18 @@
+package com.tenten.studybadge.schedule.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduleDeleteRequest {
+  @NotNull(message = "삭제할 일정의 id는 필수입니다.")
+  private Long scheduleId;
+
+  @NotNull(message = "삭제할 일정의 선택한 날짜는 필수입니다")
+  private LocalDate selectedDate;
+}

--- a/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
+++ b/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
@@ -313,6 +313,21 @@ public class ScheduleService {
             changeRepeatEndDate(selectedDate, repeatSchedule.getRepeatCycle(), repeatSchedule);
         }
 
+      // 만일 변경한 기존 반복 일정이 반복 시작 날짜와 끝나는 날짜가 같을 경우 단일 일정으로 변경한다.
+      if (repeatSchedule.getScheduleDate().equals(repeatSchedule.getRepeatEndDate())) {
+        singleScheduleRepository.save(SingleSchedule.withoutIdBuilder()
+            .scheduleName(repeatSchedule.getScheduleName())
+            .scheduleContent(repeatSchedule.getScheduleContent())
+            .scheduleDate(repeatSchedule.getScheduleDate())
+            .scheduleStartTime(repeatSchedule.getScheduleStartTime())
+            .scheduleEndTime(repeatSchedule.getScheduleEndTime())
+            .isRepeated(false)
+            .studyChannel(repeatSchedule.getStudyChannel())
+            .placeId(repeatSchedule.getPlaceId())
+            .build());
+        repeatScheduleRepository.deleteById(singleScheduleEditRequest.getScheduleId());
+      }
+
         // 선택 날짜 single schedule
         singleScheduleRepository.save(SingleSchedule.withoutIdBuilder()
             .scheduleName(singleScheduleEditRequest.getScheduleName())

--- a/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
+++ b/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
@@ -328,78 +328,48 @@ public class ScheduleService {
         return (selectedDate.isAfter(repeatEndDate) || selectedDate.isBefore(repeatStartDate));
     }
 
-    private boolean isNextRepeatStartDate(LocalDate selectedDate, RepeatCycle repeatCycle
-        , LocalDate repeatStartDate) {
-        switch (repeatCycle) {
-            case DAILY:
-                return selectedDate.minusDays(1).isEqual(repeatStartDate);
-            case WEEKLY:
-                return selectedDate.minusWeeks(1).isEqual(repeatStartDate);
-            case MONTHLY:
-                return selectedDate.minusMonths(1).isEqual(repeatStartDate);
-        }
-        return false;
+    private boolean isNextRepeatStartDate(LocalDate selectedDate, RepeatCycle repeatCycle, LocalDate repeatStartDate) {
+        return switch (repeatCycle) {
+            case DAILY -> selectedDate.minusDays(1).isEqual(repeatStartDate);
+            case WEEKLY -> selectedDate.minusWeeks(1).isEqual(repeatStartDate);
+            case MONTHLY -> selectedDate.minusMonths(1).isEqual(repeatStartDate);
+        };
     }
 
-    private boolean isFrontRepeatEndDate(LocalDate selectedDate, RepeatCycle repeatCycle
-        , LocalDate repeatEndDate) {
-        switch (repeatCycle) {
-            case DAILY:
-                return selectedDate.plusDays(1).isEqual(repeatEndDate);
-            case WEEKLY:
-                return selectedDate.plusWeeks(1).isEqual(repeatEndDate);
-            case MONTHLY:
-                return selectedDate.plusMonths(1).isEqual(repeatEndDate);
-        }
-        return false;
+    private boolean isFrontRepeatEndDate(LocalDate selectedDate, RepeatCycle repeatCycle, LocalDate repeatEndDate) {
+        return switch (repeatCycle) {
+            case DAILY -> selectedDate.plusDays(1).isEqual(repeatEndDate);
+            case WEEKLY -> selectedDate.plusWeeks(1).isEqual(repeatEndDate);
+            case MONTHLY -> selectedDate.plusMonths(1).isEqual(repeatEndDate);
+        };
     }
 
-    private void changeRepeatStartDate(LocalDate selectedDate, RepeatCycle repeatCycle
-        , RepeatSchedule repeatSchedule) {
-        switch (repeatCycle) {
-            case DAILY:
-                repeatSchedule.setRepeatStartDate(selectedDate.plusDays(1));
-                break;
-            case WEEKLY:
-                repeatSchedule.setRepeatStartDate(selectedDate.plusWeeks(1));
-                break;
-            case MONTHLY:
-                repeatSchedule.setRepeatStartDate(selectedDate.plusMonths(1));
-                break;
-        }
+    private void changeRepeatStartDate(LocalDate selectedDate, RepeatCycle repeatCycle, RepeatSchedule repeatSchedule) {
+        LocalDate newStartDate = switch (repeatCycle) {
+            case DAILY -> selectedDate.plusDays(1);
+            case WEEKLY -> selectedDate.plusWeeks(1);
+            case MONTHLY -> selectedDate.plusMonths(1);
+        };
+        repeatSchedule.setRepeatStartDate(newStartDate);
         repeatScheduleRepository.save(repeatSchedule);
     }
 
-    private void changeRepeatEndDate(LocalDate selectedDate, RepeatCycle repeatCycle
-        , RepeatSchedule repeatSchedule) {
-        switch (repeatCycle) {
-            case DAILY:
-                repeatSchedule.setRepeatEndDate(selectedDate.minusDays(1));
-                break;
-            case WEEKLY:
-                repeatSchedule.setRepeatEndDate(selectedDate.minusWeeks(1));
-                break;
-            case MONTHLY:
-                repeatSchedule.setRepeatEndDate(selectedDate.minusMonths(1));
-                break;
-        }
+    private void changeRepeatEndDate(LocalDate selectedDate, RepeatCycle repeatCycle, RepeatSchedule repeatSchedule) {
+        LocalDate newEndDate = switch (repeatCycle) {
+            case DAILY -> selectedDate.minusDays(1);
+            case WEEKLY -> selectedDate.minusWeeks(1);
+            case MONTHLY -> selectedDate.minusMonths(1);
+        };
+        repeatSchedule.setRepeatEndDate(newEndDate);
         repeatScheduleRepository.save(repeatSchedule);
     }
 
     private RepeatSchedule makeAfterCycleRepeatSchedule(LocalDate selectedDate, RepeatSchedule existRepeatSchedule) {
-        LocalDate afterStartDate = null;
-
-        switch (existRepeatSchedule.getRepeatCycle()) {
-            case DAILY:
-                afterStartDate = selectedDate.plusDays(1);
-                break;
-            case WEEKLY:
-                afterStartDate = selectedDate.plusWeeks(1);
-                break;
-            case MONTHLY:
-                afterStartDate = selectedDate.plusMonths(1);
-                break;
-        }
+        LocalDate afterStartDate = switch (existRepeatSchedule.getRepeatCycle()) {
+            case DAILY -> selectedDate.plusDays(1);
+            case WEEKLY -> selectedDate.plusWeeks(1);
+            case MONTHLY -> selectedDate.plusMonths(1);
+        };
 
         return  RepeatSchedule.withoutIdBuilder()
             .scheduleName(existRepeatSchedule.getScheduleName())

--- a/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
+++ b/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
@@ -2,6 +2,7 @@ package com.tenten.studybadge.schedule.service;
 
 import com.tenten.studybadge.common.exception.schedule.IllegalArgumentForRepeatScheduleEditRequestException;
 import com.tenten.studybadge.common.exception.schedule.IllegalArgumentForScheduleRequestException;
+import com.tenten.studybadge.common.exception.schedule.NotEqualSingleScheduleDate;
 import com.tenten.studybadge.common.exception.schedule.NotFoundRepeatScheduleException;
 import com.tenten.studybadge.common.exception.schedule.NotFoundSingleScheduleException;
 import com.tenten.studybadge.common.exception.schedule.OutRangeScheduleException;
@@ -13,6 +14,7 @@ import com.tenten.studybadge.schedule.domain.repository.SingleScheduleRepository
 import com.tenten.studybadge.schedule.dto.RepeatScheduleCreateRequest;
 import com.tenten.studybadge.schedule.dto.RepeatScheduleEditRequest;
 import com.tenten.studybadge.schedule.dto.ScheduleCreateRequest;
+import com.tenten.studybadge.schedule.dto.ScheduleDeleteRequest;
 import com.tenten.studybadge.schedule.dto.ScheduleEditRequest;
 import com.tenten.studybadge.schedule.dto.ScheduleResponse;
 import com.tenten.studybadge.schedule.dto.SingleScheduleCreateRequest;
@@ -21,6 +23,7 @@ import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
 import com.tenten.studybadge.study.channel.domain.repository.StudyChannelRepository;
 import com.tenten.studybadge.type.schedule.RepeatCycle;
 import com.tenten.studybadge.type.schedule.ScheduleOriginType;
+import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -321,6 +324,21 @@ public class ScheduleService {
             .studyChannel(repeatSchedule.getStudyChannel())
             .placeId(singleScheduleEditRequest.getPlaceId())
             .build());
+    }
+
+    public void deleteSingleSchedule(Long studyChannelId, ScheduleDeleteRequest scheduleDeleteRequest) {
+        StudyChannel studyChannel = studyChannelRepository.findById(studyChannelId)
+            .orElseThrow(NotFoundStudyChannelException::new);
+
+        SingleSchedule singleSchedule = singleScheduleRepository.findById(
+                scheduleDeleteRequest.getScheduleId())
+            .orElseThrow(NotFoundSingleScheduleException::new);
+
+        if (!scheduleDeleteRequest.getSelectedDate().equals(singleSchedule.getScheduleDate())) {
+            throw new NotEqualSingleScheduleDate();
+        }
+
+        singleScheduleRepository.deleteById(scheduleDeleteRequest.getScheduleId());
     }
 
     private boolean isNotIncluded(LocalDate selectedDate, LocalDate repeatStartDate

--- a/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
@@ -46,562 +46,650 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 class ScheduleServiceTest {
-  @Mock
-  private SingleScheduleRepository singleScheduleRepository;
-  @Mock
-  private RepeatScheduleRepository repeatScheduleRepository;
-  @Mock
-  private StudyChannelRepository studyChannelRepository;
+    @Mock
+    private SingleScheduleRepository singleScheduleRepository;
+    @Mock
+    private RepeatScheduleRepository repeatScheduleRepository;
+    @Mock
+    private StudyChannelRepository studyChannelRepository;
 
-  @InjectMocks
-  private ScheduleService scheduleService;
+    @InjectMocks
+    private ScheduleService scheduleService;
 
-  private StudyChannel studyChannel;
-  private SingleSchedule singleScheduleWithoutPlace;
-  private RepeatSchedule repeatScheduleWithoutPlace;
-  private SingleSchedule singleScheduleWithPlace;
-  private RepeatSchedule repeatScheduleWithPlace;
+    private StudyChannel studyChannel;
+    private SingleSchedule singleScheduleWithoutPlace;
+    private RepeatSchedule repeatScheduleWithoutPlace;
+    private SingleSchedule singleScheduleWithPlace;
+    private RepeatSchedule repeatScheduleWithPlace;
 
-  @BeforeEach
-  public void setUp() {
-    scheduleService = new ScheduleService(
-        singleScheduleRepository, repeatScheduleRepository, studyChannelRepository);
-    studyChannel = StudyChannel.builder()
-        .id(1L)
-        .name("test study channel1")
-        .build();
+    @BeforeEach
+    public void setUp() {
+        scheduleService = new ScheduleService(
+            singleScheduleRepository, repeatScheduleRepository, studyChannelRepository);
+        studyChannel = StudyChannel.builder()
+            .id(1L)
+            .name("test study channel1")
+            .build();
 
-    singleScheduleWithoutPlace = SingleSchedule.withoutIdBuilder()
-        .scheduleName("Single Meeting")
-        .scheduleContent("Content for single meeting")
-        .scheduleDate(LocalDate.of(2024, 7, 5))
-        .scheduleStartTime(LocalTime.of(10, 0))
-        .scheduleEndTime(LocalTime.of(11, 0))
-        .isRepeated(false)
-        .studyChannel(studyChannel)
-        .placeId(null)
-        .build();
+        singleScheduleWithoutPlace = SingleSchedule.withoutIdBuilder()
+            .scheduleName("Single Meeting")
+            .scheduleContent("Content for single meeting")
+            .scheduleDate(LocalDate.of(2024, 7, 5))
+            .scheduleStartTime(LocalTime.of(10, 0))
+            .scheduleEndTime(LocalTime.of(11, 0))
+            .isRepeated(false)
+            .studyChannel(studyChannel)
+            .placeId(null)
+            .build();
 
-    repeatScheduleWithoutPlace =  RepeatSchedule.withoutIdBuilder()
-        .scheduleName("Repeat Meeting")
-        .scheduleContent("Content for repeat meeting")
-        .scheduleDate(LocalDate.of(2024, 7, 5))
-        .scheduleStartTime(LocalTime.of(10, 0))
-        .scheduleEndTime(LocalTime.of(11, 0))
-        .repeatCycle(RepeatCycle.WEEKLY)
-        .repeatSituation(RepeatSituation.MONDAY)
-        .repeatEndDate(LocalDate.of(2024, 12, 31))
-        .isRepeated(true)
-        .studyChannel(studyChannel)
-        .placeId(null)
-        .build();
+        repeatScheduleWithoutPlace =  RepeatSchedule.withoutIdBuilder()
+            .scheduleName("Repeat Meeting")
+            .scheduleContent("Content for repeat meeting")
+            .scheduleDate(LocalDate.of(2024, 7, 5))
+            .scheduleStartTime(LocalTime.of(10, 0))
+            .scheduleEndTime(LocalTime.of(11, 0))
+            .repeatCycle(RepeatCycle.WEEKLY)
+            .repeatSituation(RepeatSituation.MONDAY)
+            .repeatEndDate(LocalDate.of(2024, 12, 31))
+            .isRepeated(true)
+            .studyChannel(studyChannel)
+            .placeId(null)
+            .build();
 
-    singleScheduleWithPlace = SingleSchedule.withoutIdBuilder()
-        .scheduleName("Single Meeting")
-        .scheduleContent("Content for single meeting")
-        .scheduleDate(LocalDate.of(2024, 7, 5))
-        .scheduleStartTime(LocalTime.of(10, 0))
-        .scheduleEndTime(LocalTime.of(11, 0))
-        .isRepeated(false)
-        .studyChannel(studyChannel)
-        .placeId(1L)
-        .build();
+        singleScheduleWithPlace = SingleSchedule.withoutIdBuilder()
+            .scheduleName("Single Meeting")
+            .scheduleContent("Content for single meeting")
+            .scheduleDate(LocalDate.of(2024, 7, 5))
+            .scheduleStartTime(LocalTime.of(10, 0))
+            .scheduleEndTime(LocalTime.of(11, 0))
+            .isRepeated(false)
+            .studyChannel(studyChannel)
+            .placeId(1L)
+            .build();
 
-    repeatScheduleWithPlace =  RepeatSchedule.withoutIdBuilder()
-        .scheduleName("Repeat Meeting")
-        .scheduleContent("Content for repeat meeting")
-        .scheduleDate(LocalDate.of(2024, 7, 5))
-        .scheduleStartTime(LocalTime.of(10, 0))
-        .scheduleEndTime(LocalTime.of(11, 0))
-        .repeatCycle(RepeatCycle.WEEKLY)
-        .repeatSituation(RepeatSituation.MONDAY)
-        .repeatEndDate(LocalDate.of(2024, 12, 31))
-        .isRepeated(true)
-        .studyChannel(studyChannel)
-        .placeId(1L)
-        .build();
-  }
-
-  @Test
-  @DisplayName("단순 일정 등록 성공 - 장소 정보가 없을 때")
-  public void testPostSingleSchedule() {
-    // given
-    SingleScheduleCreateRequest singleScheduleRequestWithoutPlace = new SingleScheduleCreateRequest(
-        "Single Meeting",
-        "Content for single meeting",
-        LocalDate.of(2024, 7, 5),
-        LocalTime.of(10, 0),
-        LocalTime.of( 11, 0),
-        null
-    );
-
-    given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
-    given(singleScheduleRepository.save(any(SingleSchedule.class))).willReturn(singleScheduleWithoutPlace);
-
-    // when
-    scheduleService.postSchedule(singleScheduleRequestWithoutPlace, 1L);
-
-    // then
-    verify(singleScheduleRepository, times(1)).save(any(SingleSchedule.class));
-    verify(repeatScheduleRepository, times(0)).save(any(RepeatSchedule.class));
-  }
-
-  @Test
-  @DisplayName("반복 일정 등록 성공 - 장소 정보가 없을 때")
-  public void testPostRepeatSchedule() {
-    // given
-    RepeatScheduleCreateRequest repeatScheduleRequestWithoutPlace = new RepeatScheduleCreateRequest(
-        "Weekly Meeting",
-        "Content for weekly meeting",
-        LocalDate.of(2024, 7, 5),
-        LocalTime.of(10, 0),
-        LocalTime.of( 11, 0),
-        RepeatCycle.WEEKLY,
-        RepeatSituation.MONDAY,
-        LocalDate.of(2024, 12, 31),
-        null
-    );
-
-    given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
-    given(repeatScheduleRepository.save(any(RepeatSchedule.class))).willReturn(repeatScheduleWithoutPlace);
-
-    // when
-    scheduleService.postSchedule(repeatScheduleRequestWithoutPlace, 1L);
-
-    // then
-    verify(repeatScheduleRepository, times(1)).save(any(RepeatSchedule.class));
-    verify(singleScheduleRepository, times(0)).save(any(SingleSchedule.class));
-  }
-
-  @Test
-  @DisplayName("단순 일정 등록 성공 - 장소 정보가 있을 때")
-  public void testPostSingleSchedule_WithPlace() {
-    // given
-    SingleScheduleCreateRequest singleScheduleRequestWithPlace = new SingleScheduleCreateRequest(
-        "Single Meeting",
-        "Content for single meeting",
-        LocalDate.of(2024, 7, 5),
-        LocalTime.of(10, 0),
-        LocalTime.of( 11, 0),
-        1L
-    );
-
-    given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
-    given(singleScheduleRepository.save(any(SingleSchedule.class))).willReturn(singleScheduleWithPlace);
-
-    // when
-    scheduleService.postSchedule(singleScheduleRequestWithPlace, 1L);
-
-    // then
-    verify(singleScheduleRepository, times(1)).save(any(SingleSchedule.class));
-    verify(repeatScheduleRepository, times(0)).save(any(RepeatSchedule.class));
-  }
-
-  @Test
-  @DisplayName("반복 일정 등록 성공 - 장소 정보가 있을 때")
-  public void testPostRepeatSchedule_WithPlace() {
-    // given
-    RepeatScheduleCreateRequest repeatScheduleRequestWithPlace = new RepeatScheduleCreateRequest(
-        "Weekly Meeting",
-        "Content for weekly meeting",
-        LocalDate.of(2024, 7, 5),
-        LocalTime.of(10, 0),
-        LocalTime.of( 11, 0),
-        RepeatCycle.WEEKLY,
-        RepeatSituation.MONDAY,
-        LocalDate.of(2024, 12, 31),
-        1L
-    );
-
-    given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
-    given(repeatScheduleRepository.save(any(RepeatSchedule.class))).willReturn(repeatScheduleWithPlace);
-
-    // when
-    scheduleService.postSchedule(repeatScheduleRequestWithPlace, 1L);
-
-    // then
-    verify(repeatScheduleRepository, times(1)).save(any(RepeatSchedule.class));
-    verify(singleScheduleRepository, times(0)).save(any(SingleSchedule.class));
-  }
-
-
-  @Test
-  @DisplayName("스터디 채널 내의 일정 전체 조회 성공")
-  public void success_testGetSchedulesInStudyChannel() {
-    // given
-    given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
-    given(singleScheduleRepository.findAllByStudyChannelId(1L))
-        .willReturn(Arrays.asList(singleScheduleWithoutPlace));
-    given(repeatScheduleRepository.findAllByStudyChannelId(1L))
-        .willReturn(Arrays.asList(repeatScheduleWithoutPlace));
-
-    // when
-    List<ScheduleResponse> scheduleResponses = scheduleService.getSchedulesInStudyChannel(1L);
-
-    // then
-    assertEquals(2, scheduleResponses.size());
-    verify(studyChannelRepository, times(1)).findById(1L);
-    verify(singleScheduleRepository, times(1)).findAllByStudyChannelId(1L);
-    verify(repeatScheduleRepository, times(1)).findAllByStudyChannelId(1L);
-  }
-
-  @Test
-  @DisplayName("스터디 채널 내의 일정 yyyy.mm 기준 전체 조회 성공")
-  public void success_testGetSchedulesInStudyChannelByYearAndMonth() {
-    // given
-    RepeatSchedule repeatSchedule2 = RepeatSchedule.withoutIdBuilder()
-        .scheduleDate(LocalDate.of(2024, 5, 15))
-        .repeatEndDate(LocalDate.of(2024, 9, 15))
-        .studyChannel(studyChannel)
-        .build();
-    LocalDate selectMonthFirstDate = LocalDate.of(2024, 7, 1);
-    LocalDate selectMonthLastDate = selectMonthFirstDate.withDayOfMonth(selectMonthFirstDate.lengthOfMonth());
-
-    given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
-    given(singleScheduleRepository.findAllByStudyChannelIdAndDateRange(
-        1L, selectMonthFirstDate, selectMonthLastDate))
-        .willReturn(Arrays.asList(singleScheduleWithoutPlace));
-
-    given(repeatScheduleRepository.findAllByStudyChannelIdAndDate(
-        1L, selectMonthFirstDate))
-        .willReturn(Arrays.asList(repeatSchedule2));
-
-    // when
-    List<ScheduleResponse> scheduleResponses = scheduleService.getSchedulesInStudyChannelForYearAndMonth(
-        1L, 2024, 7);
-
-    // then
-    assertEquals(2, scheduleResponses.size());
-    verify(studyChannelRepository, times(1)).findById(1L);
-    verify(singleScheduleRepository, times(1)).findAllByStudyChannelIdAndDateRange(
-        1L, selectMonthFirstDate, selectMonthLastDate);
-    verify(repeatScheduleRepository, times(1)).findAllByStudyChannelIdAndDate(
-        1L, selectMonthFirstDate);
-  }
-
-  @Test
-  @DisplayName("스터디 채널 내의 일정 전체 조회 실패: study channel이 존재하지 않을 때")
-  public void fail_testGetSchedulesInStudyChannel() {
-    // given
-    given(studyChannelRepository.findById(1L)).willReturn(Optional.empty());
-
-    // when & then
-    assertThrows(NotFoundStudyChannelException.class, () -> {
-      scheduleService.getSchedulesInStudyChannel(1L);
-    });
-
-    // then
-    verify(studyChannelRepository, times(1)).findById(1L);
-    verify(singleScheduleRepository, times(0)).findAllByStudyChannelId(1L);
-    verify(repeatScheduleRepository, times(0)).findAllByStudyChannelId(1L);
-  }
-
-  @DisplayName("일정 수정: 단일 -> any | 반복 -> 반복")
-  @Nested
-  class ScheduleEditTest1 {
-    @Test
-    @DisplayName("단일 일정 -> 단일 일정 수정 성공")
-    public void testPutSchedulesSingleToSingle() {
-      // given
-      SingleScheduleEditRequest singleScheduleEditRequest = new SingleScheduleEditRequest(
-          1L, ScheduleOriginType.SINGLE, "Single Meeting Edit", "Content for single meeting Edit",
-          LocalDate.of(2024, 8, 12), LocalTime.of(12, 0), LocalTime.of(13, 0),
-          null
-      );
-
-      given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
-      given(singleScheduleRepository.findById(1L)).willReturn(Optional.of(singleScheduleWithPlace));
-
-      // when
-      scheduleService.putSchedule(1L, singleScheduleEditRequest);
-
-      // then
-      ArgumentCaptor<SingleSchedule> captor = ArgumentCaptor.forClass(SingleSchedule.class);
-      verify(singleScheduleRepository, times(1)).save(captor.capture());
-      SingleSchedule savedSchedule = captor.getValue();
-
-      assertEquals("Single Meeting Edit", savedSchedule.getScheduleName());
-      assertEquals("Content for single meeting Edit", savedSchedule.getScheduleContent());
-      assertEquals(LocalDate.of(2024, 8, 12), savedSchedule.getScheduleDate());
-      assertEquals(LocalTime.of(12, 0), savedSchedule.getScheduleStartTime());
-      assertEquals(LocalTime.of(13, 0), savedSchedule.getScheduleEndTime());
-      assertNull(singleScheduleWithPlace.getPlaceId());
+        repeatScheduleWithPlace =  RepeatSchedule.withoutIdBuilder()
+            .scheduleName("Repeat Meeting")
+            .scheduleContent("Content for repeat meeting")
+            .scheduleDate(LocalDate.of(2024, 7, 5))
+            .scheduleStartTime(LocalTime.of(10, 0))
+            .scheduleEndTime(LocalTime.of(11, 0))
+            .repeatCycle(RepeatCycle.WEEKLY)
+            .repeatSituation(RepeatSituation.MONDAY)
+            .repeatEndDate(LocalDate.of(2024, 12, 31))
+            .isRepeated(true)
+            .studyChannel(studyChannel)
+            .placeId(1L)
+            .build();
     }
 
-    @Test
-    @DisplayName("단일 일정 -> 반복 일정 수정 성공")
-    public void testPutSchedulesSingleToRepeat() {
-      // given
-      RepeatScheduleEditRequest repeatScheduleEditRequest = new RepeatScheduleEditRequest(
-          1L, ScheduleOriginType.SINGLE, "Repeat Meeting", "Content for repeat meeting",
-          LocalDate.of(2024, 7, 5), LocalTime.of(12, 0), LocalTime.of(13, 0),
-          RepeatCycle.WEEKLY, RepeatSituation.MONDAY, LocalDate.of(2024, 12, 31),
-          null
-      );
+    @DisplayName("일정 등록")
+    @Nested
+    class schedulePostTest {
+        @Test
+        @DisplayName("단순 일정 등록 성공 - 장소 정보가 없을 때")
+        public void testPostSingleSchedule() {
+            // given
+            SingleScheduleCreateRequest singleScheduleRequestWithoutPlace =
+                new SingleScheduleCreateRequest(
+                "Single Meeting",
+                "Content for single meeting",
+                LocalDate.of(2024, 7, 5),
+                LocalTime.of(10, 0),
+                LocalTime.of( 11, 0),
+                null
+            );
 
-      given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
-      given(singleScheduleRepository.findById(1L)).willReturn(Optional.of(singleScheduleWithPlace));
+            given(studyChannelRepository.findById(1L))
+                .willReturn(Optional.of(studyChannel));
+            given(singleScheduleRepository.save(any(SingleSchedule.class)))
+                .willReturn(singleScheduleWithoutPlace);
 
-      // when
-      scheduleService.putSchedule(1L, repeatScheduleEditRequest);
+            // when
+            scheduleService.postSchedule(
+                singleScheduleRequestWithoutPlace, 1L);
 
-      // then
-      ArgumentCaptor<RepeatSchedule> captor = ArgumentCaptor.forClass(RepeatSchedule.class);
-      verify(repeatScheduleRepository, times(1)).save(captor.capture());
-      RepeatSchedule savedSchedule = captor.getValue();
+            // then
+            verify(singleScheduleRepository, times(1))
+                .save(any(SingleSchedule.class));
+            verify(repeatScheduleRepository, times(0))
+                .save(any(RepeatSchedule.class));
+        }
 
-      assertEquals("Repeat Meeting", savedSchedule.getScheduleName());
-      assertEquals("Content for repeat meeting", savedSchedule.getScheduleContent());
-      assertEquals(LocalDate.of(2024, 7, 5), savedSchedule.getScheduleDate());
-      assertEquals(LocalTime.of(12, 0), savedSchedule.getScheduleStartTime());
-      assertEquals(LocalTime.of(13, 0), savedSchedule.getScheduleEndTime());
-      assertEquals(RepeatCycle.WEEKLY, savedSchedule.getRepeatCycle());
-      assertEquals(RepeatSituation.MONDAY, savedSchedule.getRepeatSituation());
-      assertEquals(LocalDate.of(2024, 12, 31), savedSchedule.getRepeatEndDate());
-      assertNull(savedSchedule.getPlaceId());
-      verify(singleScheduleRepository, times(1)).deleteById(1L);
+        @Test
+        @DisplayName("반복 일정 등록 성공 - 장소 정보가 없을 때")
+        public void testPostRepeatSchedule() {
+            // given
+            RepeatScheduleCreateRequest repeatScheduleRequestWithoutPlace =
+                new RepeatScheduleCreateRequest(
+                "Weekly Meeting",
+                "Content for weekly meeting",
+                LocalDate.of(2024, 7, 5),
+                LocalTime.of(10, 0),
+                LocalTime.of( 11, 0),
+                RepeatCycle.WEEKLY,
+                RepeatSituation.MONDAY,
+                LocalDate.of(2024, 12, 31),
+                null
+            );
+
+            given(studyChannelRepository.findById(1L))
+                .willReturn(Optional.of(studyChannel));
+            given(repeatScheduleRepository.save(any(RepeatSchedule.class)))
+                .willReturn(repeatScheduleWithoutPlace);
+
+            // when
+            scheduleService.postSchedule(
+                repeatScheduleRequestWithoutPlace, 1L);
+
+            // then
+            verify(repeatScheduleRepository, times(1))
+                .save(any(RepeatSchedule.class));
+            verify(singleScheduleRepository, times(0))
+                .save(any(SingleSchedule.class));
+        }
+
+        @Test
+        @DisplayName("단순 일정 등록 성공 - 장소 정보가 있을 때")
+        public void testPostSingleSchedule_WithPlace() {
+            // given
+            SingleScheduleCreateRequest singleScheduleRequestWithPlace =
+                new SingleScheduleCreateRequest(
+                "Single Meeting",
+                "Content for single meeting",
+                LocalDate.of(2024, 7, 5),
+                LocalTime.of(10, 0),
+                LocalTime.of( 11, 0),
+                1L
+            );
+
+            given(studyChannelRepository.findById(1L))
+                .willReturn(Optional.of(studyChannel));
+            given(singleScheduleRepository.save(any(SingleSchedule.class)))
+                .willReturn(singleScheduleWithPlace);
+
+            // when
+            scheduleService.postSchedule(
+                singleScheduleRequestWithPlace, 1L);
+
+            // then
+            verify(singleScheduleRepository, times(1))
+                .save(any(SingleSchedule.class));
+            verify(repeatScheduleRepository, times(0))
+                .save(any(RepeatSchedule.class));
+        }
+
+        @Test
+        @DisplayName("반복 일정 등록 성공 - 장소 정보가 있을 때")
+        public void testPostRepeatSchedule_WithPlace() {
+            // given
+            RepeatScheduleCreateRequest repeatScheduleRequestWithPlace =
+                new RepeatScheduleCreateRequest(
+                "Weekly Meeting",
+                "Content for weekly meeting",
+                LocalDate.of(2024, 7, 5),
+                LocalTime.of(10, 0),
+                LocalTime.of( 11, 0),
+                RepeatCycle.WEEKLY,
+                RepeatSituation.MONDAY,
+                LocalDate.of(2024, 12, 31),
+                1L
+            );
+
+            given(studyChannelRepository.findById(1L))
+                .willReturn(Optional.of(studyChannel));
+            given(repeatScheduleRepository.save(any(RepeatSchedule.class)))
+                .willReturn(repeatScheduleWithPlace);
+
+            // when
+            scheduleService.postSchedule(
+                repeatScheduleRequestWithPlace, 1L);
+
+            // then
+            verify(repeatScheduleRepository, times(1))
+                .save(any(RepeatSchedule.class));
+            verify(singleScheduleRepository, times(0))
+                .save(any(SingleSchedule.class));
+        }
     }
 
-    @Test
-    @DisplayName("반복 일정 -> 반복 일정 수정 성공")
-    public void testPutSchedulesRepeatToRepeat() {
-      // given
-      RepeatScheduleEditRequest repeatScheduleEditRequest = new RepeatScheduleEditRequest(
-          2L, ScheduleOriginType.REPEAT,
-          "Repeat Meeting Edit", "Content for repeat meeting Edit",
-          LocalDate.of(2024,  8, 5), LocalTime.of(12, 0), LocalTime.of(13, 0),
-          RepeatCycle.WEEKLY, RepeatSituation.TUESDAY, LocalDate.of(2024, 12, 31),
-          null
-      );
-      given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
-      given(repeatScheduleRepository.findById(2L)).willReturn(Optional.of(repeatScheduleWithPlace));
+    @DisplayName("일정 조회")
+    @Nested
+    class ScheduleGetTest {
+        @Test
+        @DisplayName("스터디 채널 내의 일정 전체 조회 성공")
+        public void success_testGetSchedulesInStudyChannel() {
+            // given
+            given(studyChannelRepository.findById(1L))
+                .willReturn(Optional.of(studyChannel));
+            given(singleScheduleRepository.findAllByStudyChannelId(1L))
+                .willReturn(Arrays.asList(singleScheduleWithoutPlace));
+            given(repeatScheduleRepository.findAllByStudyChannelId(1L))
+                .willReturn(Arrays.asList(repeatScheduleWithoutPlace));
 
-      // when
-      scheduleService.putSchedule(1L, repeatScheduleEditRequest);
+            // when
+            List<ScheduleResponse> scheduleResponses =
+                scheduleService.getSchedulesInStudyChannel(1L);
 
-      // then
-      ArgumentCaptor<RepeatSchedule> captor = ArgumentCaptor.forClass(RepeatSchedule.class);
-      verify(repeatScheduleRepository, times(1)).save(captor.capture());
-      RepeatSchedule savedSchedule = captor.getValue();
+            // then
+            assertEquals(2, scheduleResponses.size());
+            verify(studyChannelRepository, times(1)).findById(1L);
+            verify(singleScheduleRepository, times(1)).findAllByStudyChannelId(1L);
+            verify(repeatScheduleRepository, times(1)).findAllByStudyChannelId(1L);
+        }
 
-      assertEquals("Repeat Meeting Edit", savedSchedule.getScheduleName());
-      assertEquals("Content for repeat meeting Edit", savedSchedule.getScheduleContent());
-      assertEquals(LocalDate.of(2024, 8, 5), savedSchedule.getScheduleDate());
-      assertEquals(LocalTime.of(12, 0), savedSchedule.getScheduleStartTime());
-      assertEquals(LocalTime.of(13, 0), savedSchedule.getScheduleEndTime());
-      assertEquals(RepeatCycle.WEEKLY, savedSchedule.getRepeatCycle());
-      assertEquals(RepeatSituation.TUESDAY, savedSchedule.getRepeatSituation());
-      assertEquals(LocalDate.of(2024, 12, 31), savedSchedule.getRepeatEndDate());
-      assertNull( savedSchedule.getPlaceId());
-    }
-  }
+        @Test
+        @DisplayName("스터디 채널 내의 일정 yyyy.mm 기준 전체 조회 성공")
+        public void success_testGetSchedulesInStudyChannelByYearAndMonth() {
+            // given
+            RepeatSchedule repeatSchedule2 =
+                RepeatSchedule.withoutIdBuilder()
+                .scheduleDate(LocalDate.of(2024, 5, 15))
+                .repeatEndDate(LocalDate.of(2024, 9, 15))
+                .studyChannel(studyChannel)
+                .build();
+            LocalDate selectMonthFirstDate = LocalDate.of(2024, 7, 1);
+            LocalDate selectMonthLastDate = selectMonthFirstDate.withDayOfMonth(selectMonthFirstDate.lengthOfMonth());
 
-  @DisplayName("일정 수정: 반복 -> 단일")
-  @Nested
-  class ScheduleEditTest2 {
+            given(studyChannelRepository.findById(1L))
+                .willReturn(Optional.of(studyChannel));
+            given(singleScheduleRepository.findAllByStudyChannelIdAndDateRange(
+                1L, selectMonthFirstDate, selectMonthLastDate))
+                .willReturn(Arrays.asList(singleScheduleWithoutPlace));
 
-    private RepeatSchedule repeatDailySchedule = RepeatSchedule.withoutIdBuilder()
-        .scheduleName("7월 1일 부터 15일까지 매일 반복 일정")
-          .scheduleContent("Content for repeat meeting")
-          .scheduleDate(LocalDate.of(2024, 7, 1))
-          .scheduleStartTime(LocalTime.of(10, 0))
-          .scheduleEndTime(LocalTime.of(11, 0))
-          .repeatCycle(RepeatCycle.DAILY)
-          .repeatSituation(RepeatSituation.EVERYDAY)
-          .repeatEndDate(LocalDate.of(2024, 7, 15))
-          .isRepeated(true)
-          .studyChannel(studyChannel)
-          .placeId(null)
-          .build();
+            given(repeatScheduleRepository.findAllByStudyChannelIdAndDate(
+                1L, selectMonthFirstDate))
+                .willReturn(Arrays.asList(repeatSchedule2));
 
-    @Test
-    @DisplayName("반복 일정 -> 단일 일정 변경 | 이후 이벤트 동일 O - 반복 일정 중간 날짜")
-    public void testPutRepeatScheduleWithAfterEventSameYes_MiddleDate() {
-      // given
-      SingleScheduleEditRequest singleScheduleEditRequest = new SingleScheduleEditRequest(
-          2L, ScheduleOriginType.REPEAT,
-          "반복 일정 중간에 단일 일정으로 수정", "반복 일정 중간에 단일 일정으로 수정 내용",
-          LocalDate.of(2024, 7, 6), LocalTime.of(12, 0), LocalTime.of(13, 0), null
-      );
+            // when
+            List<ScheduleResponse> scheduleResponses =
+                scheduleService.getSchedulesInStudyChannelForYearAndMonth(
+                1L, 2024, 7);
 
-      given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
-      given(repeatScheduleRepository.findById(2L)).willReturn(Optional.of(repeatDailySchedule));
+            // then
+            assertEquals(2, scheduleResponses.size());
+            verify(studyChannelRepository, times(1)).findById(1L);
+            verify(singleScheduleRepository, times(1))
+                .findAllByStudyChannelIdAndDateRange(
+                1L, selectMonthFirstDate, selectMonthLastDate);
+            verify(repeatScheduleRepository, times(1))
+                .findAllByStudyChannelIdAndDate(
+                1L, selectMonthFirstDate);
+        }
 
-      // when
-      scheduleService.putRepeatScheduleWithAfterEventSame(1L, true, singleScheduleEditRequest);
+        @Test
+        @DisplayName("스터디 채널 내의 일정 전체 조회 실패: study channel이 존재하지 않을 때")
+        public void fail_testGetSchedulesInStudyChannel() {
+            // given
+            given(studyChannelRepository.findById(1L))
+                .willReturn(Optional.empty());
 
-      // then
-      ArgumentCaptor<SingleSchedule> singleCaptor = ArgumentCaptor.forClass(SingleSchedule.class);
-      verify(singleScheduleRepository, times(1)).save(singleCaptor.capture());
-      SingleSchedule savedSingleSchedule = singleCaptor.getValue();
+            // when & then
+            assertThrows(NotFoundStudyChannelException.class, () -> {
+              scheduleService.getSchedulesInStudyChannel(1L);
+            });
 
-
-      assertEquals("반복 일정 중간에 단일 일정으로 수정", savedSingleSchedule.getScheduleName());
-      assertEquals("반복 일정 중간에 단일 일정으로 수정 내용", savedSingleSchedule.getScheduleContent());
-      assertEquals(LocalDate.of(2024, 7, 6), savedSingleSchedule.getScheduleDate());
-      assertEquals(LocalDate.of(2024, 7, 5), repeatDailySchedule.getRepeatEndDate());
-    }
-
-    @Test
-    @DisplayName("반복 일정 -> 단일 일정 변경 | 이후 이벤트 동일 O - 반복 일정 처음 날짜")
-    public void testPutRepeatScheduleWithAfterEventSameYes_FirstDate() {
-      // given
-      SingleScheduleEditRequest singleScheduleEditRequest = new SingleScheduleEditRequest(
-          2L, ScheduleOriginType.REPEAT,
-          "반복 일정 처음에 단일 일정으로 수정", "반복 일정 처음에 단일 일정으로 수정 내용",
-          LocalDate.of(2024, 7, 1), LocalTime.of(12, 0), LocalTime.of(13, 0), null
-      );
-
-      given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
-      given(repeatScheduleRepository.findById(2L)).willReturn(Optional.of(repeatDailySchedule));
-
-      // when
-      scheduleService.putRepeatScheduleWithAfterEventSame(1L, true, singleScheduleEditRequest);
-
-      // then
-      ArgumentCaptor<SingleSchedule> singleCaptor = ArgumentCaptor.forClass(SingleSchedule.class);
-      verify(singleScheduleRepository, times(1)).save(singleCaptor.capture());
-      SingleSchedule savedSingleSchedule = singleCaptor.getValue();
-
-
-      assertEquals("반복 일정 처음에 단일 일정으로 수정", savedSingleSchedule.getScheduleName());
-      assertEquals("반복 일정 처음에 단일 일정으로 수정 내용", savedSingleSchedule.getScheduleContent());
-      assertEquals(LocalDate.of(2024, 7, 1), savedSingleSchedule.getScheduleDate());
-
-      verify(repeatScheduleRepository, times(1)).deleteById(2L);
+            // then
+            verify(studyChannelRepository, times(1)).findById(1L);
+            verify(singleScheduleRepository, times(0)).findAllByStudyChannelId(1L);
+            verify(repeatScheduleRepository, times(0)).findAllByStudyChannelId(1L);
+        }
     }
 
-    @Test
-    @DisplayName("반복 일정 -> 단일 일정 변경 | 이후 이벤트 동일 O - 반복 일정 마지막 날짜")
-    public void testPutRepeatScheduleWithAfterEventSameYes_LastDate() {
-      // given
-      SingleScheduleEditRequest singleScheduleEditRequest = new SingleScheduleEditRequest(
-          2L, ScheduleOriginType.REPEAT,
-          "반복 일정 마지막에 단일 일정으로 수정", "반복 일정 마지막에 단일 일정으로 수정 내용",
-          LocalDate.of(2024, 7, 15), LocalTime.of(12, 0), LocalTime.of(13, 0), null
-      );
+    @DisplayName("일정 수정: 단일 -> any | 반복 -> 반복")
+    @Nested
+    class ScheduleEditTest1 {
+        @Test
+        @DisplayName("단일 일정 -> 단일 일정 수정 성공")
+        public void testPutSchedulesSingleToSingle() {
+            // given
+            SingleScheduleEditRequest singleScheduleEditRequest =
+                new SingleScheduleEditRequest(
+                1L, ScheduleOriginType.SINGLE, "Single Meeting Edit", "Content for single meeting Edit",
+                LocalDate.of(2024, 8, 12), LocalTime.of(12, 0), LocalTime.of(13, 0),
+                null
+            );
 
-      given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
-      given(repeatScheduleRepository.findById(2L)).willReturn(Optional.of(repeatDailySchedule));
+            given(studyChannelRepository.findById(1L))
+                .willReturn(Optional.of(studyChannel));
+            given(singleScheduleRepository.findById(1L))
+                .willReturn(Optional.of(singleScheduleWithPlace));
 
-      // when
-      scheduleService.putRepeatScheduleWithAfterEventSame(1L, true, singleScheduleEditRequest);
+            // when
+            scheduleService.putSchedule(
+                1L, singleScheduleEditRequest);
 
-      // then
-      ArgumentCaptor<SingleSchedule> singleCaptor = ArgumentCaptor.forClass(SingleSchedule.class);
-      verify(singleScheduleRepository, times(1)).save(singleCaptor.capture());
-      SingleSchedule savedSingleSchedule = singleCaptor.getValue();
+            // then
+            ArgumentCaptor<SingleSchedule> captor =
+                ArgumentCaptor.forClass(SingleSchedule.class);
+            verify(singleScheduleRepository, times(1)).save(captor.capture());
+            SingleSchedule savedSchedule = captor.getValue();
 
-      assertEquals("반복 일정 마지막에 단일 일정으로 수정", savedSingleSchedule.getScheduleName());
-      assertEquals("반복 일정 마지막에 단일 일정으로 수정 내용", savedSingleSchedule.getScheduleContent());
-      assertEquals(LocalDate.of(2024, 7, 15), savedSingleSchedule.getScheduleDate());
-      assertEquals(LocalDate.of(2024, 7, 14), repeatDailySchedule.getRepeatEndDate());
+            assertEquals("Single Meeting Edit", savedSchedule.getScheduleName());
+            assertEquals("Content for single meeting Edit", savedSchedule.getScheduleContent());
+            assertEquals(LocalDate.of(2024, 8, 12), savedSchedule.getScheduleDate());
+            assertEquals(LocalTime.of(12, 0), savedSchedule.getScheduleStartTime());
+            assertEquals(LocalTime.of(13, 0), savedSchedule.getScheduleEndTime());
+            assertNull(singleScheduleWithPlace.getPlaceId());
+        }
+
+        @Test
+        @DisplayName("단일 일정 -> 반복 일정 수정 성공")
+        public void testPutSchedulesSingleToRepeat() {
+            // given
+            RepeatScheduleEditRequest repeatScheduleEditRequest =
+                new RepeatScheduleEditRequest(
+                1L, ScheduleOriginType.SINGLE, "Repeat Meeting", "Content for repeat meeting",
+                LocalDate.of(2024, 7, 5), LocalTime.of(12, 0), LocalTime.of(13, 0),
+                RepeatCycle.WEEKLY, RepeatSituation.MONDAY, LocalDate.of(2024, 12, 31),
+                null
+            );
+
+            given(studyChannelRepository.findById(1L))
+                .willReturn(Optional.of(studyChannel));
+            given(singleScheduleRepository.findById(1L))
+                .willReturn(Optional.of(singleScheduleWithPlace));
+
+            // when
+            scheduleService.putSchedule(
+                1L, repeatScheduleEditRequest);
+
+            // then
+            ArgumentCaptor<RepeatSchedule> captor =
+                ArgumentCaptor.forClass(RepeatSchedule.class);
+            verify(repeatScheduleRepository, times(1)).save(captor.capture());
+            RepeatSchedule savedSchedule = captor.getValue();
+
+            assertEquals("Repeat Meeting", savedSchedule.getScheduleName());
+            assertEquals("Content for repeat meeting", savedSchedule.getScheduleContent());
+            assertEquals(LocalDate.of(2024, 7, 5), savedSchedule.getScheduleDate());
+            assertEquals(LocalTime.of(12, 0), savedSchedule.getScheduleStartTime());
+            assertEquals(LocalTime.of(13, 0), savedSchedule.getScheduleEndTime());
+            assertEquals(RepeatCycle.WEEKLY, savedSchedule.getRepeatCycle());
+            assertEquals(RepeatSituation.MONDAY, savedSchedule.getRepeatSituation());
+            assertEquals(LocalDate.of(2024, 12, 31), savedSchedule.getRepeatEndDate());
+            assertNull(savedSchedule.getPlaceId());
+            verify(singleScheduleRepository, times(1)).deleteById(1L);
+        }
+
+        @Test
+        @DisplayName("반복 일정 -> 반복 일정 수정 성공")
+        public void testPutSchedulesRepeatToRepeat() {
+            // given
+            RepeatScheduleEditRequest repeatScheduleEditRequest =
+                new RepeatScheduleEditRequest(
+                2L, ScheduleOriginType.REPEAT,
+                "Repeat Meeting Edit", "Content for repeat meeting Edit",
+                LocalDate.of(2024,  8, 5), LocalTime.of(12, 0), LocalTime.of(13, 0),
+                RepeatCycle.WEEKLY, RepeatSituation.TUESDAY, LocalDate.of(2024, 12, 31),
+                null
+            );
+            given(studyChannelRepository.findById(1L))
+                .willReturn(Optional.of(studyChannel));
+            given(repeatScheduleRepository.findById(2L))
+                .willReturn(Optional.of(repeatScheduleWithPlace));
+
+            // when
+            scheduleService.putSchedule(
+                1L, repeatScheduleEditRequest);
+
+            // then
+            ArgumentCaptor<RepeatSchedule> captor =
+                ArgumentCaptor.forClass(RepeatSchedule.class);
+            verify(repeatScheduleRepository, times(1)).save(captor.capture());
+            RepeatSchedule savedSchedule = captor.getValue();
+
+            assertEquals("Repeat Meeting Edit", savedSchedule.getScheduleName());
+            assertEquals("Content for repeat meeting Edit", savedSchedule.getScheduleContent());
+            assertEquals(LocalDate.of(2024, 8, 5), savedSchedule.getScheduleDate());
+            assertEquals(LocalTime.of(12, 0), savedSchedule.getScheduleStartTime());
+            assertEquals(LocalTime.of(13, 0), savedSchedule.getScheduleEndTime());
+            assertEquals(RepeatCycle.WEEKLY, savedSchedule.getRepeatCycle());
+            assertEquals(RepeatSituation.TUESDAY, savedSchedule.getRepeatSituation());
+            assertEquals(LocalDate.of(2024, 12, 31), savedSchedule.getRepeatEndDate());
+            assertNull( savedSchedule.getPlaceId());
+          }
+      }
+
+    @DisplayName("일정 수정: 반복 -> 단일")
+    @Nested
+    class ScheduleEditTest2 {
+
+        private RepeatSchedule repeatDailySchedule =
+            RepeatSchedule.withoutIdBuilder()
+            .scheduleName("7월 1일 부터 15일까지 매일 반복 일정")
+            .scheduleContent("Content for repeat meeting")
+            .scheduleDate(LocalDate.of(2024, 7, 1))
+            .scheduleStartTime(LocalTime.of(10, 0))
+            .scheduleEndTime(LocalTime.of(11, 0))
+            .repeatCycle(RepeatCycle.DAILY)
+            .repeatSituation(RepeatSituation.EVERYDAY)
+            .repeatEndDate(LocalDate.of(2024, 7, 15))
+            .isRepeated(true)
+            .studyChannel(studyChannel)
+            .placeId(null)
+            .build();
+
+        @Test
+        @DisplayName("반복 일정 -> 단일 일정 변경 | 이후 이벤트 동일 O - 반복 일정 중간 날짜")
+        public void testPutRepeatScheduleWithAfterEventSameYes_MiddleDate() {
+            // given
+            SingleScheduleEditRequest singleScheduleEditRequest =
+                new SingleScheduleEditRequest(
+                2L, ScheduleOriginType.REPEAT,
+                "반복 일정 중간에 단일 일정으로 수정", "반복 일정 중간에 단일 일정으로 수정 내용",
+                LocalDate.of(2024, 7, 6), LocalTime.of(12, 0), LocalTime.of(13, 0), null
+            );
+
+            given(studyChannelRepository.findById(1L))
+                .willReturn(Optional.of(studyChannel));
+            given(repeatScheduleRepository.findById(2L))
+                .willReturn(Optional.of(repeatDailySchedule));
+
+            // when
+            scheduleService.putRepeatScheduleWithAfterEventSame(
+                1L, true, singleScheduleEditRequest);
+
+            // then
+            ArgumentCaptor<SingleSchedule> singleCaptor =
+                ArgumentCaptor.forClass(SingleSchedule.class);
+            verify(singleScheduleRepository, times(1)).save(singleCaptor.capture());
+            SingleSchedule savedSingleSchedule = singleCaptor.getValue();
+
+
+            assertEquals("반복 일정 중간에 단일 일정으로 수정", savedSingleSchedule.getScheduleName());
+            assertEquals("반복 일정 중간에 단일 일정으로 수정 내용", savedSingleSchedule.getScheduleContent());
+            assertEquals(LocalDate.of(2024, 7, 6), savedSingleSchedule.getScheduleDate());
+            assertEquals(LocalDate.of(2024, 7, 5), repeatDailySchedule.getRepeatEndDate());
+        }
+
+        @Test
+        @DisplayName("반복 일정 -> 단일 일정 변경 | 이후 이벤트 동일 O - 반복 일정 처음 날짜")
+        public void testPutRepeatScheduleWithAfterEventSameYes_FirstDate() {
+            // given
+            SingleScheduleEditRequest singleScheduleEditRequest =
+                new SingleScheduleEditRequest(
+                2L, ScheduleOriginType.REPEAT,
+                "반복 일정 처음에 단일 일정으로 수정", "반복 일정 처음에 단일 일정으로 수정 내용",
+                LocalDate.of(2024, 7, 1), LocalTime.of(12, 0), LocalTime.of(13, 0), null
+            );
+
+            given(studyChannelRepository.findById(1L))
+                .willReturn(Optional.of(studyChannel));
+            given(repeatScheduleRepository.findById(2L))
+                .willReturn(Optional.of(repeatDailySchedule));
+
+            // when
+            scheduleService.putRepeatScheduleWithAfterEventSame(
+                1L, true, singleScheduleEditRequest);
+
+            // then
+            ArgumentCaptor<SingleSchedule> singleCaptor =
+                ArgumentCaptor.forClass(SingleSchedule.class);
+            verify(singleScheduleRepository, times(1)).save(singleCaptor.capture());
+            SingleSchedule savedSingleSchedule = singleCaptor.getValue();
+
+
+            assertEquals("반복 일정 처음에 단일 일정으로 수정", savedSingleSchedule.getScheduleName());
+            assertEquals("반복 일정 처음에 단일 일정으로 수정 내용", savedSingleSchedule.getScheduleContent());
+            assertEquals(LocalDate.of(2024, 7, 1), savedSingleSchedule.getScheduleDate());
+
+            verify(repeatScheduleRepository, times(1)).deleteById(2L);
+        }
+
+        @Test
+        @DisplayName("반복 일정 -> 단일 일정 변경 | 이후 이벤트 동일 O - 반복 일정 마지막 날짜")
+        public void testPutRepeatScheduleWithAfterEventSameYes_LastDate() {
+            // given
+            SingleScheduleEditRequest singleScheduleEditRequest =
+                new SingleScheduleEditRequest(
+                2L, ScheduleOriginType.REPEAT,
+                "반복 일정 마지막에 단일 일정으로 수정", "반복 일정 마지막에 단일 일정으로 수정 내용",
+                LocalDate.of(2024, 7, 15), LocalTime.of(12, 0), LocalTime.of(13, 0), null
+            );
+
+            given(studyChannelRepository.findById(1L))
+                .willReturn(Optional.of(studyChannel));
+            given(repeatScheduleRepository.findById(2L))
+                .willReturn(Optional.of(repeatDailySchedule));
+
+            // when
+            scheduleService.putRepeatScheduleWithAfterEventSame(
+                1L, true, singleScheduleEditRequest);
+
+            // then
+            ArgumentCaptor<SingleSchedule> singleCaptor =
+                ArgumentCaptor.forClass(SingleSchedule.class);
+            verify(singleScheduleRepository, times(1)).save(singleCaptor.capture());
+            SingleSchedule savedSingleSchedule = singleCaptor.getValue();
+
+            assertEquals("반복 일정 마지막에 단일 일정으로 수정", savedSingleSchedule.getScheduleName());
+            assertEquals("반복 일정 마지막에 단일 일정으로 수정 내용", savedSingleSchedule.getScheduleContent());
+            assertEquals(LocalDate.of(2024, 7, 15), savedSingleSchedule.getScheduleDate());
+            assertEquals(LocalDate.of(2024, 7, 14), repeatDailySchedule.getRepeatEndDate());
+        }
+
+        @Test
+        @DisplayName("반복 일정 -> 단일 일정 변경 | 이후 이벤트 동일 X - 반복 일정 중간 날짜")
+        public void testPutRepeatScheduleWithAfterEventSameNo_MiddleDate() {
+            // given
+            SingleScheduleEditRequest singleScheduleEditRequest =
+                new SingleScheduleEditRequest(
+                2L, ScheduleOriginType.REPEAT,
+                "반복 일정 중간에 단일 일정으로 수정", "반복 일정 중간에 단일 일정으로 수정 내용",
+                LocalDate.of(2024, 7, 6), LocalTime.of(12, 0), LocalTime.of(13, 0), null
+            );
+
+            given(studyChannelRepository.findById(1L))
+                .willReturn(Optional.of(studyChannel));
+            given(repeatScheduleRepository.findById(2L))
+                .willReturn(Optional.of(repeatDailySchedule));
+
+            // when
+            scheduleService.putRepeatScheduleWithAfterEventSame(
+                1L, false, singleScheduleEditRequest);
+
+            // then
+            ArgumentCaptor<SingleSchedule> singleCaptor =
+                ArgumentCaptor.forClass(SingleSchedule.class);
+            verify(singleScheduleRepository, times(1)).save(singleCaptor.capture());
+            SingleSchedule savedSingleSchedule = singleCaptor.getValue();
+
+            ArgumentCaptor<RepeatSchedule> repeatCaptor =
+                ArgumentCaptor.forClass(RepeatSchedule.class);
+            verify(repeatScheduleRepository, times(1)).save(repeatCaptor.capture());
+            RepeatSchedule savedRepeatSchedule = repeatCaptor.getValue();
+
+            assertEquals("반복 일정 중간에 단일 일정으로 수정", savedSingleSchedule.getScheduleName());
+            assertEquals("반복 일정 중간에 단일 일정으로 수정 내용", savedSingleSchedule.getScheduleContent());
+            assertEquals(LocalDate.of(2024, 7, 6), savedSingleSchedule.getScheduleDate());
+            assertEquals(LocalDate.of(2024, 7, 5), repeatDailySchedule.getRepeatEndDate());
+            assertEquals(LocalDate.of(2024, 7, 7), savedRepeatSchedule.getScheduleDate());
+        }
+
+        @Test
+        @DisplayName("반복 일정 -> 단일 일정 변경 | 이후 이벤트 동일 X - 반복 일정 처음 날짜")
+        public void testPutRepeatScheduleWithAfterEventSameNo_FirstDate() {
+            // given
+            SingleScheduleEditRequest singleScheduleEditRequest =
+                new SingleScheduleEditRequest(
+                2L, ScheduleOriginType.REPEAT,
+                "반복 일정 처음에 단일 일정으로 수정", "반복 일정 처음에 단일 일정으로 수정 내용",
+                LocalDate.of(2024, 7, 1), LocalTime.of(12, 0), LocalTime.of(13, 0), null
+            );
+
+            given(studyChannelRepository.findById(1L))
+                .willReturn(Optional.of(studyChannel));
+            given(repeatScheduleRepository.findById(2L))
+                .willReturn(Optional.of(repeatDailySchedule));
+
+            // when
+            scheduleService.putRepeatScheduleWithAfterEventSame(
+                1L, false, singleScheduleEditRequest);
+
+            // then
+            ArgumentCaptor<SingleSchedule> singleCaptor =
+                ArgumentCaptor.forClass(SingleSchedule.class);
+            verify(singleScheduleRepository, times(1)).save(singleCaptor.capture());
+            SingleSchedule savedSingleSchedule = singleCaptor.getValue();
+
+            assertEquals("반복 일정 처음에 단일 일정으로 수정", savedSingleSchedule.getScheduleName());
+            assertEquals("반복 일정 처음에 단일 일정으로 수정 내용", savedSingleSchedule.getScheduleContent());
+            assertEquals(LocalDate.of(2024, 7, 1), savedSingleSchedule.getScheduleDate());
+            assertEquals(LocalDate.of(2024, 7, 2), repeatDailySchedule.getScheduleDate());
+            assertEquals(LocalDate.of(2024, 7, 15), repeatDailySchedule.getRepeatEndDate());
+        }
+
+        @Test
+        @DisplayName("반복 일정 -> 단일 일정 변경 | 이후 이벤트 동일 X - 반복 일정 마지막 날짜")
+        public void testPutRepeatScheduleWithAfterEventSameNo_LastDate() {
+            // given
+            SingleScheduleEditRequest singleScheduleEditRequest =
+                new SingleScheduleEditRequest(
+                2L, ScheduleOriginType.REPEAT,
+                "반복 일정 처음에 단일 일정으로 수정", "반복 일정 처음에 단일 일정으로 수정 내용",
+                LocalDate.of(2024, 7, 15), LocalTime.of(12, 0), LocalTime.of(13, 0), null
+            );
+
+            given(studyChannelRepository.findById(1L))
+                .willReturn(Optional.of(studyChannel));
+            given(repeatScheduleRepository.findById(2L))
+                .willReturn(Optional.of(repeatDailySchedule));
+
+            // when
+            scheduleService.putRepeatScheduleWithAfterEventSame(
+                1L, false, singleScheduleEditRequest);
+
+            // then
+            ArgumentCaptor<SingleSchedule> singleCaptor =
+                ArgumentCaptor.forClass(SingleSchedule.class);
+            verify(singleScheduleRepository, times(1)).save(singleCaptor.capture());
+            SingleSchedule savedSingleSchedule = singleCaptor.getValue();
+
+            assertEquals("반복 일정 처음에 단일 일정으로 수정", savedSingleSchedule.getScheduleName());
+            assertEquals("반복 일정 처음에 단일 일정으로 수정 내용", savedSingleSchedule.getScheduleContent());
+            assertEquals(LocalDate.of(2024, 7, 15), savedSingleSchedule.getScheduleDate());
+            assertEquals(LocalDate.of(2024, 7, 14), repeatDailySchedule.getRepeatEndDate());
+        }
+
+        @Test
+        @DisplayName("반복 일정 -> 단일 일정 변경 후 이벤트 동일 여부 확인 - 범위 초과")
+        public void testPutRepeatScheduleWithAfterEventSameOutOfRange() {
+            // given
+            SingleScheduleEditRequest singleScheduleEditRequest =
+                new SingleScheduleEditRequest(
+                2L, ScheduleOriginType.REPEAT, "Single Meeting Edit", "Content for single meeting Edit",
+                LocalDate.of(2025, 1, 1), LocalTime.of(12, 0), LocalTime.of(13, 0), null
+            );
+
+            given(studyChannelRepository.findById(1L))
+                .willReturn(Optional.of(studyChannel));
+            given(repeatScheduleRepository.findById(2L))
+                .willReturn(Optional.of(repeatDailySchedule));
+
+            // when & then
+            assertThrows(OutRangeScheduleException.class, () -> {
+              scheduleService.putRepeatScheduleWithAfterEventSame(1L, true, singleScheduleEditRequest);
+            });
+        }
     }
-
-    @Test
-    @DisplayName("반복 일정 -> 단일 일정 변경 | 이후 이벤트 동일 X - 반복 일정 중간 날짜")
-    public void testPutRepeatScheduleWithAfterEventSameNo_MiddleDate() {
-      // given
-      SingleScheduleEditRequest singleScheduleEditRequest = new SingleScheduleEditRequest(
-          2L, ScheduleOriginType.REPEAT,
-          "반복 일정 중간에 단일 일정으로 수정", "반복 일정 중간에 단일 일정으로 수정 내용",
-          LocalDate.of(2024, 7, 6), LocalTime.of(12, 0), LocalTime.of(13, 0), null
-      );
-
-      given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
-      given(repeatScheduleRepository.findById(2L)).willReturn(Optional.of(repeatDailySchedule));
-
-      // when
-      scheduleService.putRepeatScheduleWithAfterEventSame(1L, false, singleScheduleEditRequest);
-
-      // then
-      ArgumentCaptor<SingleSchedule> singleCaptor = ArgumentCaptor.forClass(SingleSchedule.class);
-      verify(singleScheduleRepository, times(1)).save(singleCaptor.capture());
-      SingleSchedule savedSingleSchedule = singleCaptor.getValue();
-
-      ArgumentCaptor<RepeatSchedule> repeatCaptor = ArgumentCaptor.forClass(RepeatSchedule.class);
-      verify(repeatScheduleRepository, times(1)).save(repeatCaptor.capture());
-      RepeatSchedule savedRepeatSchedule = repeatCaptor.getValue();
-
-      assertEquals("반복 일정 중간에 단일 일정으로 수정", savedSingleSchedule.getScheduleName());
-      assertEquals("반복 일정 중간에 단일 일정으로 수정 내용", savedSingleSchedule.getScheduleContent());
-      assertEquals(LocalDate.of(2024, 7, 6), savedSingleSchedule.getScheduleDate());
-      assertEquals(LocalDate.of(2024, 7, 5), repeatDailySchedule.getRepeatEndDate());
-      assertEquals(LocalDate.of(2024, 7, 7), savedRepeatSchedule.getScheduleDate());
-    }
-
-    @Test
-    @DisplayName("반복 일정 -> 단일 일정 변경 | 이후 이벤트 동일 X - 반복 일정 처음 날짜")
-    public void testPutRepeatScheduleWithAfterEventSameNo_FirstDate() {
-      // given
-      SingleScheduleEditRequest singleScheduleEditRequest = new SingleScheduleEditRequest(
-          2L, ScheduleOriginType.REPEAT,
-          "반복 일정 처음에 단일 일정으로 수정", "반복 일정 처음에 단일 일정으로 수정 내용",
-          LocalDate.of(2024, 7, 1), LocalTime.of(12, 0), LocalTime.of(13, 0), null
-      );
-
-      given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
-      given(repeatScheduleRepository.findById(2L)).willReturn(Optional.of(repeatDailySchedule));
-
-      // when
-      scheduleService.putRepeatScheduleWithAfterEventSame(1L, false, singleScheduleEditRequest);
-
-      // then
-      ArgumentCaptor<SingleSchedule> singleCaptor = ArgumentCaptor.forClass(SingleSchedule.class);
-      verify(singleScheduleRepository, times(1)).save(singleCaptor.capture());
-      SingleSchedule savedSingleSchedule = singleCaptor.getValue();
-
-      assertEquals("반복 일정 처음에 단일 일정으로 수정", savedSingleSchedule.getScheduleName());
-      assertEquals("반복 일정 처음에 단일 일정으로 수정 내용", savedSingleSchedule.getScheduleContent());
-      assertEquals(LocalDate.of(2024, 7, 1), savedSingleSchedule.getScheduleDate());
-      assertEquals(LocalDate.of(2024, 7, 2), repeatDailySchedule.getScheduleDate());
-      assertEquals(LocalDate.of(2024, 7, 15), repeatDailySchedule.getRepeatEndDate());
-    }
-
-    @Test
-    @DisplayName("반복 일정 -> 단일 일정 변경 | 이후 이벤트 동일 X - 반복 일정 마지막 날짜")
-    public void testPutRepeatScheduleWithAfterEventSameNo_LastDate() {
-      // given
-      SingleScheduleEditRequest singleScheduleEditRequest = new SingleScheduleEditRequest(
-          2L, ScheduleOriginType.REPEAT,
-          "반복 일정 처음에 단일 일정으로 수정", "반복 일정 처음에 단일 일정으로 수정 내용",
-          LocalDate.of(2024, 7, 15), LocalTime.of(12, 0), LocalTime.of(13, 0), null
-      );
-
-      given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
-      given(repeatScheduleRepository.findById(2L)).willReturn(Optional.of(repeatDailySchedule));
-
-      // when
-      scheduleService.putRepeatScheduleWithAfterEventSame(1L, false, singleScheduleEditRequest);
-
-      // then
-      ArgumentCaptor<SingleSchedule> singleCaptor = ArgumentCaptor.forClass(SingleSchedule.class);
-      verify(singleScheduleRepository, times(1)).save(singleCaptor.capture());
-      SingleSchedule savedSingleSchedule = singleCaptor.getValue();
-
-      assertEquals("반복 일정 처음에 단일 일정으로 수정", savedSingleSchedule.getScheduleName());
-      assertEquals("반복 일정 처음에 단일 일정으로 수정 내용", savedSingleSchedule.getScheduleContent());
-      assertEquals(LocalDate.of(2024, 7, 15), savedSingleSchedule.getScheduleDate());
-      assertEquals(LocalDate.of(2024, 7, 14), repeatDailySchedule.getRepeatEndDate());
-    }
-
-    @Test
-    @DisplayName("반복 일정 -> 단일 일정 변경 후 이벤트 동일 여부 확인 - 범위 초과")
-    public void testPutRepeatScheduleWithAfterEventSameOutOfRange() {
-      // given
-      SingleScheduleEditRequest singleScheduleEditRequest = new SingleScheduleEditRequest(
-          2L, ScheduleOriginType.REPEAT, "Single Meeting Edit", "Content for single meeting Edit",
-          LocalDate.of(2025, 1, 1), LocalTime.of(12, 0), LocalTime.of(13, 0), null
-      );
-
-      given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
-      given(repeatScheduleRepository.findById(2L)).willReturn(Optional.of(repeatDailySchedule));
-
-      // when & then
-      assertThrows(OutRangeScheduleException.class, () -> {
-        scheduleService.putRepeatScheduleWithAfterEventSame(1L, true, singleScheduleEditRequest);
-      });
-    }
-
-  }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
- 단일 일정 삭제
- 반복 일정 삭제
    - 이후 이벤트 동일하게 O
    - 이후 이벤트 동일하게 X


## 반복 일정 삭제: 이후 이벤트 동일하게 X

- 처음/ 마지막 날짜일 경우
    - 기존 일정 (시작 or 마감)날짜만 변경
- 중간일 경우
    - 반복 일정1> 기존 저장한 마감날짜 수정
    - 반복 일정2> 삭제한 중간 날짜 이후부터 시작 날짜 ~ 기존 마감 날짜
        

##  반복 일정 삭제: 이후 이벤트 동일하게 O

- 첫날 일 경우
    - 반복 일정 아예 삭제
- 중간 날짜/ 마지막 날짜 일 경우
    - 기존 반복 일정의 반복 마감 일정만 변경


***현재 토큰 없이도 일정 등록, 수정, 삭제가 가능합니다. 확인하고 다시 제 쪽에서 수정해야할 문제가 있으면 추가하겠습니다.***

***그 밖에 스터디 리더만 일정 등록, 수정, 삭제가 가능한 부분, Principal 관련 코드는 추후 차주 refactoring에 추가하겠습니다.***

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
- [X] API 테스트 