### PR TITLE
feat: STD-21 스터디 참가 신청자 목록 조회 기능

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -34,10 +35,9 @@ public class SecurityConfig {
 
         return http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests( requests -> requests
-                        .requestMatchers("/api/members/sign-up", "/api/members/auth/**", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/api/members/login/**").permitAll()
-                        .requestMatchers("/api/study-channels/**", "/error", "/api/participation/**").permitAll()
-                .requestMatchers("/api/members/logout", "api/study-channels/*/places",
-                    "/api/study-channels/*/schedules", "/api/token/re-issue").hasRole("USER"))
+                        .requestMatchers("/api/members/sign-up", "/api/members/auth/**", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/api/members/login/**", "/error").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/study-channels").permitAll()
+                        .requestMatchers("/api/members/logout", "api/study-channels/*/places", "/api/study-channels/**", "/api/token/re-issue").hasRole("USER"))
 
 
                 .headers(headers -> headers // h2-console 페이지 접속을 위한 설정

--- a/src/main/java/com/tenten/studybadge/common/exception/studychannel/NotStudyLeaderException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/studychannel/NotStudyLeaderException.java
@@ -1,0 +1,28 @@
+package com.tenten.studybadge.common.exception.studychannel;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class NotStudyLeaderException extends AbstractException {
+
+    private static final String ERROR_CODE = "NOT_STUDY_LEADER";
+    private static final String ERROR_MESSAGE = "해당 작업은 스터디 리더만 가능합니다.";
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return BAD_REQUEST;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public String getMessage() {
+        return ERROR_MESSAGE;
+    }
+
+}

--- a/src/main/java/com/tenten/studybadge/participation/ParticipantResponse.java
+++ b/src/main/java/com/tenten/studybadge/participation/ParticipantResponse.java
@@ -1,0 +1,18 @@
+package com.tenten.studybadge.participation;
+
+import com.tenten.studybadge.type.member.BadgeLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ParticipantResponse {
+    private Long memberId;
+    private String imageUrl;
+    private String name;
+    private int banCnt;
+    private BadgeLevel badgeLevel;
+    private Long participationId;
+}

--- a/src/main/java/com/tenten/studybadge/participation/controller/StudyChannelParticipationController.java
+++ b/src/main/java/com/tenten/studybadge/participation/controller/StudyChannelParticipationController.java
@@ -24,18 +24,20 @@ public class StudyChannelParticipationController {
     @PostMapping("/api/study-channels/{studyChannelId}/participation")
     @Operation(summary = "스터디 채널 참가 신청", description = "특정 스터디 채널에 참가 신청을 하는 기능", security = @SecurityRequirement(name = "bearerToken"))
     @Parameter(name = "studyChannelId", description = "참가 신청을 할 스터디 채널 ID", required = true)
-    public ResponseEntity<Void> applyParticipation(@PathVariable("studyChannelId") Long studyChannelId) {
-        Long memberId = 1L;
-        studyChannelParticipationService.apply(studyChannelId, memberId);
+    public ResponseEntity<Void> applyParticipation(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable("studyChannelId") Long studyChannelId) {
+        studyChannelParticipationService.apply(studyChannelId, principal.getId());
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/api/participation/{participationId}")
     @Operation(summary = "참가 신청 취소", description = "참가 신청을 취소하는 기능", security = @SecurityRequirement(name = "BearerToken"))
     @Parameter(name = "participationId", description = "참가 신청 ID", required = true)
-    public ResponseEntity<Void> cancelParticipation(@PathVariable("participationId") Long participationId) {
-        Long memberId = 1L;
-        studyChannelParticipationService.cancel(participationId, memberId);
+    public ResponseEntity<Void> cancelParticipation(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable("participationId") Long participationId) {
+        studyChannelParticipationService.cancel(participationId, principal.getId());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/tenten/studybadge/participation/controller/StudyChannelParticipationController.java
+++ b/src/main/java/com/tenten/studybadge/participation/controller/StudyChannelParticipationController.java
@@ -1,5 +1,6 @@
 package com.tenten.studybadge.participation.controller;
 
+import com.tenten.studybadge.common.security.CustomUserDetails;
 import com.tenten.studybadge.participation.ParticipantResponse;
 import com.tenten.studybadge.participation.service.StudyChannelParticipationService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -42,10 +44,10 @@ public class StudyChannelParticipationController {
     @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
     @Parameter(name = "participationId", description = "참가 신청 ID", required = true)
     public ResponseEntity<Void> approveParticipation(
+            @AuthenticationPrincipal CustomUserDetails principal,
             @PathVariable("studyChannelId") Long studyChannelId,
             @PathVariable("participationId") Long participationId) {
-        Long memberId = 2L;
-        studyChannelParticipationService.approve(studyChannelId, participationId, memberId);
+        studyChannelParticipationService.approve(studyChannelId, participationId, principal.getId());
         return ResponseEntity.ok().build();
     }
 
@@ -54,18 +56,19 @@ public class StudyChannelParticipationController {
     @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
     @Parameter(name = "participationId", description = "참가 신청 ID", required = true)
     public ResponseEntity<Void> rejectParticipation(
+            @AuthenticationPrincipal CustomUserDetails principal,
             @PathVariable("studyChannelId") Long studyChannelId,
             @PathVariable("participationId") Long participationId) {
-        Long memberId = 2L;
-        studyChannelParticipationService.reject(studyChannelId, participationId, memberId);
+        studyChannelParticipationService.reject(studyChannelId, participationId, principal.getId());
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/api/study-channels/{studyChannelId}/participants")
     @Operation(summary = "참가 신청자 조회", description = "특정 스터디 채널의 참가 신청자를 조회하는 기능", security = @SecurityRequirement(name = "BearerToken"))
     @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
-    public ResponseEntity<List<ParticipantResponse>> getParticipants(@PathVariable Long studyChannelId) {
-        Long memberId = 1L;
-        return ResponseEntity.ok(studyChannelParticipationService.getParticipants(studyChannelId, memberId));
+    public ResponseEntity<List<ParticipantResponse>> getParticipants(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable Long studyChannelId) {
+        return ResponseEntity.ok(studyChannelParticipationService.getParticipants(studyChannelId, principal.getId()));
     }
 }

--- a/src/main/java/com/tenten/studybadge/participation/controller/StudyChannelParticipationController.java
+++ b/src/main/java/com/tenten/studybadge/participation/controller/StudyChannelParticipationController.java
@@ -1,5 +1,6 @@
 package com.tenten.studybadge.participation.controller;
 
+import com.tenten.studybadge.participation.ParticipantResponse;
 import com.tenten.studybadge.participation.service.StudyChannelParticipationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -7,10 +8,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -61,4 +61,11 @@ public class StudyChannelParticipationController {
         return ResponseEntity.ok().build();
     }
 
+    @GetMapping("/api/study-channels/{studyChannelId}/participants")
+    @Operation(summary = "참가 신청자 조회", description = "특정 스터디 채널의 참가 신청자를 조회하는 기능", security = @SecurityRequirement(name = "BearerToken"))
+    @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
+    public ResponseEntity<List<ParticipantResponse>> getParticipants(@PathVariable Long studyChannelId) {
+        Long memberId = 1L;
+        return ResponseEntity.ok(studyChannelParticipationService.getParticipants(studyChannelId, memberId));
+    }
 }

--- a/src/main/java/com/tenten/studybadge/participation/controller/StudyChannelParticipationController.java
+++ b/src/main/java/com/tenten/studybadge/participation/controller/StudyChannelParticipationController.java
@@ -16,12 +16,13 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 @Tag(name = "Study Channel Participation API", description = "스터디 채널 참가 신청에 대한 신청, 취소, 승인, 거절할 수 있는 API")
 public class StudyChannelParticipationController {
 
     private final StudyChannelParticipationService studyChannelParticipationService;
 
-    @PostMapping("/api/study-channels/{studyChannelId}/participation")
+    @PostMapping("/study-channels/{studyChannelId}/participation")
     @Operation(summary = "스터디 채널 참가 신청", description = "특정 스터디 채널에 참가 신청을 하는 기능", security = @SecurityRequirement(name = "bearerToken"))
     @Parameter(name = "studyChannelId", description = "참가 신청을 할 스터디 채널 ID", required = true)
     public ResponseEntity<Void> applyParticipation(
@@ -31,7 +32,7 @@ public class StudyChannelParticipationController {
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping("/api/participation/{participationId}")
+    @DeleteMapping("/participation/{participationId}")
     @Operation(summary = "참가 신청 취소", description = "참가 신청을 취소하는 기능", security = @SecurityRequirement(name = "BearerToken"))
     @Parameter(name = "participationId", description = "참가 신청 ID", required = true)
     public ResponseEntity<Void> cancelParticipation(
@@ -41,7 +42,7 @@ public class StudyChannelParticipationController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/api/study-channels/{studyChannelId}/participation/{participationId}/approve")
+    @PostMapping("/study-channels/{studyChannelId}/participation/{participationId}/approve")
     @Operation(summary = "참가 신청 승인", description = "참가 신청을 승인하는 기능", security = @SecurityRequirement(name = "BearerToken"))
     @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
     @Parameter(name = "participationId", description = "참가 신청 ID", required = true)
@@ -53,7 +54,7 @@ public class StudyChannelParticipationController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/api/study-channels/{studyChannelId}/participation/{participationId}/reject")
+    @PostMapping("/study-channels/{studyChannelId}/participation/{participationId}/reject")
     @Operation(summary = "참가 신청 거절", description = "참가 신청을 거절하는 기능", security = @SecurityRequirement(name = "BearerToken"))
     @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
     @Parameter(name = "participationId", description = "참가 신청 ID", required = true)
@@ -65,7 +66,7 @@ public class StudyChannelParticipationController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/api/study-channels/{studyChannelId}/participants")
+    @GetMapping("/study-channels/{studyChannelId}/participants")
     @Operation(summary = "참가 신청자 조회", description = "특정 스터디 채널의 참가 신청자를 조회하는 기능", security = @SecurityRequirement(name = "BearerToken"))
     @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
     public ResponseEntity<List<ParticipantResponse>> getParticipants(

--- a/src/main/java/com/tenten/studybadge/participation/domain/entity/Participation.java
+++ b/src/main/java/com/tenten/studybadge/participation/domain/entity/Participation.java
@@ -2,6 +2,7 @@ package com.tenten.studybadge.participation.domain.entity;
 
 import com.tenten.studybadge.common.BaseEntity;
 import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.participation.ParticipantResponse;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
 import com.tenten.studybadge.type.participation.ParticipationStatus;
 import jakarta.persistence.*;
@@ -53,5 +54,16 @@ public class Participation extends BaseEntity {
 
     public void reject() {
         this.participationStatus = ParticipationStatus.REJECTED;
+    }
+
+    public ParticipantResponse toResponse() {
+        return ParticipantResponse.builder()
+                .participationId(this.id)
+                .banCnt(this.member.getBanCnt())
+                .memberId(this.member.getId())
+                .imageUrl(this.member.getImgUrl())
+                .name(this.member.getName())
+                .badgeLevel(this.member.getBadgeLevel())
+                .build();
     }
 }

--- a/src/main/java/com/tenten/studybadge/participation/domain/repository/ParticipationRepository.java
+++ b/src/main/java/com/tenten/studybadge/participation/domain/repository/ParticipationRepository.java
@@ -2,9 +2,17 @@ package com.tenten.studybadge.participation.domain.repository;
 
 import com.tenten.studybadge.participation.domain.entity.Participation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface ParticipationRepository extends JpaRepository<Participation, Long> {
 
     boolean existsByMemberIdAndStudyChannelId(Long memberId, Long studyChannelId);
 
+    @Query("SELECT p FROM Participation p " +
+            "JOIN p.member " +
+            "JOIN p.studyChannel " +
+            "WHERE p.studyChannel.id = :studyChannelId")
+    List<Participation> findByStudyChannelIdWithMember(Long studyChannelId);
 }

--- a/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
+++ b/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
@@ -110,7 +110,7 @@ public class StudyChannelParticipationService {
 
         Member member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
         StudyChannel studyChannel = studyChannelRepository.findById(studyChannelId).orElseThrow(NotFoundStudyChannelException::new);
-        if (studyChannel.isLeader(member)) {
+        if (!studyChannel.isLeader(member)) {
             throw new NotStudyLeaderException();
         }
         List<Participation> participationList = participationRepository.findByStudyChannelIdWithMember(studyChannelId);

--- a/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
+++ b/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
@@ -4,9 +4,11 @@ import com.tenten.studybadge.common.exception.member.NotFoundMemberException;
 import com.tenten.studybadge.common.exception.participation.*;
 import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelException;
 import com.tenten.studybadge.common.exception.studychannel.AlreadyStudyMemberException;
+import com.tenten.studybadge.common.exception.studychannel.NotStudyLeaderException;
 import com.tenten.studybadge.common.exception.studychannel.RecruitmentCompletedStudyChannelException;
 import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.member.domain.repository.MemberRepository;
+import com.tenten.studybadge.participation.ParticipantResponse;
 import com.tenten.studybadge.participation.domain.entity.Participation;
 import com.tenten.studybadge.participation.domain.repository.ParticipationRepository;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
@@ -15,6 +17,8 @@ import com.tenten.studybadge.type.participation.ParticipationStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -102,4 +106,16 @@ public class StudyChannelParticipationService {
         participationRepository.save(participation);
     }
 
+    public List<ParticipantResponse> getParticipants(Long studyChannelId, Long memberId) {
+
+        Member member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
+        StudyChannel studyChannel = studyChannelRepository.findById(studyChannelId).orElseThrow(NotFoundStudyChannelException::new);
+        if (studyChannel.isLeader(member)) {
+            throw new NotStudyLeaderException();
+        }
+        List<Participation> participationList = participationRepository.findByStudyChannelIdWithMember(studyChannelId);
+        return participationList.stream()
+                .map(Participation::toResponse)
+                .toList();
+    }
 }

--- a/src/main/java/com/tenten/studybadge/study/channel/controller/StudyChannelController.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/controller/StudyChannelController.java
@@ -1,5 +1,6 @@
 package com.tenten.studybadge.study.channel.controller;
 
+import com.tenten.studybadge.common.security.CustomUserDetails;
 import com.tenten.studybadge.study.channel.dto.StudyChannelCreateRequest;
 import com.tenten.studybadge.study.channel.service.StudyChannelService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,10 +27,10 @@ public class StudyChannelController {
     @PostMapping("/api/study-channels")
     @Operation(summary = "스터디 채널을 생성", description = "스터디 채널을 만들기 위해 사용되는 API", security = @SecurityRequirement(name = "bearerToken"))
     @Parameter(name = "request", description = "스터디 채널을 생성하기 위해 필요한 정보", required = true)
-    public ResponseEntity<Void> createStudyChannel(@RequestBody @Valid StudyChannelCreateRequest request) {
-        // TODO 추후 로그인 기능 완료되면 파라미터로 memberId 를 받아오는 것으로 변경해야 함.
-        Long memberId = 1L;
-        Long studyChannelId = studyChannelService.create(request, memberId);
+    public ResponseEntity<Void> createStudyChannel(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @RequestBody @Valid StudyChannelCreateRequest request) {
+        Long studyChannelId = studyChannelService.create(request, principal.getId());
         return ResponseEntity
                 .created(URI.create("/api/study-channels/" + studyChannelId))
                 .build();

--- a/src/main/java/com/tenten/studybadge/study/channel/controller/StudyChannelController.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/controller/StudyChannelController.java
@@ -13,18 +13,20 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 @Tag(name = "Study Channel API", description = "스터디 채널과 관련된 생성, 수정, 삭제 기능을 제공하는 API")
 public class StudyChannelController {
 
     private final StudyChannelService studyChannelService;
 
-    @PostMapping("/api/study-channels")
+    @PostMapping("/study-channels")
     @Operation(summary = "스터디 채널을 생성", description = "스터디 채널을 만들기 위해 사용되는 API", security = @SecurityRequirement(name = "bearerToken"))
     @Parameter(name = "request", description = "스터디 채널을 생성하기 위해 필요한 정보", required = true)
     public ResponseEntity<Void> createStudyChannel(

--- a/src/test/java/com/tenten/studybadge/study/channel/service/StudyChannelServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/study/channel/service/StudyChannelServiceTest.java
@@ -57,11 +57,12 @@ class StudyChannelServiceTest {
         void success_createStudyChannel() {
 
             // given
+            LocalDate now = LocalDate.now();
             StudyChannelCreateRequest request = StudyChannelCreateRequest.builder()
                     .name("스터디명")
                     .description("스터디 설명")
-                    .startDate(LocalDate.of(2024, 7, 10))
-                    .endDate(LocalDate.of(2024, 7, 20))
+                    .startDate(now.plusDays(3))
+                    .endDate(now.plusMonths(3))
                     .recruitmentNumber(8)
                     .minRecruitmentNumber(4)
                     .category(Category.IT)


### PR DESCRIPTION
### 변경사항
**AS-IS**
* 이전 기능(스터디 채널 생성, 참가 신청 관련 기능) 에서 내부적으로 memberId = 1L 같이 값을 만들어서 구현.
* 테스트 코드 내 특정 날짜를 지정
* SecurityConfig에 경로 설정할 때 저 상세한 주소가 뒤에 작성.

**TO-BE**
* Security 작업이 완료되어서 @AuthenticationPrincipal을 통해 memberId를 가져오도록 수정했습니다!
* 테스트 코드에서 특정 날짜를 기준으로 구현할 경우 테스트를 돌리는 날짜에 따라 오류가 발생했습니다. 따라서
  현재 시간을 기준으로 plus 해서 날짜 관련 오류가 발생하지 않도록 했습니다.
* SecurityConfig에서 경로에 대한 허가 및 권한을 설정할 때 상세한 주소를 먼저 작성해야 해서 해당 부분을 수정

[구현한 기능]
* 특정 스터디 채널에 참가 신청을 한 참가 신청자들에 대한 조회 기능을 구현.
* 스터디 리더가 아닐 경우 신청자들을 조회할 수 없도록 했습니다.
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 