### PR TITLE
feat: STD-22 특정 스터디 채널 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
@@ -35,8 +35,8 @@ public class SecurityConfig {
 
         return http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests( requests -> requests
-                        .requestMatchers("/api/members/sign-up", "/api/members/auth/", "/h2-console/", "/swagger-ui/", "/v3/api-docs/", "/api/members/login/", "/error", "/health-check").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/study-channels/**").permitAll()
+                        .requestMatchers("/api/members/sign-up", "/api/members/auth/**", "/h2-console/**", "/swagger-ui/", "/v3/api-docs/**", "/api/members/login/**", "/error", "/health-check").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/study-channels", "/api/study-channels/{studyChannelId:\\d+}").permitAll()
                         .requestMatchers("/api/members/logout", "api/study-channels/*/places", "/api/study-channels/**", "/api/token/re-issue").hasRole("USER"))
 
                 .cors(cors -> new CorsConfig())

--- a/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
 
         return http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests( requests -> requests
-                        .requestMatchers("/api/members/sign-up", "/api/members/auth/**", "/h2-console/**", "/swagger-ui/", "/v3/api-docs/**", "/api/members/login/**", "/error", "/health-check").permitAll()
+                        .requestMatchers("/api/members/sign-up", "/api/members/auth/**", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/api/members/login/**", "/error", "/health-check").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/study-channels", "/api/study-channels/{studyChannelId:\\d+}").permitAll()
                         .requestMatchers("/api/members/logout", "api/study-channels/*/places", "/api/study-channels/**", "/api/token/re-issue").hasRole("USER"))
 

--- a/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
@@ -35,12 +35,9 @@ public class SecurityConfig {
 
         return http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests( requests -> requests
-                        .requestMatchers("/api/members/sign-up", "/api/members/auth/**", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**",
-                            "/api/members/login/**", "/health-check").permitAll()
-                        .requestMatchers("/api/study-channels/**", "/error", "/api/participation/**").permitAll()
-                .requestMatchers("/api/members/logout", "api/study-channels/*/places",
-                    "/api/study-channels/*/schedules", "/api/token/re-issue").hasRole("USER"))
-
+                        .requestMatchers("/api/members/sign-up", "/api/members/auth/", "/h2-console/", "/swagger-ui/", "/v3/api-docs/", "/api/members/login/", "/error", "/health-check").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/study-channels/**").permitAll()
+                        .requestMatchers("/api/members/logout", "api/study-channels/*/places", "/api/study-channels/**", "/api/token/re-issue").hasRole("USER"))
 
                 .cors(cors -> new CorsConfig())
                 .headers(headers -> headers // h2-console 페이지 접속을 위한 설정

--- a/src/main/java/com/tenten/studybadge/study/channel/controller/StudyChannelController.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/controller/StudyChannelController.java
@@ -4,6 +4,7 @@ import com.tenten.studybadge.common.security.CustomUserDetails;
 import com.tenten.studybadge.common.utils.PagingUtils;
 import com.tenten.studybadge.study.channel.dto.SearchCondition;
 import com.tenten.studybadge.study.channel.dto.StudyChannelCreateRequest;
+import com.tenten.studybadge.study.channel.dto.StudyChannelDetailsResponse;
 import com.tenten.studybadge.study.channel.dto.StudyChannelListResponse;
 import com.tenten.studybadge.study.channel.service.StudyChannelService;
 import com.tenten.studybadge.type.study.channel.Category;
@@ -60,6 +61,17 @@ public class StudyChannelController {
         @RequestParam(name = "category", required = false) Category category
     ) {
         return ResponseEntity.ok(studyChannelService.getStudyChannels(PagingUtils.createPageable(page, size, sortOrder), new SearchCondition(type, status, category)));
+    }
+
+    // 회원이 아닌 사람의 경우 로그인하라고 유도
+    @GetMapping("/study-channels/{studyChannelId}")
+    @Operation(summary = "특정 스터디 채널 조회", description = "특정 스터디 채널을 조회하기 위한 API")
+    @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
+    public ResponseEntity<StudyChannelDetailsResponse> getStudyChannel(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable Long studyChannelId
+    ) {
+        return ResponseEntity.ok(studyChannelService.getStudyChannel(studyChannelId, principal.getId()));
     }
 
 }

--- a/src/main/java/com/tenten/studybadge/study/channel/controller/StudyChannelController.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/controller/StudyChannelController.java
@@ -71,7 +71,7 @@ public class StudyChannelController {
             @AuthenticationPrincipal CustomUserDetails principal,
             @PathVariable Long studyChannelId
     ) {
-        return ResponseEntity.ok(studyChannelService.getStudyChannel(studyChannelId, principal.getId()));
+        return ResponseEntity.ok(studyChannelService.getStudyChannel(studyChannelId, principal == null ? null : principal.getId()));
     }
 
 }

--- a/src/main/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannel.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannel.java
@@ -102,7 +102,7 @@ public class StudyChannel extends BaseEntity {
                 .leaderName(leader.getMember().getName())
                 .subLeaderName(Objects.requireNonNullElse(subLeader, leader).getMember().getName());
 
-        if (isStudyMember(member.getId())) {
+        if (member != null && isStudyMember(member.getId())) {
             builder.chattingUrl(this.chattingUrl);
         }
 

--- a/src/main/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannel.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannel.java
@@ -2,6 +2,7 @@ package com.tenten.studybadge.study.channel.domain.entity;
 
 import com.tenten.studybadge.common.BaseEntity;
 import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.study.channel.dto.StudyChannelDetailsResponse;
 import com.tenten.studybadge.study.member.domain.entity.StudyMember;
 import com.tenten.studybadge.type.study.channel.Category;
 import com.tenten.studybadge.type.study.channel.MeetingType;
@@ -11,6 +12,7 @@ import lombok.*;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @Entity
@@ -70,6 +72,44 @@ public class StudyChannel extends BaseEntity {
     public void addMember(Member member) {
         StudyMember studyMember = StudyMember.member(member, this);
         studyMembers.add(studyMember);
+    }
+
+    private StudyMember getLeader() {
+        return studyMembers.stream()
+                .filter(StudyMember::isLeader)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private StudyMember getSubLeader() {
+        return studyMembers.stream()
+                .filter(StudyMember::isSubLeader)
+                .findFirst()
+                .orElse(null);
+    }
+
+    public StudyChannelDetailsResponse toResponse(Member member) {
+        StudyMember leader = getLeader();
+        StudyMember subLeader = getSubLeader();
+        StudyChannelDetailsResponse.StudyChannelDetailsResponseBuilder builder = StudyChannelDetailsResponse.builder()
+                .studyChannelId(this.id)
+                .studyChannelName(this.name)
+                .studyChannelDescription(this.description)
+                .deposit(this.deposit)
+                .category(this.category)
+                .meetingType(this.meetingType)
+                .region(this.region)
+                .startDate(this.studyDuration.getStudyStartDate())
+                .endDate(this.studyDuration.getStudyEndDate())
+                .capacity(this.recruitment.getRecruitmentNumber())
+                .leaderName(leader.getMember().getName())
+                .subLeaderName(Objects.requireNonNullElse(subLeader, leader).getMember().getName());
+
+        if (isStudyMember(member.getId())) {
+            builder.chattingUrl(this.chattingUrl);
+        }
+
+        return builder.build();
     }
 
 }

--- a/src/main/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannel.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannel.java
@@ -63,10 +63,7 @@ public class StudyChannel extends BaseEntity {
 
     public boolean isLeader(Member member) {
         return studyMembers.stream()
-                .filter(studyMember -> studyMember.getMember().equals(member))
-                .findFirst()
-                .map(StudyMember::isLeader)
-                .orElse(false);
+                .anyMatch(studyMember -> studyMember.getMember().getId().equals(member.getId()) && studyMember.isLeader());
     }
 
     public void addMember(Member member) {

--- a/src/main/java/com/tenten/studybadge/study/channel/domain/repository/StudyChannelRepository.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/domain/repository/StudyChannelRepository.java
@@ -3,6 +3,16 @@ package com.tenten.studybadge.study.channel.domain.repository;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface StudyChannelRepository extends JpaRepository<StudyChannel, Long>, JpaSpecificationExecutor<StudyChannel> {
+
+    @Query("select sc from StudyChannel sc " +
+            "join fetch sc.studyMembers sm " +
+            "join fetch sm.member m " +
+            "where sc.id = :studyChannelId")
+    Optional<StudyChannel> findByIdWithMember(Long studyChannelId);
+
 }

--- a/src/main/java/com/tenten/studybadge/study/channel/dto/StudyChannelDetailsResponse.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/dto/StudyChannelDetailsResponse.java
@@ -1,0 +1,30 @@
+package com.tenten.studybadge.study.channel.dto;
+
+import com.tenten.studybadge.type.study.channel.Category;
+import com.tenten.studybadge.type.study.channel.MeetingType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class StudyChannelDetailsResponse {
+
+    private Long studyChannelId;
+    private String studyChannelName;
+    private String studyChannelDescription;
+    private String chattingUrl;
+    private int capacity;
+    private Category category;
+    private MeetingType meetingType;
+    private String region;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private int deposit;
+    private String leaderName;
+    private String subLeaderName;
+
+}

--- a/src/main/java/com/tenten/studybadge/study/channel/service/StudyChannelService.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/service/StudyChannelService.java
@@ -2,12 +2,14 @@ package com.tenten.studybadge.study.channel.service;
 
 import com.tenten.studybadge.common.exception.member.NotFoundMemberException;
 import com.tenten.studybadge.common.exception.studychannel.InvalidStudyStartDateException;
+import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelException;
 import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.member.domain.repository.MemberRepository;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
 import com.tenten.studybadge.study.channel.domain.repository.StudyChannelRepository;
 import com.tenten.studybadge.study.channel.dto.SearchCondition;
 import com.tenten.studybadge.study.channel.dto.StudyChannelCreateRequest;
+import com.tenten.studybadge.study.channel.dto.StudyChannelDetailsResponse;
 import com.tenten.studybadge.study.channel.dto.StudyChannelListResponse;
 import com.tenten.studybadge.study.member.domain.entity.StudyMember;
 import com.tenten.studybadge.study.member.domain.repository.StudyMemberRepository;
@@ -78,6 +80,12 @@ public class StudyChannelService {
                 .collect(Collectors.toMap(studyMember -> studyMember.getStudyChannel().getId(), Function.identity()));
 
         return StudyChannelListResponse.from(studyChannels, leaderMap);
+    }
+
+    public StudyChannelDetailsResponse getStudyChannel(Long studyChannelId, Long memberId) {
+        StudyChannel studyChannel = studyChannelRepository.findByIdWithMember(studyChannelId).orElseThrow(NotFoundStudyChannelException::new);
+        Member member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
+        return studyChannel.toResponse(member);
     }
 
     public static class StudyChannelSpecification {

--- a/src/main/java/com/tenten/studybadge/study/channel/service/StudyChannelService.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/service/StudyChannelService.java
@@ -14,6 +14,7 @@ import com.tenten.studybadge.study.channel.dto.StudyChannelListResponse;
 import com.tenten.studybadge.study.member.domain.entity.StudyMember;
 import com.tenten.studybadge.study.member.domain.repository.StudyMemberRepository;
 import com.tenten.studybadge.type.study.member.StudyMemberRole;
+import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -82,9 +83,12 @@ public class StudyChannelService {
         return StudyChannelListResponse.from(studyChannels, leaderMap);
     }
 
-    public StudyChannelDetailsResponse getStudyChannel(Long studyChannelId, Long memberId) {
+    public StudyChannelDetailsResponse getStudyChannel(Long studyChannelId, @Nullable Long memberId) {
         StudyChannel studyChannel = studyChannelRepository.findByIdWithMember(studyChannelId).orElseThrow(NotFoundStudyChannelException::new);
-        Member member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
+        Member member = null;
+        if (memberId != null) {
+            member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
+        }
         return studyChannel.toResponse(member);
     }
 

--- a/src/main/java/com/tenten/studybadge/study/member/domain/entity/StudyMember.java
+++ b/src/main/java/com/tenten/studybadge/study/member/domain/entity/StudyMember.java
@@ -7,8 +7,7 @@ import com.tenten.studybadge.type.study.member.StudyMemberRole;
 import jakarta.persistence.*;
 import lombok.*;
 
-import static com.tenten.studybadge.type.study.member.StudyMemberRole.LEADER;
-import static com.tenten.studybadge.type.study.member.StudyMemberRole.STUDY_MEMBER;
+import static com.tenten.studybadge.type.study.member.StudyMemberRole.*;
 import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
@@ -55,6 +54,10 @@ public class StudyMember extends BaseEntity {
 
     public boolean isLeader() {
         return this.studyMemberRole.equals(LEADER);
+    }
+
+    public boolean isSubLeader() {
+        return this.studyMemberRole.equals(SUB_LEADER);
     }
 
 }

--- a/src/test/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannelTest.java
+++ b/src/test/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannelTest.java
@@ -1,0 +1,55 @@
+package com.tenten.studybadge.study.channel.domain.entity;
+
+import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.study.member.domain.entity.StudyMember;
+import com.tenten.studybadge.type.study.channel.Category;
+import com.tenten.studybadge.type.study.channel.MeetingType;
+import com.tenten.studybadge.type.study.channel.RecruitmentStatus;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+class StudyChannelTest {
+
+    @DisplayName("특정 회원이 해당 스터디 채널의 리더일 경우 True를 반환한다.")
+    @Test
+    void isLeader_returnTrue() {
+
+        Member member1 = Member.builder().id(1L).name("회원 1").build();
+        Member member2 = Member.builder().id(2L).name("회원 2").build();
+
+        LocalDate now = LocalDate.now();
+        StudyChannel studyChannel = StudyChannel.builder()
+                .id(1L)
+                .name("스터디명")
+                .description("스터디 설명")
+                .studyDuration(StudyDuration.builder()
+                        .studyStartDate(now.plusDays(2))
+                        .studyEndDate(now.plusMonths(4))
+                        .build())
+                .recruitment(Recruitment.builder()
+                        .recruitmentNumber(6)
+                        .recruitmentStatus(RecruitmentStatus.RECRUITING)
+                        .build())
+                .category(Category.IT)
+                .region("")
+                .meetingType(MeetingType.ONLINE)
+                .chattingUrl("오픈채팅방 URL")
+                .deposit(10_000)
+                .viewCnt(4)
+                .build();
+
+        StudyMember leader = StudyMember.leader(member1, studyChannel);
+        StudyMember member = StudyMember.member(member2, studyChannel);
+        studyChannel.getStudyMembers().add(leader);
+        studyChannel.getStudyMembers().add(member);
+
+        boolean actual = studyChannel.isLeader(member1);
+
+        Assertions.assertThat(actual).isTrue();
+
+    }
+
+}

--- a/src/test/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannelTest.java
+++ b/src/test/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannelTest.java
@@ -5,23 +5,27 @@ import com.tenten.studybadge.study.member.domain.entity.StudyMember;
 import com.tenten.studybadge.type.study.channel.Category;
 import com.tenten.studybadge.type.study.channel.MeetingType;
 import com.tenten.studybadge.type.study.channel.RecruitmentStatus;
-import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class StudyChannelTest {
 
-    @DisplayName("특정 회원이 해당 스터디 채널의 리더일 경우 True를 반환한다.")
-    @Test
-    void isLeader_returnTrue() {
+    Member member1;
+    Member member2;
+    StudyChannel studyChannel;
 
-        Member member1 = Member.builder().id(1L).name("회원 1").build();
-        Member member2 = Member.builder().id(2L).name("회원 2").build();
+    @BeforeEach
+    void setUp() {
+        member1 = Member.builder().id(1L).name("회원 1").build();
+        member2 = Member.builder().id(2L).name("회원 2").build();
 
         LocalDate now = LocalDate.now();
-        StudyChannel studyChannel = StudyChannel.builder()
+        studyChannel = StudyChannel.builder()
                 .id(1L)
                 .name("스터디명")
                 .description("스터디 설명")
@@ -41,14 +45,33 @@ class StudyChannelTest {
                 .viewCnt(4)
                 .build();
 
+    }
+
+    @DisplayName("특정 회원이 해당 스터디 채널의 리더일 경우 True를 반환한다.")
+    @Test
+    void isLeader_returnTrue() {
+
+        StudyMember leader = StudyMember.leader(member1, studyChannel);
+        studyChannel.getStudyMembers().add(leader);
+
+        boolean actual = studyChannel.isLeader(member1);
+
+        assertThat(actual).isTrue();
+
+    }
+
+    @DisplayName("해당 스터디 채널의 리더가 아닐 경우 경우 False를 반환한다.")
+    @Test
+    void isLeader_returnFalse() {
+
         StudyMember leader = StudyMember.leader(member1, studyChannel);
         StudyMember member = StudyMember.member(member2, studyChannel);
         studyChannel.getStudyMembers().add(leader);
         studyChannel.getStudyMembers().add(member);
 
-        boolean actual = studyChannel.isLeader(member1);
+        boolean actual = studyChannel.isLeader(member2);
 
-        Assertions.assertThat(actual).isTrue();
+        assertThat(actual).isFalse();
 
     }
 


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 해당 스터디 채널의 리더인지 판단하는 로직이 stream의 filter와 map을 활용해 리더 여부를 반환하도록 구현되어 있었습니다.

**TO-BE**
- 멘토링 때 받은 피드백으로 anyMatch를 활용해서도 구현가능하다고 하셔서 anyMatch를 통해 동작하도록 리팩토링했습니다.
- 이를 위해 해당 엔티티에 대한 테스트 코드를 먼저 작성한 후 리팩토링을 진행했고 리팩토링 이후에서 테스트는 모두 정상입니다.

[기능 개발]
- 특정 스터디 채널 정보를 조회하는 기능을 구현
- 조회할 때 필요한 요구사항은 아래 3가지 입니다.
  -  로그인한 회원이 아닐 경우 로그인을 해야한다.
  - 해당 스터디 채널의 스터디 멤버가 아닐 경우 채팅 URL은 보이지 않아야 한다.
  - 서브 리더가 없을 경우 서브 리더명에 현재 리더의 이름을 작성  

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
   - 테스트 코드 작성 시 중복된 데이터가 많아서 이러한 데이터들은 테스트 클래스 내 인스턴스 변수로 지정해서 테스트를 진행
- [x] API 테스트 