### PR TITLE
feat: STD-23 스터디 모집 시작 기능 

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/exception/studychannel/AlreadyStudyMemberFullException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/studychannel/AlreadyStudyMemberFullException.java
@@ -1,0 +1,28 @@
+package com.tenten.studybadge.common.exception.studychannel;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class AlreadyStudyMemberFullException extends AbstractException {
+
+    private static final String ERROR_CODE = "ALREADY_STUDY_MEMBER_FULL";
+    private static final String ERROR_MESSAGE = "이미 정원이 가득 찬 상태입니다.";
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return BAD_REQUEST;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public String getMessage() {
+        return ERROR_MESSAGE;
+    }
+
+}

--- a/src/main/java/com/tenten/studybadge/common/exception/studychannel/NotChangeRecruitmentStatusException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/studychannel/NotChangeRecruitmentStatusException.java
@@ -1,0 +1,28 @@
+package com.tenten.studybadge.common.exception.studychannel;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class NotChangeRecruitmentStatusException extends AbstractException {
+
+    private static final String ERROR_CODE = "NOT_CHANGE_RECRUITMENT_STATUS";
+    private static final String ERROR_MESSAGE = "모집 상태를 변경할 수 없습니다.";
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return BAD_REQUEST;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public String getMessage() {
+        return ERROR_MESSAGE;
+    }
+
+}

--- a/src/main/java/com/tenten/studybadge/study/channel/controller/StudyChannelController.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/controller/StudyChannelController.java
@@ -46,8 +46,9 @@ public class StudyChannelController {
     @PostMapping("/study-channels/{studyChannelId}/recruitment/start")
     @Operation(summary = "스터디 채널 모집 시작", description = "스터디 채널 모집을 시작하기 위한 API", security = @SecurityRequirement(name = "bearerToken"))
     @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
-    public void startRecruitment(@AuthenticationPrincipal CustomUserDetails principal, @PathVariable Long studyChannelId) {
+    public ResponseEntity<Void> startRecruitment(@AuthenticationPrincipal CustomUserDetails principal, @PathVariable Long studyChannelId) {
         studyChannelService.startRecruitment(studyChannelId, principal.getId());
+        return ResponseEntity.ok().build();
     }
 
     // [ Query ]

--- a/src/main/java/com/tenten/studybadge/study/channel/controller/StudyChannelController.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/controller/StudyChannelController.java
@@ -43,6 +43,13 @@ public class StudyChannelController {
                 .build();
     }
 
+    @PostMapping("/study-channels/{studyChannelId}/recruitment/start")
+    @Operation(summary = "스터디 채널 모집 시작", description = "스터디 채널 모집을 시작하기 위한 API", security = @SecurityRequirement(name = "bearerToken"))
+    @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
+    public void startRecruitment(@AuthenticationPrincipal CustomUserDetails principal, @PathVariable Long studyChannelId) {
+        studyChannelService.startRecruitment(studyChannelId, principal.getId());
+    }
+
     // [ Query ]
     @GetMapping("/study-channels")
     @Operation(summary = "스터디 채널 목록 조회", description = "스터디 채널 목록을 조회하기 위한 API")

--- a/src/main/java/com/tenten/studybadge/study/channel/domain/entity/Recruitment.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/domain/entity/Recruitment.java
@@ -24,4 +24,8 @@ public class Recruitment {
         return Objects.equals(recruitmentStatus, RecruitmentStatus.RECRUIT_COMPLETED);
     }
 
+    public void start() {
+        this.recruitmentStatus = RecruitmentStatus.RECRUITING;
+    }
+
 }

--- a/src/main/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannel.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannel.java
@@ -1,6 +1,8 @@
 package com.tenten.studybadge.study.channel.domain.entity;
 
 import com.tenten.studybadge.common.BaseEntity;
+import com.tenten.studybadge.common.exception.studychannel.AlreadyStudyMemberFullException;
+import com.tenten.studybadge.common.exception.studychannel.NotChangeRecruitmentStatusException;
 import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.study.channel.dto.StudyChannelDetailsResponse;
 import com.tenten.studybadge.study.member.domain.entity.StudyMember;
@@ -83,6 +85,16 @@ public class StudyChannel extends BaseEntity {
                 .filter(StudyMember::isSubLeader)
                 .findFirst()
                 .orElse(null);
+    }
+
+    public void startRecruitment() {
+        if (!recruitment.isCompleted()) {
+            throw new NotChangeRecruitmentStatusException();
+        }
+        if (recruitment.getRecruitmentNumber() == studyMembers.size()) {
+            throw new AlreadyStudyMemberFullException();
+        }
+        recruitment.start();
     }
 
     public StudyChannelDetailsResponse toResponse(Member member) {

--- a/src/main/java/com/tenten/studybadge/study/channel/service/StudyChannelService.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/service/StudyChannelService.java
@@ -3,6 +3,7 @@ package com.tenten.studybadge.study.channel.service;
 import com.tenten.studybadge.common.exception.member.NotFoundMemberException;
 import com.tenten.studybadge.common.exception.studychannel.InvalidStudyStartDateException;
 import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelException;
+import com.tenten.studybadge.common.exception.studychannel.NotStudyLeaderException;
 import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.member.domain.repository.MemberRepository;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
@@ -90,6 +91,22 @@ public class StudyChannelService {
             member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
         }
         return studyChannel.toResponse(member);
+    }
+
+    public void startRecruitment(Long studyChannelId, Long memberId) {
+        StudyChannel studyChannel = studyChannelRepository.findByIdWithMember(studyChannelId).orElseThrow(NotFoundStudyChannelException::new);
+        Member member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
+
+        checkLeader(studyChannel, member);
+        studyChannel.startRecruitment();
+
+        studyChannelRepository.save(studyChannel);
+    }
+
+    private void checkLeader(StudyChannel studyChannel, Member member) {
+        if (!studyChannel.isLeader(member)) {
+            throw new NotStudyLeaderException();
+        }
     }
 
     public static class StudyChannelSpecification {


### PR DESCRIPTION
### 변경사항

**AS-IS**

**TO-BE**
스터디 채널 모집 시작 기능을 구현했습니다.

- 스터디 채널은 현재 상태가 "모집 마감" 상태일 때 가능합니다.
- 모집 시작 기능은 "리더"만 가능합니다.
- 만약 현재 스터디 멤버의 수와 정원 수가 동일할 경우 즉, 정원이 가득찼을 경우 예외가 발생합니다.
   -  따라서 별도로 모집 인원을 늘려야 합니다.


### 테스트
- [x] 테스트 코드
- [x] API 테스트 