### PR TITLE
feat: 참가 신청자 조회 기능에서 현재 스터디 채널의 참가 신청 상태를 조회하도록 변경

### DIFF
--- a/src/main/java/com/tenten/studybadge/participation/controller/StudyChannelParticipationController.java
+++ b/src/main/java/com/tenten/studybadge/participation/controller/StudyChannelParticipationController.java
@@ -1,7 +1,7 @@
 package com.tenten.studybadge.participation.controller;
 
 import com.tenten.studybadge.common.security.CustomUserDetails;
-import com.tenten.studybadge.participation.ParticipantResponse;
+import com.tenten.studybadge.participation.dto.StudyChannelParticipationStatusResponse;
 import com.tenten.studybadge.participation.service.StudyChannelParticipationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,8 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -66,12 +64,12 @@ public class StudyChannelParticipationController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/study-channels/{studyChannelId}/participants")
-    @Operation(summary = "참가 신청자 조회", description = "특정 스터디 채널의 참가 신청자를 조회하는 기능", security = @SecurityRequirement(name = "BearerToken"))
+    @GetMapping("/study-channels/{studyChannelId}/participation-status")
+    @Operation(summary = "참가 신청 현황 조회", description = "특정 스터디 채널의 모집 상태에 따라 참가 신청 현황을 조회하는 기능", security = @SecurityRequirement(name = "BearerToken"))
     @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
-    public ResponseEntity<List<ParticipantResponse>> getParticipants(
+    public ResponseEntity<StudyChannelParticipationStatusResponse> getStudyChannelParticipationStatus(
             @AuthenticationPrincipal CustomUserDetails principal,
             @PathVariable Long studyChannelId) {
-        return ResponseEntity.ok(studyChannelParticipationService.getParticipants(studyChannelId, principal.getId()));
+        return ResponseEntity.ok(studyChannelParticipationService.getParticipationStatus(studyChannelId, principal.getId()));
     }
 }

--- a/src/main/java/com/tenten/studybadge/participation/domain/entity/Participation.java
+++ b/src/main/java/com/tenten/studybadge/participation/domain/entity/Participation.java
@@ -2,7 +2,7 @@ package com.tenten.studybadge.participation.domain.entity;
 
 import com.tenten.studybadge.common.BaseEntity;
 import com.tenten.studybadge.member.domain.entity.Member;
-import com.tenten.studybadge.participation.ParticipantResponse;
+import com.tenten.studybadge.participation.dto.ParticipantResponse;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
 import com.tenten.studybadge.type.participation.ParticipationStatus;
 import jakarta.persistence.*;
@@ -64,6 +64,7 @@ public class Participation extends BaseEntity {
                 .imageUrl(this.member.getImgUrl())
                 .name(this.member.getName())
                 .badgeLevel(this.member.getBadgeLevel())
+                .participationStatus(this.participationStatus)
                 .build();
     }
 }

--- a/src/main/java/com/tenten/studybadge/participation/dto/ParticipantResponse.java
+++ b/src/main/java/com/tenten/studybadge/participation/dto/ParticipantResponse.java
@@ -1,6 +1,7 @@
-package com.tenten.studybadge.participation;
+package com.tenten.studybadge.participation.dto;
 
 import com.tenten.studybadge.type.member.BadgeLevel;
+import com.tenten.studybadge.type.participation.ParticipationStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,4 +16,5 @@ public class ParticipantResponse {
     private int banCnt;
     private BadgeLevel badgeLevel;
     private Long participationId;
+    private ParticipationStatus participationStatus;
 }

--- a/src/main/java/com/tenten/studybadge/participation/dto/StudyChannelParticipationStatusResponse.java
+++ b/src/main/java/com/tenten/studybadge/participation/dto/StudyChannelParticipationStatusResponse.java
@@ -1,0 +1,19 @@
+package com.tenten.studybadge.participation.dto;
+
+import com.tenten.studybadge.type.study.channel.RecruitmentStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class StudyChannelParticipationStatusResponse {
+
+    private Long studyChannelId;
+    private RecruitmentStatus recruitmentStatus;
+    private List<ParticipantResponse> participants;
+
+}


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 모집 페이지에 보이는 참가자 목록 조회 기능을 구현 .

**TO-BE**
- 실제 모집 페이지에서는 현재 모집 상태에 따라 참가자 목록을 보여주거나 보여주지 않도록 되어야 합니다.
- 그래서 현재 스터디 채널의 모집 현황을 조회하는 API를 호출하면 아래와 같이 응답이 가도록 변경했습니다.

- "모집중" 일 경우
   - 이때 현재 참가 신청자 목록과 현재 스터디 채널의 상태를 함께 반환
- "모집완료"일 경우
   - 이때는 모집 상태만 반환하고 별도의 신청자 목록을 반환하지 않습니다.

모집완료 상태일 때 이미 해당 스터디 채널의 참가 신청 내역에는 "승인 대기" 상태인 데이터는 없어야하기 때문에
participationRepository에서 위와 같이 조회 쿼리를 날릴 수 있습니다.

하지만 모집완료인 상태에서는 별도의 조회 쿼리를 사용하지 않고 바로 빈 컬렉션을 반환해야 하기 때문에
이런 조회쿼리를 날리지 않도록 분기 처리를 했습니다.

```
// 1) 현재 모집 마감 상태일 경우
{
    "studyChannelId" : 1,
    "recruitmentStatus" : "RECRUITMENT_COMPLETED",
    "participants" : {}
}

// 2) 모집중 상태일 경우
{
    "studyChannelId" : 1,
    "recruitment_status" : "RECRUITING",
    "participants" : {
		{
			"memberId" : 참가 신청자 회원 아이디,
			"participationId" : 참가 신청 아이디,
			"badgeLevel" : 뱃지 레벨,
			"profileImage" : "참가 신청자 프로필 이미지",
			"nickname" : "참가 신청자 닉네임",
			"banCnt" : "퇴출당한 횟수"   
			"participationStatus" : "신청 상태"  // APPROVE_WAITING, APPROVED, REJECTED, CANCELED
		},
		// ...
	}
}
``` 
[또 다른 대안]
아니면 현재 스터디 채널의 모집 상태를 조회하는 API를 호출하고 해당 값에 따라 신청자 목록을 조회하는 API를 
호출하도록 프론트에서 2번 호출할 수도 있지만 일단은 API 호출 횟수를 줄일 겸 하나의 API로 두 응답을 주도록 구현했습니다.

### 테스트
- [x] 테스트 코드
- [x] API 테스트 