### PR TITLE
feat: STD-6 OAuth2 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,14 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
+	//Oauth2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client:3.3.1'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+
+	implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.3'
+
+
+
 	// Json simple
 	implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,11 +30,7 @@ dependencies {
 
 	//Oauth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client:3.3.1'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
-
 	implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.3'
-
-
 
 	// Json simple
 	implementation 'com.googlecode.json-simple:json-simple:1.1.1'

--- a/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.tenten.studybadge.common.config;
 
 import com.tenten.studybadge.common.jwt.JwtTokenFilter;
 import com.tenten.studybadge.common.jwt.JwtTokenProvider;
+import com.tenten.studybadge.common.oauth2.CustomOAuth2UserService;
+import com.tenten.studybadge.common.oauth2.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,6 +28,8 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisTemplate redisTemplate;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -36,14 +40,26 @@ public class SecurityConfig {
         return http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests( requests -> requests
                         .requestMatchers("/api/members/sign-up", "/api/members/auth/**", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/api/members/login/**", "/error", "/health-check").permitAll()
+                        .requestMatchers("/api/token/oauth2/**", "/favicon.ico", "/oauth2/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/study-channels", "/api/study-channels/{studyChannelId:\\d+}").permitAll()
-                        .requestMatchers("/api/members/logout", "api/study-channels/*/places", "/api/study-channels/**", "/api/token/re-issue").hasRole("USER"))
+                        .requestMatchers("/api/members/logout", "api/study-channels/*/places", "/api/study-channels/**", "/api/token/re-issue", "/api/members/my-info", "/api/members/my-info/update").hasRole("USER"))
 
                 .cors(cors -> new CorsConfig())
                 .headers(headers -> headers // h2-console 페이지 접속을 위한 설정
                         .frameOptions(HeadersConfigurer.FrameOptionsConfig::disable)
                         .contentSecurityPolicy(csp -> csp
                                 .policyDirectives("frame-ancestors 'self'")))
+
+                .oauth2Login(oauth2Login ->
+                        oauth2Login
+
+                                .failureUrl("/login")
+                                .redirectionEndpoint( endpoint -> endpoint.baseUri("/oauth2/callback/*"))
+                                .userInfoEndpoint(userInfoEndpoint ->
+                                        userInfoEndpoint.userService(customOAuth2UserService)
+                                )
+                                .successHandler(oAuth2SuccessHandler)
+                )
 
                 .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(
                         SessionCreationPolicy.STATELESS))

--- a/src/main/java/com/tenten/studybadge/common/constant/Oauth2Contant.java
+++ b/src/main/java/com/tenten/studybadge/common/constant/Oauth2Contant.java
@@ -1,0 +1,30 @@
+package com.tenten.studybadge.common.constant;
+
+public class Oauth2Contant {
+
+    public static final String NICKNAME = "nickname";
+
+    public static final String NAME = "name";
+
+    public static final String EMAIL = "email";
+
+    public static final String NAVER = "naver";
+
+    public static final String KAKAO = "kakao";
+
+    public static final String NAVER_ATTRIBUTE_KEY = "response";
+
+    public static final String KAKAO_ATTRIBUTE_KEY = "profile";
+
+    public static final String KAKAO_ACCOUNT = "kakao_account";
+
+    public static final String NAVER_PROFILE_IMG = "profile_image";
+
+    public static final String KAKAO_PROFILE_IMG = "profile_image_url";
+
+    public static final String OAUTH2_PASSWORD = "SNS";
+
+    public static final String LOGIN_REDIRECT_URI = "/api/token/oauth2";
+
+    public static final String SIGN_UP_REDIRECT_URI = "/oauth2/sign-up";
+}

--- a/src/main/java/com/tenten/studybadge/common/constant/TokenConstant.java
+++ b/src/main/java/com/tenten/studybadge/common/constant/TokenConstant.java
@@ -24,6 +24,8 @@ public class TokenConstant {
 
     public static final String REFRESH_TOKEN = "refreshToken";
 
+    public static final String ACCESS_TOKEN = "accessToken";
+
     public static final long ACCESS_TOKEN_EXPIRES_IN = TimeUnit.HOURS.toMillis(1);
 
     public static final long REFRESH_TOKEN_EXPIRES_IN = TimeUnit.DAYS.toMillis(14);

--- a/src/main/java/com/tenten/studybadge/common/exception/oauth2/UnsupportedProviderException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/oauth2/UnsupportedProviderException.java
@@ -1,0 +1,20 @@
+package com.tenten.studybadge.common.exception.oauth2;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class UnsupportedProviderException extends AbstractException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+    @Override
+    public String getErrorCode() {
+        return "UNSUPPORTED_PROVIDER";
+    }
+    @Override
+    public String getMessage() {
+        return "지원하지 않는 플랫폼입니다.";
+    }
+}

--- a/src/main/java/com/tenten/studybadge/common/jwt/JwtTokenCreator.java
+++ b/src/main/java/com/tenten/studybadge/common/jwt/JwtTokenCreator.java
@@ -28,9 +28,9 @@ public class JwtTokenCreator {
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    public TokenDto createToken(String username, MemberRole role, Platform platform) {
+    public TokenDto createToken(String memberId, MemberRole role, Platform platform) {
 
-        Claims commonClaims = Jwts.claims().setSubject(username);
+        Claims commonClaims = Jwts.claims().setSubject(memberId);
         commonClaims.put(PLATFORM, platform);
 
 
@@ -49,7 +49,7 @@ public class JwtTokenCreator {
         String accessToken = Jwts.builder()
                 .setClaims(accessTokenClaims)
                 .setIssuedAt(Date.from(now))
-                .setSubject(username)
+                .setSubject(memberId)
                 .setExpiration(accessTokenExpiresIn)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
@@ -66,9 +66,9 @@ public class JwtTokenCreator {
                 .build();
     }
 
-    public String reissue(String email, MemberRole role, Platform platform) {
+    public String reissue(String memberId, MemberRole role, Platform platform) {
 
-        Claims claims = Jwts.claims().setSubject(email);
+        Claims claims = Jwts.claims().setSubject(memberId);
         claims.put(PLATFORM, platform);
         List<String> roles = Arrays.asList(ROLE_PREFIX + role.name());
         claims.put(ROLE, roles);

--- a/src/main/java/com/tenten/studybadge/common/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/tenten/studybadge/common/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,55 @@
+package com.tenten.studybadge.common.oauth2;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tenten.studybadge.common.security.CustomUserDetails;
+import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+
+        Map<String, Object> oAuth2UserAttributes = super.loadUser(userRequest).getAttributes();
+
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
+                .getUserInfoEndpoint().getUserNameAttributeName();
+
+
+        OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfo.of(registrationId, oAuth2UserAttributes);
+
+
+        Member member = getOrSave(oAuth2UserInfo);
+
+
+        return new CustomUserDetails(member, oAuth2UserAttributes, userNameAttributeName);
+    }
+
+    private Member getOrSave(OAuth2UserInfo oAuth2UserInfo) {
+
+        Member member = memberRepository.findByEmailAndPlatform(oAuth2UserInfo.email(), oAuth2UserInfo.platform())
+                .orElseGet(oAuth2UserInfo::toEntity);
+
+        return memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/tenten/studybadge/common/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/tenten/studybadge/common/oauth2/OAuth2SuccessHandler.java
@@ -56,7 +56,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     private void loginSuccess(HttpServletResponse response, CustomUserDetails userDetails) throws IOException {
 
 
-        TokenDto tokenDto = jwtTokenCreator.createToken(userDetails.getName(), userDetails.getRole(), userDetails.getPlatform());
+        TokenDto tokenDto = jwtTokenCreator.createToken(String.valueOf(userDetails.getId()), userDetails.getRole(), userDetails.getPlatform());
 
        String redirectUrl = UriComponentsBuilder.fromUriString(LOGIN_REDIRECT_URI)
                 .queryParam(ACCESS_TOKEN, tokenDto.getAccessToken())

--- a/src/main/java/com/tenten/studybadge/common/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/tenten/studybadge/common/oauth2/OAuth2SuccessHandler.java
@@ -1,0 +1,73 @@
+package com.tenten.studybadge.common.oauth2;
+
+import com.tenten.studybadge.common.jwt.JwtTokenCreator;
+import com.tenten.studybadge.common.security.CustomUserDetails;
+import com.tenten.studybadge.common.token.dto.TokenDto;
+import com.tenten.studybadge.common.utils.CookieUtils;
+import com.tenten.studybadge.member.domain.type.MemberRole;
+import com.tenten.studybadge.type.member.MemberStatus;
+import com.tenten.studybadge.type.member.Platform;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+import static com.tenten.studybadge.common.constant.Oauth2Contant.LOGIN_REDIRECT_URI;
+import static com.tenten.studybadge.common.constant.Oauth2Contant.SIGN_UP_REDIRECT_URI;
+import static com.tenten.studybadge.common.constant.TokenConstant.ACCESS_TOKEN;
+import static com.tenten.studybadge.common.constant.TokenConstant.BEARER;
+
+@RequiredArgsConstructor
+@Component
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+
+    private final JwtTokenCreator jwtTokenCreator;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        Platform platform = userDetails.getPlatform();
+        MemberRole role = userDetails.getRole();
+
+        if(userDetails.getStatus() == MemberStatus.WAIT_FOR_APPROVAL) {
+
+            TokenDto tokenDto = jwtTokenCreator.createToken(authentication.getName(), role, platform);
+            String authorizationHeader = BEARER + tokenDto.getAccessToken();
+            response.sendRedirect(SIGN_UP_REDIRECT_URI);
+            response.addHeader(HttpHeaders.AUTHORIZATION, authorizationHeader);
+
+        } else {
+
+            loginSuccess(response, userDetails);
+
+        }
+    }
+
+    private void loginSuccess(HttpServletResponse response, CustomUserDetails userDetails) throws IOException {
+
+
+        TokenDto tokenDto = jwtTokenCreator.createToken(userDetails.getName(), userDetails.getRole(), userDetails.getPlatform());
+
+       String redirectUrl = UriComponentsBuilder.fromUriString(LOGIN_REDIRECT_URI)
+                .queryParam(ACCESS_TOKEN, tokenDto.getAccessToken())
+                .build().toUriString();
+
+        ResponseCookie refreshCookie = CookieUtils.addCookie(tokenDto.getRefreshToken());
+        String authorizationHeader = BEARER + tokenDto.getAccessToken();
+
+        response.sendRedirect(redirectUrl);
+        response.addHeader(HttpHeaders.AUTHORIZATION, authorizationHeader);
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+
+    }
+}

--- a/src/main/java/com/tenten/studybadge/common/oauth2/OAuth2UserInfo.java
+++ b/src/main/java/com/tenten/studybadge/common/oauth2/OAuth2UserInfo.java
@@ -1,6 +1,7 @@
 package com.tenten.studybadge.common.oauth2;
 
 import com.tenten.studybadge.common.exception.InvalidTokenException;
+import com.tenten.studybadge.common.exception.oauth2.UnsupportedProviderException;
 import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.member.domain.type.MemberRole;
 import com.tenten.studybadge.type.member.BadgeLevel;
@@ -27,7 +28,7 @@ public record OAuth2UserInfo(
         return switch (registrationId) {
             case NAVER -> ofNaver(attributes);
             case KAKAO -> ofKakao(attributes);
-            default -> throw new InvalidTokenException();
+            default -> throw new UnsupportedProviderException();
         };
     }
 

--- a/src/main/java/com/tenten/studybadge/common/oauth2/OAuth2UserInfo.java
+++ b/src/main/java/com/tenten/studybadge/common/oauth2/OAuth2UserInfo.java
@@ -1,0 +1,74 @@
+package com.tenten.studybadge.common.oauth2;
+
+import com.tenten.studybadge.common.exception.InvalidTokenException;
+import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.member.domain.type.MemberRole;
+import com.tenten.studybadge.type.member.BadgeLevel;
+import com.tenten.studybadge.type.member.MemberStatus;
+import com.tenten.studybadge.type.member.Platform;
+import lombok.Builder;
+
+import java.util.Map;
+
+import static com.tenten.studybadge.common.constant.Oauth2Contant.*;
+
+@Builder
+public record OAuth2UserInfo(
+        String name,
+        String nickname,
+        String email,
+        String profile,
+        Platform platform
+) {
+
+
+
+    public static OAuth2UserInfo of(String registrationId, Map<String, Object> attributes) {
+        return switch (registrationId) {
+            case NAVER -> ofNaver(attributes);
+            case KAKAO -> ofKakao(attributes);
+            default -> throw new InvalidTokenException();
+        };
+    }
+
+    private static OAuth2UserInfo ofNaver(Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) attributes.get(NAVER_ATTRIBUTE_KEY);
+
+        return OAuth2UserInfo.builder()
+                .name((String) response.get(NAME))
+                .email((String) response.get(EMAIL))
+                .nickname((String) response.get(NICKNAME))
+                .profile((String) response.get(NAVER_PROFILE_IMG))
+                .platform(Platform.NAVER)
+                .build();
+    }
+
+    private static OAuth2UserInfo ofKakao(Map<String, Object> attributes) {
+        Map<String, Object> account = (Map<String, Object>) attributes.get(KAKAO_ACCOUNT);
+        Map<String, Object> profile = (Map<String, Object>) account.get(KAKAO_ATTRIBUTE_KEY);
+
+        return OAuth2UserInfo.builder()
+                .name((String) profile.get(NICKNAME))
+                .email((String) account.get(EMAIL))
+                .nickname((String) profile.get(NICKNAME))
+                .profile((String) profile.get(KAKAO_PROFILE_IMG))
+                .platform(Platform.KAKAO)
+                .build();
+    }
+
+    public Member toEntity() {
+        return Member.builder()
+                .name(name)
+                .email(email)
+                .imgUrl(profile)
+                .password(OAUTH2_PASSWORD)
+                .role(MemberRole.USER)
+                .badgeLevel(BadgeLevel.NONE)
+                .nickname(nickname)
+                .point(0)
+                .status(MemberStatus.WAIT_FOR_APPROVAL)
+                .platform(platform)
+                .isAuth(true)
+                .build();
+    }
+}

--- a/src/main/java/com/tenten/studybadge/common/security/CustomUserDetailService.java
+++ b/src/main/java/com/tenten/studybadge/common/security/CustomUserDetailService.java
@@ -17,7 +17,7 @@ public class CustomUserDetailService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 
-        return new CustomUserDetails(memberRepository.findByEmail(username).orElseThrow(NotFoundMemberException::new));
+        return new CustomUserDetails(memberRepository.findById(Long.valueOf(username)).orElseThrow(NotFoundMemberException::new));
 
 
     }

--- a/src/main/java/com/tenten/studybadge/common/security/CustomUserDetails.java
+++ b/src/main/java/com/tenten/studybadge/common/security/CustomUserDetails.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.*;
 
@@ -18,13 +19,16 @@ import static com.tenten.studybadge.common.constant.TokenConstant.ROLE_PREFIX;
 @Getter
 @Setter
 @Slf4j
-public class CustomUserDetails implements UserDetails {
+public class CustomUserDetails implements UserDetails, OAuth2User {
 
     private String email;
     private MemberStatus status;
     private MemberRole role;
     private Platform platform;
     private Long id;
+    private Map<String, Object> attributes;
+    private String attributeKey;
+
 
     public CustomUserDetails(Member member) {
         this.email = member.getEmail();
@@ -33,6 +37,25 @@ public class CustomUserDetails implements UserDetails {
         this.platform = member.getPlatform();
         this.id = member.getId();
     }
+
+    public CustomUserDetails(Member member, Map<String, Object> attributes, String attributeKey) {
+        this.email = member.getEmail();
+        this.status = member.getStatus();
+        this.role = member.getRole();
+        this.platform = member.getPlatform();
+        this.id = member.getId();
+        this.attributes = attributes;
+        this.attributeKey = attributeKey;
+        this.status = member.getStatus();
+
+
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Collections.singleton(new SimpleGrantedAuthority(ROLE_PREFIX + getRole().name()));
@@ -66,5 +89,10 @@ public class CustomUserDetails implements UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
+    }
+
+    @Override
+    public String getName() {
+        return attributes.get(attributeKey).toString();
     }
 }

--- a/src/main/java/com/tenten/studybadge/common/security/CustomUserDetails.java
+++ b/src/main/java/com/tenten/studybadge/common/security/CustomUserDetails.java
@@ -68,7 +68,7 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
 
     @Override
     public String getUsername() {
-        return this.getEmail();
+        return String.valueOf(this.getId());
     }
 
     @Override

--- a/src/main/java/com/tenten/studybadge/common/token/controller/TokenController.java
+++ b/src/main/java/com/tenten/studybadge/common/token/controller/TokenController.java
@@ -1,5 +1,6 @@
 package com.tenten.studybadge.common.token.controller;
 
+import com.tenten.studybadge.common.token.dto.SocialLoginResponse;
 import com.tenten.studybadge.common.token.service.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -26,5 +27,12 @@ public class TokenController {
         return ResponseEntity.status(HttpStatus.OK)
                 .header("Authorization", "Bearer " + newAccessToken)
                 .body(newAccessToken);
+    }
+    @Operation(summary = "Oauth2 토큰발급", description = "Oauth2 로그인 토큰 발급")
+    @GetMapping("/oauth2")
+    public ResponseEntity<SocialLoginResponse> SocialLogin(SocialLoginResponse socialLoginResponse) {
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(socialLoginResponse);
     }
 }

--- a/src/main/java/com/tenten/studybadge/common/token/dto/SocialLoginResponse.java
+++ b/src/main/java/com/tenten/studybadge/common/token/dto/SocialLoginResponse.java
@@ -1,0 +1,15 @@
+package com.tenten.studybadge.common.token.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SocialLoginResponse {
+
+    private String accessToken;
+}

--- a/src/main/java/com/tenten/studybadge/common/token/dto/TokenCreateDto.java
+++ b/src/main/java/com/tenten/studybadge/common/token/dto/TokenCreateDto.java
@@ -11,6 +11,8 @@ import lombok.NoArgsConstructor;
 @Builder
 public class TokenCreateDto {
 
+    private String id;
+
     private String email;
 
     private MemberRole role;

--- a/src/main/java/com/tenten/studybadge/member/controller/MemberController.java
+++ b/src/main/java/com/tenten/studybadge/member/controller/MemberController.java
@@ -57,7 +57,7 @@ public class MemberController {
     public ResponseEntity<TokenDto> login(@Valid @RequestBody MemberLoginRequest loginRequest) {
 
         TokenCreateDto createDto = memberService.login(loginRequest, LOCAL);
-        TokenDto tokenDto = tokenService.create(createDto.getEmail(), createDto.getRole(), LOCAL);
+        TokenDto tokenDto = tokenService.create(createDto.getId(), createDto.getRole(), LOCAL);
         ResponseCookie addCookie = CookieUtils.addCookie(tokenDto.getRefreshToken());
 
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/tenten/studybadge/member/domain/entity/Member.java
+++ b/src/main/java/com/tenten/studybadge/member/domain/entity/Member.java
@@ -32,6 +32,8 @@ public class Member extends BaseEntity {
 
     private String account;
 
+    private String accountBank;
+
     private String imgUrl;
 
     private Boolean isAuth;

--- a/src/main/java/com/tenten/studybadge/member/dto/MemberSignUpRequest.java
+++ b/src/main/java/com/tenten/studybadge/member/dto/MemberSignUpRequest.java
@@ -36,6 +36,8 @@ public class MemberSignUpRequest {
     @NotBlank(message = "계좌번호를 입력해주세요.")
     private String account;
 
+    private String accountBank;
+
     @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;
 
@@ -59,6 +61,7 @@ public class MemberSignUpRequest {
                 .point(0)
                 .banCnt(0)
                 .account(signUpRequest.getAccount())
+                .accountBank(signUpRequest.getAccountBank())
                 .status(MemberStatus.WAIT_FOR_APPROVAL)
                 .badgeLevel(BadgeLevel.NONE)
                 .build();

--- a/src/main/java/com/tenten/studybadge/member/service/MemberService.java
+++ b/src/main/java/com/tenten/studybadge/member/service/MemberService.java
@@ -123,6 +123,7 @@ public class MemberService {
         }
 
         return TokenCreateDto.builder()
+                .id(String.valueOf(member.getId()))
                 .email(member.getEmail())
                 .role(member.getRole())
                 .build();


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 기존 회원가입시 계좌번호만 존재하고 은행명 필드는 없었습니다.
- 기존 토큰 subject는 email로  설정되어있음 -> 이메일 중복 이슈로 id값으로 변경 할 예정입니다.

**TO-BE**
- OAuth2 로그인 구현
  - Naver, Kakao 로그인
  - 첫 로그인 시 자동 회원가입이 되며, 가입대기 상태로 가입 진행됩니다.
  - 회원 가입이 되어 있으면, 바로 로그인 진행됩니다.
  - 계좌나 자기소개 등은 추가 정보 입력 창으로 이동 -> 입력 후 활성 상태로 변경
  - 은행명 필드 추가하였습니다.
  - 이메일 중복 이슈로 인해 토큰 subject memberId로 변경했습니다.
  - 이제 이메일이 아닌 memberId 로 멤버를 찾아옵니다.
  - 프론트와 추가 상의 후 변경될 수도 있습니다.




### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 