### PR TITLE
feat: STD-25 스터디 멤버 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/exception/studychannel/NotStudyMemberException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/studychannel/NotStudyMemberException.java
@@ -1,0 +1,28 @@
+package com.tenten.studybadge.common.exception.studychannel;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class NotStudyMemberException extends AbstractException {
+
+    private static final String ERROR_CODE = "NOT_STUDY_MEMBER";
+    private static final String ERROR_MESSAGE = "해당 스터디 채널의 멤버가 아닙니다.";
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return BAD_REQUEST;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public String getMessage() {
+        return ERROR_MESSAGE;
+    }
+
+}

--- a/src/main/java/com/tenten/studybadge/study/member/controller/StudyMemberController.java
+++ b/src/main/java/com/tenten/studybadge/study/member/controller/StudyMemberController.java
@@ -1,0 +1,30 @@
+package com.tenten.studybadge.study.member.controller;
+
+import com.tenten.studybadge.common.security.CustomUserDetails;
+import com.tenten.studybadge.study.member.dto.StudyMembersResponse;
+import com.tenten.studybadge.study.member.service.StudyMemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class StudyMemberController {
+
+    private final StudyMemberService studyMemberService;
+
+    @GetMapping("/api/study-channels/{studyChannelId}/members")
+    @Operation(summary = "스터디 멤버 리스트 조회", description = "특정 스터디 채널의 스터디 멤버 리스트를 조회하는 API")
+    @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
+    public ResponseEntity<StudyMembersResponse> getStudyMembers(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable Long studyChannelId) {
+        return ResponseEntity.ok(studyMemberService.getStudyMembers(studyChannelId, principal.getId()));
+    }
+
+}

--- a/src/main/java/com/tenten/studybadge/study/member/domain/entity/StudyMember.java
+++ b/src/main/java/com/tenten/studybadge/study/member/domain/entity/StudyMember.java
@@ -3,6 +3,7 @@ package com.tenten.studybadge.study.member.domain.entity;
 import com.tenten.studybadge.common.BaseEntity;
 import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
+import com.tenten.studybadge.study.member.dto.StudyMemberInfoResponse;
 import com.tenten.studybadge.type.study.member.StudyMemberRole;
 import jakarta.persistence.*;
 import lombok.*;
@@ -58,6 +59,16 @@ public class StudyMember extends BaseEntity {
 
     public boolean isSubLeader() {
         return this.studyMemberRole.equals(SUB_LEADER);
+    }
+
+    public StudyMemberInfoResponse toResponse() {
+        return StudyMemberInfoResponse.builder()
+                .memberId(this.member.getId())
+                .name(this.member.getName())
+                .imageUrl(this.member.getImgUrl())
+                .badgeLevel(this.member.getBadgeLevel())
+                .role(this.studyMemberRole)
+                .build();
     }
 
 }

--- a/src/main/java/com/tenten/studybadge/study/member/domain/repository/StudyMemberRepository.java
+++ b/src/main/java/com/tenten/studybadge/study/member/domain/repository/StudyMemberRepository.java
@@ -14,4 +14,11 @@ public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> 
             "WHERE sm.studyChannel.id IN (:studyChannelIds) " +
             "AND sm.studyMemberRole = :studyMemberRole")
     List<StudyMember> findAllWithLeader(List<Long> studyChannelIds, StudyMemberRole studyMemberRole);
+
+    boolean existsByStudyChannelIdAndMemberId(Long studyChannelId, Long memberId);
+
+    @Query("SELECT sm FROM StudyMember sm " +
+            "JOIN FETCH sm.member " +
+            "WHERE sm.studyChannel.id = :studyChannelId")
+    List<StudyMember> findAllByStudyChannelIdWithMember(Long studyChannelId);
 }

--- a/src/main/java/com/tenten/studybadge/study/member/dto/StudyMemberInfoResponse.java
+++ b/src/main/java/com/tenten/studybadge/study/member/dto/StudyMemberInfoResponse.java
@@ -1,0 +1,20 @@
+package com.tenten.studybadge.study.member.dto;
+
+import com.tenten.studybadge.type.member.BadgeLevel;
+import com.tenten.studybadge.type.study.member.StudyMemberRole;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class StudyMemberInfoResponse {
+
+    private Long memberId;
+    private String name;
+    private String imageUrl;
+    private BadgeLevel badgeLevel;
+    private StudyMemberRole role;
+
+}

--- a/src/main/java/com/tenten/studybadge/study/member/dto/StudyMembersResponse.java
+++ b/src/main/java/com/tenten/studybadge/study/member/dto/StudyMembersResponse.java
@@ -1,0 +1,17 @@
+package com.tenten.studybadge.study.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class StudyMembersResponse {
+
+    List<StudyMemberInfoResponse> studyMembers;
+    boolean isLeader;
+
+}

--- a/src/main/java/com/tenten/studybadge/study/member/service/StudyMemberService.java
+++ b/src/main/java/com/tenten/studybadge/study/member/service/StudyMemberService.java
@@ -1,0 +1,39 @@
+package com.tenten.studybadge.study.member.service;
+
+import com.tenten.studybadge.common.exception.studychannel.NotStudyMemberException;
+import com.tenten.studybadge.study.member.domain.entity.StudyMember;
+import com.tenten.studybadge.study.member.domain.repository.StudyMemberRepository;
+import com.tenten.studybadge.study.member.dto.StudyMemberInfoResponse;
+import com.tenten.studybadge.study.member.dto.StudyMembersResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StudyMemberService {
+
+    private final StudyMemberRepository studyMemberRepository;
+
+    public StudyMembersResponse getStudyMembers(Long studyChannelId, Long memberId) {
+
+        if (!studyMemberRepository.existsByStudyChannelIdAndMemberId(studyChannelId, memberId)) {
+            throw new NotStudyMemberException();
+        }
+        List<StudyMember> studyMembers = studyMemberRepository.findAllByStudyChannelIdWithMember(studyChannelId);
+
+        boolean isLeader = studyMembers.stream()
+                .anyMatch(studyMember -> studyMember.getMember().getId().equals(memberId) && studyMember.isLeader());
+
+        List<StudyMemberInfoResponse> responses = studyMembers.stream()
+                .map(StudyMember::toResponse)
+                .toList();
+
+        return StudyMembersResponse.builder()
+                .studyMembers(responses)
+                .isLeader(isLeader)
+                .build();
+    }
+
+}

--- a/src/test/java/com/tenten/studybadge/study/member/service/StudyMemberServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/study/member/service/StudyMemberServiceTest.java
@@ -1,0 +1,124 @@
+package com.tenten.studybadge.study.member.service;
+
+import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
+import com.tenten.studybadge.study.member.domain.entity.StudyMember;
+import com.tenten.studybadge.study.member.domain.repository.StudyMemberRepository;
+import com.tenten.studybadge.study.member.dto.StudyMembersResponse;
+import com.tenten.studybadge.type.member.BadgeLevel;
+import com.tenten.studybadge.type.study.member.StudyMemberRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class StudyMemberServiceTest {
+
+    @InjectMocks
+    private StudyMemberService studyMemberService;
+
+    @Mock
+    private StudyMemberRepository studyMemberRepository;
+
+    @DisplayName("[스터디 멤버 리스트 조회 테스트]")
+    @Nested
+    class GetStudyMembersTest {
+
+        Member member1;
+        Member member2;
+
+        @BeforeEach
+        void setUp() {
+            member1 = Member.builder()
+                    .id(1L)
+                    .name("회원1")
+                    .banCnt(2)
+                    .imgUrl("imageUrl1")
+                    .badgeLevel(BadgeLevel.SILVER)
+                    .build();
+            member2 = Member.builder()
+                    .id(2L)
+                    .name("회원2")
+                    .banCnt(2)
+                    .imgUrl("imageUrl2")
+                    .badgeLevel(BadgeLevel.NONE)
+                    .build();
+
+        }
+
+        @DisplayName("리더가 스터디 멤버를 조회할 경우 isLeader는 True")
+        @Test
+        void success_getStudyMembersForLeader() {
+            StudyChannel studyChannel = StudyChannel.builder().id(1L).build();
+
+            StudyMember leader = StudyMember.leader(member1, studyChannel);
+            StudyMember studyMember = StudyMember.member(member2, studyChannel);
+            List<StudyMember> studyMembers = List.of(leader, studyMember);
+
+            given(studyMemberRepository.existsByStudyChannelIdAndMemberId(1L, 1L))
+                    .willReturn(true);
+
+            given(studyMemberRepository.findAllByStudyChannelIdWithMember(1L)).willReturn(studyMembers);
+
+            StudyMembersResponse response = studyMemberService.getStudyMembers(1L, 1L);
+
+            assertThat(response.isLeader()).isTrue();
+            assertThat(response.getStudyMembers().size()).isEqualTo(2);
+            assertThat(response.getStudyMembers().get(0).getMemberId()).isEqualTo(1L);
+            assertThat(response.getStudyMembers().get(0).getImageUrl()).isEqualTo("imageUrl1");
+            assertThat(response.getStudyMembers().get(0).getName()).isEqualTo("회원1");
+            assertThat(response.getStudyMembers().get(0).getRole()).isEqualTo(StudyMemberRole.LEADER);
+            assertThat(response.getStudyMembers().get(0).getBadgeLevel()).isEqualTo(BadgeLevel.SILVER);
+            assertThat(response.getStudyMembers().get(1).getMemberId()).isEqualTo(2L);
+            assertThat(response.getStudyMembers().get(1).getImageUrl()).isEqualTo("imageUrl2");
+            assertThat(response.getStudyMembers().get(1).getName()).isEqualTo("회원2");
+            assertThat(response.getStudyMembers().get(1).getRole()).isEqualTo(StudyMemberRole.STUDY_MEMBER);
+            assertThat(response.getStudyMembers().get(1).getBadgeLevel()).isEqualTo(BadgeLevel.NONE);
+
+        }
+
+        @DisplayName("스터디 멤버가 스터디 멤버를 조회할 경우 isLeader는 False")
+        @Test
+        void success_getStudyMembersForStudyMember() {
+            StudyChannel studyChannel = StudyChannel.builder().id(1L).build();
+
+            StudyMember leader = StudyMember.leader(member1, studyChannel);
+            StudyMember studyMember = StudyMember.member(member2, studyChannel);
+            List<StudyMember> studyMembers = List.of(leader, studyMember);
+
+            given(studyMemberRepository.existsByStudyChannelIdAndMemberId(1L, 2L))
+                    .willReturn(true);
+
+            given(studyMemberRepository.findAllByStudyChannelIdWithMember(1L)).willReturn(studyMembers);
+
+            StudyMembersResponse response = studyMemberService.getStudyMembers(1L, 2L);
+
+            assertThat(response.isLeader()).isFalse();
+            assertThat(response.getStudyMembers().size()).isEqualTo(2);
+            assertThat(response.getStudyMembers().get(0).getMemberId()).isEqualTo(1L);
+            assertThat(response.getStudyMembers().get(0).getImageUrl()).isEqualTo("imageUrl1");
+            assertThat(response.getStudyMembers().get(0).getName()).isEqualTo("회원1");
+            assertThat(response.getStudyMembers().get(0).getRole()).isEqualTo(StudyMemberRole.LEADER);
+            assertThat(response.getStudyMembers().get(0).getBadgeLevel()).isEqualTo(BadgeLevel.SILVER);
+            assertThat(response.getStudyMembers().get(1).getMemberId()).isEqualTo(2L);
+            assertThat(response.getStudyMembers().get(1).getImageUrl()).isEqualTo("imageUrl2");
+            assertThat(response.getStudyMembers().get(1).getName()).isEqualTo("회원2");
+            assertThat(response.getStudyMembers().get(1).getRole()).isEqualTo(StudyMemberRole.STUDY_MEMBER);
+            assertThat(response.getStudyMembers().get(1).getBadgeLevel()).isEqualTo(BadgeLevel.NONE);
+
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**

**TO-BE**

스터디 멤버 목록을 조회하는 기능을 구현했습니다.
- 현재 로그인한 회원이 해당 스터디 채널의 리더일 경우 isLeader 라는 플래그 값을 True로 반환합니다.
-  만약 리더가 아니고 스터디 멤버일 경우  isLeader 라는 플래그 값을 False로 반환합니다.
- 만약 해당 스터디 채널의 멤버가 아닐 경우 예외가 발생합니다.


### 테스트
- [x] 테스트 코드
- [x] API 테스트 