### PR TITLE
feat: STD-7 결제요청 구현

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/config/PaymentConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/PaymentConfig.java
@@ -1,0 +1,27 @@
+package com.tenten.studybadge.common.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class PaymentConfig {
+
+
+    @Value("${payment.toss.test_client_api_key}")
+    private String testClientApiKey;
+
+    @Value("${payment.toss.test_secret_api_key}")
+    private String testSecretKey;
+
+    @Value("${payment.toss.success_url}")
+    private String successUrl;
+
+    @Value("${payment.toss.fail_url}")
+    private String failUrl;
+
+
+    // 토스페이먼츠에 결제 승인 요청할 URL
+    public static final String TOSS_URL = "https://api.tosspayments.com/v1/payments/";
+}

--- a/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
@@ -42,7 +42,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/members/sign-up", "/api/members/auth/**", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/api/members/login/**", "/error", "/health-check").permitAll()
                         .requestMatchers("/api/token/oauth2/**", "/favicon.ico", "/oauth2/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/study-channels", "/api/study-channels/{studyChannelId:\\d+}").permitAll()
-                        .requestMatchers("/api/members/logout", "api/study-channels/*/places", "/api/study-channels/**", "/api/token/re-issue", "/api/members/my-info", "/api/members/my-info/update").hasRole("USER"))
+                        .requestMatchers("/api/members/logout", "api/study-channels/*/places", "/api/study-channels/**", "/api/token/re-issue"
+                                , "/api/members/my-info", "/api/members/my-info/update", "/api/payments/**").hasRole("USER"))
 
                 .cors(cors -> new CorsConfig())
                 .headers(headers -> headers // h2-console 페이지 접속을 위한 설정

--- a/src/main/java/com/tenten/studybadge/common/exception/payment/InvalidAmountException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/payment/InvalidAmountException.java
@@ -1,0 +1,20 @@
+package com.tenten.studybadge.common.exception.payment;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidAmountException extends AbstractException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+    @Override
+    public String getErrorCode() {
+        return "INVALID_AMOUNT";
+    }
+    @Override
+    public String getMessage() {
+        return "최소 충전 금액은 10,000원 입니다.";
+    }
+}

--- a/src/main/java/com/tenten/studybadge/payment/controller/PaymentController.java
+++ b/src/main/java/com/tenten/studybadge/payment/controller/PaymentController.java
@@ -1,0 +1,34 @@
+package com.tenten.studybadge.payment.controller;
+
+import com.tenten.studybadge.common.security.CustomUserDetails;
+import com.tenten.studybadge.payment.dto.PaymentRequest;
+import com.tenten.studybadge.payment.dto.PaymentResponse;
+import com.tenten.studybadge.payment.service.PaymentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/payments")
+public class PaymentController {
+
+    private final PaymentService paymentService;
+    @Operation(summary = "결제 요청", description = "토스페이먼츠에 결제 요청할 API", security = @SecurityRequirement(name = "bearerToken"))
+    @Parameter(name = "paymentRequest", description = "결제 요청을 위한 값들")
+    @PostMapping("/toss")
+    public ResponseEntity<PaymentResponse> requestPayment(@AuthenticationPrincipal CustomUserDetails principal, @Valid @RequestBody PaymentRequest paymentRequest) {
+
+        PaymentResponse response = paymentService.requestPayment(principal.getId(), paymentRequest);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/tenten/studybadge/payment/domain/entity/Payment.java
+++ b/src/main/java/com/tenten/studybadge/payment/domain/entity/Payment.java
@@ -1,0 +1,45 @@
+package com.tenten.studybadge.payment.domain.entity;
+
+import com.tenten.studybadge.common.BaseEntity;
+import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.type.payment.PayType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class Payment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private PayType payType;
+
+    private Long amount;
+
+    private String orderName;
+
+    private String orderId;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "customer_id")
+    private Member customer;
+
+    private String paymentKey;
+
+    private String failReason;
+
+    private boolean successYN;
+
+    private boolean cancelYN;
+
+    private String cancelReason;
+}

--- a/src/main/java/com/tenten/studybadge/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/tenten/studybadge/payment/domain/repository/PaymentRepository.java
@@ -1,0 +1,9 @@
+package com.tenten.studybadge.payment.domain.repository;
+
+import com.tenten.studybadge.payment.domain.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+}

--- a/src/main/java/com/tenten/studybadge/payment/dto/PaymentRequest.java
+++ b/src/main/java/com/tenten/studybadge/payment/dto/PaymentRequest.java
@@ -1,0 +1,43 @@
+package com.tenten.studybadge.payment.dto;
+
+import com.tenten.studybadge.payment.domain.entity.Payment;
+import com.tenten.studybadge.type.payment.PayType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PaymentRequest {
+
+    @NotNull
+    private PayType payType;
+
+    @NotNull
+    private Long amount;
+
+    @NotBlank
+    private String orderName;
+
+    public Payment toEntity() {
+
+        String date = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String uuid = UUID.randomUUID().toString();
+        String orderId = date + "_" + uuid;
+
+        return Payment.builder()
+                .payType(payType)
+                .amount(amount)
+                .orderName(orderName)
+                .orderId(orderId)
+                .successYN(false)
+                .build();
+    }
+}

--- a/src/main/java/com/tenten/studybadge/payment/dto/PaymentResponse.java
+++ b/src/main/java/com/tenten/studybadge/payment/dto/PaymentResponse.java
@@ -1,0 +1,49 @@
+package com.tenten.studybadge.payment.dto;
+
+import com.tenten.studybadge.payment.domain.entity.Payment;
+import lombok.*;
+@Setter
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PaymentResponse {
+
+    private String payType;
+
+    private Long amount;
+
+    private String orderName;
+
+    private String orderId;
+
+    private String customerEmail;
+
+    private String customerName;
+
+    private String successUrl;
+
+    private String failUrl;
+
+    private String failReason;
+
+    private boolean cancelYN;
+
+    private String cancelReason;
+
+
+    public static PaymentResponse toResponse(Payment payment, String successUrl, String failUrl) {
+        return PaymentResponse.builder()
+                .payType(payment.getPayType().getDescription())
+                .amount(payment.getAmount())
+                .orderName(payment.getOrderName())
+                .orderId(payment.getOrderId())
+                .cancelYN(payment.isCancelYN())
+                .successUrl(successUrl)
+                .failUrl(failUrl)
+                .customerEmail(payment.getCustomer().getEmail())
+                .customerName(payment.getCustomer().getName())
+                .failReason(payment.getFailReason())
+                .build();
+    }
+}

--- a/src/main/java/com/tenten/studybadge/payment/service/PaymentService.java
+++ b/src/main/java/com/tenten/studybadge/payment/service/PaymentService.java
@@ -1,0 +1,42 @@
+package com.tenten.studybadge.payment.service;
+
+import com.tenten.studybadge.common.config.PaymentConfig;
+import com.tenten.studybadge.common.exception.member.NotFoundMemberException;
+import com.tenten.studybadge.common.exception.payment.InvalidAmountException;
+import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.member.domain.repository.MemberRepository;
+import com.tenten.studybadge.payment.domain.entity.Payment;
+import com.tenten.studybadge.payment.domain.repository.PaymentRepository;
+import com.tenten.studybadge.payment.dto.PaymentRequest;
+import com.tenten.studybadge.payment.dto.PaymentResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final MemberRepository memberRepository;
+    private final PaymentRepository paymentRepository;
+    private final PaymentConfig paymentConfig;
+    @Transactional
+    public PaymentResponse requestPayment(Long memberId, PaymentRequest paymentRequest) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+
+        if(paymentRequest.getAmount() < 10000) {
+            throw new InvalidAmountException();
+        }
+
+        Payment payment = paymentRequest.toEntity();
+
+        Payment updatedPayment = payment.toBuilder()
+                .customer(member)
+                .build();
+        Payment savedPayment = paymentRepository.save(updatedPayment);
+
+        return PaymentResponse.toResponse(savedPayment, paymentConfig.getSuccessUrl(), paymentConfig.getFailUrl());
+    }
+}

--- a/src/main/java/com/tenten/studybadge/type/payment/PayType.java
+++ b/src/main/java/com/tenten/studybadge/type/payment/PayType.java
@@ -1,0 +1,17 @@
+package com.tenten.studybadge.type.payment;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public enum PayType {
+
+    CARD("카드"),
+    CASH("현금"),
+    POINT("포인트");
+
+    private String description;
+}

--- a/src/test/java/com/tenten/studybadge/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/payment/service/PaymentServiceTest.java
@@ -1,0 +1,116 @@
+package com.tenten.studybadge.payment.service;
+
+import com.tenten.studybadge.common.config.PaymentConfig;
+import com.tenten.studybadge.common.exception.member.NotFoundMemberException;
+import com.tenten.studybadge.common.exception.payment.InvalidAmountException;
+import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.member.domain.repository.MemberRepository;
+import com.tenten.studybadge.payment.domain.entity.Payment;
+import com.tenten.studybadge.payment.domain.repository.PaymentRepository;
+import com.tenten.studybadge.payment.dto.PaymentRequest;
+import com.tenten.studybadge.payment.dto.PaymentResponse;
+import com.tenten.studybadge.type.payment.PayType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class PaymentServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private PaymentConfig paymentConfig;
+
+    @InjectMocks
+    private PaymentService paymentService;
+
+    private Member member;
+    private PaymentRequest paymentRequest;
+    private Payment payment;
+    private Payment savedPayment;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder().id(1L).email("test@example.com").build();
+
+        paymentRequest = new PaymentRequest();
+        paymentRequest.setAmount(20000L);
+        paymentRequest.setOrderName("포인트충전");
+        paymentRequest.setPayType(PayType.CARD);
+
+        payment = Payment.builder()
+                .payType(paymentRequest.getPayType())
+                .customer(member)
+                .orderName(paymentRequest.getOrderName())
+                .build();
+
+
+        savedPayment = Payment.builder()
+                .payType(paymentRequest.getPayType())
+                .customer(member)
+                .orderName(paymentRequest.getOrderName())
+                .build();
+    }
+
+    @DisplayName("[결제 요청 성공]")
+    @Test
+    void requestPayment_Success() {
+        // Given
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
+        when(paymentRepository.save(any(Payment.class))).thenReturn(savedPayment);
+        when(paymentConfig.getSuccessUrl()).thenReturn("http://success.url");
+        when(paymentConfig.getFailUrl()).thenReturn("http://fail.url");
+
+        // When
+        PaymentResponse response = paymentService.requestPayment(1L, paymentRequest);
+
+        // Then
+        assertNotNull(response);
+        assertEquals("http://success.url", response.getSuccessUrl());
+        assertEquals("http://fail.url", response.getFailUrl());
+        assertEquals("카드", response.getPayType());
+        assertEquals("포인트충전", response.getOrderName());
+        assertEquals("test@example.com", response.getCustomerEmail());
+    }
+
+    @DisplayName("[존재하지 않는 회원]")
+    @Test
+    void requestPayment_MemberNotFound() {
+        // Given
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(NotFoundMemberException.class, () -> {
+            paymentService.requestPayment(1L, paymentRequest);
+        });
+    }
+
+    @DisplayName("[조건에 맞지않는 충전금액]")
+    @Test
+    void requestPayment_InvalidAmount() {
+        // Given
+        paymentRequest.setAmount(5000L);
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
+
+        // When & Then
+        assertThrows(InvalidAmountException.class, () -> {
+            paymentService.requestPayment(1L, paymentRequest);
+        });
+    }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
[구현 기능]
- 토스페이먼츠 API를 사용하여 결제 요청 기능을 구현하였습니다.
- 결제 요청 시 결제 모달 창이 뜨며, 본인의 스마트폰으로 결제 테스트 가능합니다.

***임시로 yml 파일에 성공/실패 Url 값을 넣어놨으며, 추후 프론트와 상의하여 변경할 예정입니다.***

**PaymentRequest에서 문자열은 따로 어디다 뺄지 애매하여 일단 두었습니다.**
**결제 명칭을 Payment로 할지 포인트 충전 개념인 Charge로 할지 고민중입니다.**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
  - [x] 결제 모달창 테스트