### PR TITLE
feat: STD-26 스터디 채널 정보 수정 기능 구현

### DIFF
--- a/src/main/java/com/tenten/studybadge/study/channel/controller/StudyChannelController.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/controller/StudyChannelController.java
@@ -2,10 +2,7 @@ package com.tenten.studybadge.study.channel.controller;
 
 import com.tenten.studybadge.common.security.CustomUserDetails;
 import com.tenten.studybadge.common.utils.PagingUtils;
-import com.tenten.studybadge.study.channel.dto.SearchCondition;
-import com.tenten.studybadge.study.channel.dto.StudyChannelCreateRequest;
-import com.tenten.studybadge.study.channel.dto.StudyChannelDetailsResponse;
-import com.tenten.studybadge.study.channel.dto.StudyChannelListResponse;
+import com.tenten.studybadge.study.channel.dto.*;
 import com.tenten.studybadge.study.channel.service.StudyChannelService;
 import com.tenten.studybadge.type.study.channel.Category;
 import com.tenten.studybadge.type.study.channel.MeetingType;
@@ -41,6 +38,18 @@ public class StudyChannelController {
         return ResponseEntity
                 .created(URI.create("/api/study-channels/" + studyChannelId))
                 .build();
+    }
+
+    @PutMapping("/study-channels/{studyChannelId}")
+    @Operation(summary = "스터디 채널 정보를 수정", description = "스터디 채널 정보를 수정하기 위해 사용되는 API" ,security = @SecurityRequirement(name = "bearerToken"))
+    @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
+    @Parameter(name = "studyChannelEditRequest", description = "스터디 채널 정보를 수정할 때 필요한 정보들", required = true)
+    public ResponseEntity<Void> putStudyChannel(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable Long studyChannelId,
+            @Valid @RequestBody StudyChannelEditRequest studyChannelEditRequest) {
+        studyChannelService.editStudyChannel(studyChannelId, principal.getId(), studyChannelEditRequest);
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/study-channels/{studyChannelId}/recruitment/start")

--- a/src/main/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannel.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannel.java
@@ -6,6 +6,7 @@ import com.tenten.studybadge.common.exception.studychannel.InSufficientMinMember
 import com.tenten.studybadge.common.exception.studychannel.NotChangeRecruitmentStatusException;
 import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.study.channel.dto.StudyChannelDetailsResponse;
+import com.tenten.studybadge.study.channel.dto.StudyChannelEditRequest;
 import com.tenten.studybadge.study.member.domain.entity.StudyMember;
 import com.tenten.studybadge.type.study.channel.Category;
 import com.tenten.studybadge.type.study.channel.MeetingType;
@@ -132,4 +133,9 @@ public class StudyChannel extends BaseEntity {
         return builder.build();
     }
 
+    public void edit(StudyChannelEditRequest studyChannelEditRequest) {
+        this.name = studyChannelEditRequest.getName();
+        this.description = studyChannelEditRequest.getDescription();
+        this.chattingUrl = studyChannelEditRequest.getChattingUrl();
+    }
 }

--- a/src/main/java/com/tenten/studybadge/study/channel/dto/StudyChannelEditRequest.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/dto/StudyChannelEditRequest.java
@@ -1,0 +1,19 @@
+package com.tenten.studybadge.study.channel.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class StudyChannelEditRequest {
+
+    @NotBlank(message = "스터디 채널명은 필수입니다.")
+    private String name;
+    @NotBlank(message = "스터디 채널 소개글은 필수입니다.")
+    private String description;
+    private String chattingUrl;
+
+}

--- a/src/main/java/com/tenten/studybadge/study/channel/service/StudyChannelService.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/service/StudyChannelService.java
@@ -10,10 +10,7 @@ import com.tenten.studybadge.participation.domain.entity.Participation;
 import com.tenten.studybadge.participation.domain.repository.ParticipationRepository;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
 import com.tenten.studybadge.study.channel.domain.repository.StudyChannelRepository;
-import com.tenten.studybadge.study.channel.dto.SearchCondition;
-import com.tenten.studybadge.study.channel.dto.StudyChannelCreateRequest;
-import com.tenten.studybadge.study.channel.dto.StudyChannelDetailsResponse;
-import com.tenten.studybadge.study.channel.dto.StudyChannelListResponse;
+import com.tenten.studybadge.study.channel.dto.*;
 import com.tenten.studybadge.study.member.domain.entity.StudyMember;
 import com.tenten.studybadge.study.member.domain.repository.StudyMemberRepository;
 import com.tenten.studybadge.type.participation.ParticipationStatus;
@@ -128,6 +125,16 @@ public class StudyChannelService {
         if (!studyChannel.isLeader(member)) {
             throw new NotStudyLeaderException();
         }
+    }
+
+    public void editStudyChannel(Long studyChannelId, Long memberId, StudyChannelEditRequest studyChannelEditRequest) {
+        Member member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
+        StudyChannel studyChannel = studyChannelRepository.findByIdWithMember(studyChannelId).orElseThrow(NotFoundStudyChannelException::new);
+        if (!studyChannel.isLeader(member)) {
+            throw new NotStudyLeaderException();
+        }
+        studyChannel.edit(studyChannelEditRequest);
+        studyChannelRepository.save(studyChannel);
     }
 
     public static class StudyChannelSpecification {


### PR DESCRIPTION
### 변경사항
**AS-IS**

**TO-BE**
- 스터디 채널 정보를 수정하는 기능을 구현했습니다.
- 일단 프론트 측에서 수정할 데이터 중 변경된 값과 기존 값을 모두 같이 보내준다는 가정하에 코드를 작성했습니다.
- 스터디 리더가 아닐 경우 스터디 채널 정보를 수정할 수 없습니다.

### 테스트
- [x] 테스트 코드
- [x] API 테스트 