### PR TITLE
Feat: STD-8 결제 승인(성공) 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client:3.3.1'
 	implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.3'
 
+	//WebClient
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	// Json simple
 	implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,9 +35,6 @@ dependencies {
 	//WebClient
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-	// Json simple
-	implementation 'com.googlecode.json-simple:json-simple:1.1.1'
-
 	//JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/tenten/studybadge/common/config/WebClientConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/WebClientConfig.java
@@ -1,0 +1,13 @@
+package com.tenten.studybadge.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient webClient() {
+        return WebClient.create();
+    }
+}

--- a/src/main/java/com/tenten/studybadge/common/constant/PaymentConstant.java
+++ b/src/main/java/com/tenten/studybadge/common/constant/PaymentConstant.java
@@ -1,0 +1,8 @@
+package com.tenten.studybadge.common.constant;
+
+public class PaymentConstant {
+
+    public static final String BASIC = "Basic ";
+
+    public static final String COLON = ":";
+}

--- a/src/main/java/com/tenten/studybadge/common/exception/payment/AlreadyApprovedException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/payment/AlreadyApprovedException.java
@@ -1,0 +1,20 @@
+package com.tenten.studybadge.common.exception.payment;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class AlreadyApprovedException extends AbstractException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+    @Override
+    public String getErrorCode() {
+        return "ALREADY_APPROVED";
+    }
+    @Override
+    public String getMessage() {
+        return "이미 승인된 결제입니다.";
+    }
+}

--- a/src/main/java/com/tenten/studybadge/common/exception/payment/AlreadyApprovedPaymentException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/payment/AlreadyApprovedPaymentException.java
@@ -3,7 +3,7 @@ package com.tenten.studybadge.common.exception.payment;
 import com.tenten.studybadge.common.exception.basic.AbstractException;
 import org.springframework.http.HttpStatus;
 
-public class AlreadyApprovedException extends AbstractException {
+public class AlreadyApprovedPaymentException extends AbstractException {
 
     @Override
     public HttpStatus getHttpStatus() {

--- a/src/main/java/com/tenten/studybadge/common/exception/payment/NotFoundOrderException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/payment/NotFoundOrderException.java
@@ -1,0 +1,20 @@
+package com.tenten.studybadge.common.exception.payment;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundOrderException extends AbstractException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+    @Override
+    public String getErrorCode() {
+        return "NOT_FOUND_ORDER";
+    }
+    @Override
+    public String getMessage() {
+        return "주문번호에 해당하는 주문이 없습니다.";
+    }
+}

--- a/src/main/java/com/tenten/studybadge/common/exception/payment/NotMatchAmountException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/payment/NotMatchAmountException.java
@@ -1,0 +1,20 @@
+package com.tenten.studybadge.common.exception.payment;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class NotMatchAmountException extends AbstractException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+    @Override
+    public String getErrorCode() {
+        return "NOT_MATCH_AMOUNT";
+    }
+    @Override
+    public String getMessage() {
+        return "주문 금액과 요청한 금액이 일치하지 않습니다.";
+    }
+}

--- a/src/main/java/com/tenten/studybadge/payment/controller/PaymentController.java
+++ b/src/main/java/com/tenten/studybadge/payment/controller/PaymentController.java
@@ -33,7 +33,7 @@ public class PaymentController {
     @Operation(summary = "결제 성공", description = "토스페이먼츠에서 결제 승인되어 성공 정보를 저장하는 API", security = @SecurityRequirement(name = "bearerToken"))
     @Parameter(name = "confirmRequest", description = "결제 승인을 위한 요청 값(paymentKey, orderId, amount)")
     @PostMapping("/success")
-    public ResponseEntity<PaymentConfirm> paymentConfirm(@Valid @RequestBody PaymentConfirmRequest confirmRequest) {
+    public ResponseEntity<PaymentConfirm> confirmPayment(@Valid @RequestBody PaymentConfirmRequest confirmRequest) {
 
         PaymentConfirm confirm = paymentService.paymentConfirm(confirmRequest);
 

--- a/src/main/java/com/tenten/studybadge/payment/controller/PaymentController.java
+++ b/src/main/java/com/tenten/studybadge/payment/controller/PaymentController.java
@@ -32,7 +32,7 @@ public class PaymentController {
     }
     @Operation(summary = "결제 성공", description = "토스페이먼츠에서 결제 승인되어 성공 정보를 저장하는 API", security = @SecurityRequirement(name = "bearerToken"))
     @Parameter(name = "confirmRequest", description = "결제 승인을 위한 요청 값(paymentKey, orderId, amount)")
-    @GetMapping("/success")
+    @PostMapping("/success")
     public ResponseEntity<PaymentConfirm> paymentConfirm(@Valid @RequestBody PaymentConfirmRequest confirmRequest) {
 
         PaymentConfirm confirm = paymentService.paymentConfirm(confirmRequest);

--- a/src/main/java/com/tenten/studybadge/payment/controller/PaymentController.java
+++ b/src/main/java/com/tenten/studybadge/payment/controller/PaymentController.java
@@ -1,8 +1,10 @@
 package com.tenten.studybadge.payment.controller;
 
 import com.tenten.studybadge.common.security.CustomUserDetails;
+import com.tenten.studybadge.payment.dto.PaymentConfirmRequest;
 import com.tenten.studybadge.payment.dto.PaymentRequest;
 import com.tenten.studybadge.payment.dto.PaymentResponse;
+import com.tenten.studybadge.payment.dto.PaymentConfirm;
 import com.tenten.studybadge.payment.service.PaymentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,10 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,5 +29,15 @@ public class PaymentController {
         PaymentResponse response = paymentService.requestPayment(principal.getId(), paymentRequest);
 
         return ResponseEntity.ok(response);
+    }
+    @Operation(summary = "결제 성공", description = "토스페이먼츠에서 결제 승인되어 성공 정보를 저장하는 API", security = @SecurityRequirement(name = "bearerToken"))
+    @Parameter(name = "confirmRequest", description = "결제 승인을 위한 요청 값(paymentKey, orderId, amount)")
+    @GetMapping("/success")
+    public ResponseEntity<PaymentConfirm> paymentConfirm(@Valid @RequestBody PaymentConfirmRequest confirmRequest) {
+
+        PaymentConfirm confirm = paymentService.paymentConfirm(confirmRequest);
+
+        return ResponseEntity.ok(confirm);
+
     }
 }

--- a/src/main/java/com/tenten/studybadge/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/tenten/studybadge/payment/domain/repository/PaymentRepository.java
@@ -4,6 +4,9 @@ import com.tenten.studybadge.payment.domain.entity.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    Optional<Payment> findByOrderId(String orderId);
 }

--- a/src/main/java/com/tenten/studybadge/payment/dto/PaymentConfirm.java
+++ b/src/main/java/com/tenten/studybadge/payment/dto/PaymentConfirm.java
@@ -1,0 +1,25 @@
+package com.tenten.studybadge.payment.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class PaymentConfirm {
+
+    private String paymentKey;
+
+    private String orderId;
+
+    private String orderName;
+
+    private String method;
+
+    private String totalAmount;
+
+    private String requestedAt;
+
+    private String approvedAt;
+}

--- a/src/main/java/com/tenten/studybadge/payment/dto/PaymentConfirm.java
+++ b/src/main/java/com/tenten/studybadge/payment/dto/PaymentConfirm.java
@@ -2,6 +2,8 @@ package com.tenten.studybadge.payment.dto;
 
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -17,9 +19,9 @@ public class PaymentConfirm {
 
     private String method;
 
-    private String totalAmount;
+    private int totalAmount;
 
-    private String requestedAt;
+    private LocalDateTime requestedAt;
 
-    private String approvedAt;
+    private LocalDateTime approvedAt;
 }

--- a/src/main/java/com/tenten/studybadge/payment/dto/PaymentConfirmRequest.java
+++ b/src/main/java/com/tenten/studybadge/payment/dto/PaymentConfirmRequest.java
@@ -1,0 +1,24 @@
+package com.tenten.studybadge.payment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentConfirmRequest {
+
+    @NotBlank
+    private String paymentKey;
+
+    @NotBlank
+    private String orderId;
+
+    @NotNull
+    private Long amount;
+}

--- a/src/main/java/com/tenten/studybadge/payment/service/PaymentService.java
+++ b/src/main/java/com/tenten/studybadge/payment/service/PaymentService.java
@@ -33,7 +33,7 @@ public class PaymentService {
     private final MemberRepository memberRepository;
     private final PaymentRepository paymentRepository;
     private final PaymentConfig paymentConfig;
-    @Transactional
+
     public PaymentResponse requestPayment(Long memberId, PaymentRequest paymentRequest) {
 
         Member member = memberRepository.findById(memberId)
@@ -84,7 +84,6 @@ public class PaymentService {
         return payment;
     }
 
-    @Transactional
     public PaymentConfirm requestPaymentAccept(PaymentConfirmRequest confirmRequest) {
 
         WebClient webClient = WebClient.builder()

--- a/src/main/java/com/tenten/studybadge/payment/service/PaymentService.java
+++ b/src/main/java/com/tenten/studybadge/payment/service/PaymentService.java
@@ -3,15 +3,28 @@ package com.tenten.studybadge.payment.service;
 import com.tenten.studybadge.common.config.PaymentConfig;
 import com.tenten.studybadge.common.exception.member.NotFoundMemberException;
 import com.tenten.studybadge.common.exception.payment.InvalidAmountException;
+import com.tenten.studybadge.common.exception.payment.NotFoundOrderException;
+import com.tenten.studybadge.common.exception.payment.NotMatchAmountException;
 import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.member.domain.repository.MemberRepository;
 import com.tenten.studybadge.payment.domain.entity.Payment;
 import com.tenten.studybadge.payment.domain.repository.PaymentRepository;
+import com.tenten.studybadge.payment.dto.PaymentConfirmRequest;
 import com.tenten.studybadge.payment.dto.PaymentRequest;
 import com.tenten.studybadge.payment.dto.PaymentResponse;
+import com.tenten.studybadge.payment.dto.PaymentConfirm;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static com.tenten.studybadge.common.constant.PaymentConstant.BASIC;
+import static com.tenten.studybadge.common.constant.PaymentConstant.COLON;
 
 @Service
 @RequiredArgsConstructor
@@ -38,5 +51,62 @@ public class PaymentService {
         Payment savedPayment = paymentRepository.save(updatedPayment);
 
         return PaymentResponse.toResponse(savedPayment, paymentConfig.getSuccessUrl(), paymentConfig.getFailUrl());
+    }
+    @Transactional
+    public PaymentConfirm paymentConfirm(PaymentConfirmRequest confirmRequest) {
+
+        Payment payment = verifyPayment(confirmRequest.getOrderId(), confirmRequest.getAmount());
+        PaymentConfirm result = requestPaymentAccept(confirmRequest);
+
+        Member updatedCustomer = payment.getCustomer().toBuilder()
+                .point((int) (payment.getCustomer().getPoint() + confirmRequest.getAmount()))
+                .build();
+        memberRepository.save(updatedCustomer);
+
+        Payment updatedPayment = payment.toBuilder()
+                .successYN(true)
+                .paymentKey(confirmRequest.getPaymentKey())
+                .build();
+        paymentRepository.save(updatedPayment);
+
+        return result;
+    }
+
+    public Payment verifyPayment(String orderId, Long amount) {
+        Payment payment = paymentRepository.findByOrderId(orderId)
+                .orElseThrow(NotFoundOrderException::new);
+
+        if (!payment.getAmount().equals(amount)) {
+
+            throw new NotMatchAmountException();
+        }
+
+        return payment;
+    }
+
+    @Transactional
+    public PaymentConfirm requestPaymentAccept(PaymentConfirmRequest confirmRequest) {
+
+        WebClient webClient = WebClient.builder()
+                .baseUrl(PaymentConfig.TOSS_URL)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, createAuthorizationHeader())
+                .build();
+
+        return webClient.post()
+                .uri(uriBuilder -> uriBuilder.path(confirmRequest.getPaymentKey())
+                        .build())
+                .bodyValue(confirmRequest)
+                .retrieve()
+                .bodyToMono(PaymentConfirm.class)
+                .block();
+    }
+
+    private String createAuthorizationHeader() {
+
+        String auth = paymentConfig.getTestSecretKey() + COLON;
+        byte[] encodedAuth = Base64.getEncoder().encode(auth.getBytes(StandardCharsets.UTF_8));
+
+        return BASIC + new String(encodedAuth);
     }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
[기능 구현]
- 토스페이먼츠 결제 승인 요청하는 기능을 구현하였습니다.
   - 승인이 성공적으로 완료되면, 토스 테스트서버에 결제내역에 결제완료로 남게됩니다.
   - paymentKey는 토스 결제 식별키로 데이터베이스에 저장됩니다.
   - 결제 성공 후 successYN이 기존 false에서 true를 반환하게 됩니다.
 
**브랜치 이름은 success이지만 어감이 이상하여, confirm으로 변경된 점 이해해주시길 바랍니다.**

***간단하게 RestTemplate을 사용하려했지만, Spring 에서 Webclient를 권장하여 Webclient를 적용하였습니다.***

Webclient를 더 알아보고 더 깔끔하게 작성할 수 있게 추후에 리팩토링도 진행할 예정입니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 