### PR TITLE
feat: STD-27 서브 리더 역할 부여 기능

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/exception/studychannel/AlreadyExistsSubLeaderException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/studychannel/AlreadyExistsSubLeaderException.java
@@ -1,0 +1,28 @@
+package com.tenten.studybadge.common.exception.studychannel;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class AlreadyExistsSubLeaderException extends AbstractException {
+
+    private static final String ERROR_CODE = "ALREADY_EXISTS_SUB_LEADER";
+    private static final String ERROR_MESSAGE = "이미 서브 리더가 존재합니다. 서브 리더는 스터디 채널 당 1명만 가능합니다.";
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return BAD_REQUEST;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public String getMessage() {
+        return ERROR_MESSAGE;
+    }
+
+}

--- a/src/main/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannel.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannel.java
@@ -75,14 +75,14 @@ public class StudyChannel extends BaseEntity {
         studyMembers.add(studyMember);
     }
 
-    private StudyMember getLeader() {
+    public StudyMember getLeader() {
         return studyMembers.stream()
                 .filter(StudyMember::isLeader)
                 .findFirst()
                 .orElse(null);
     }
 
-    private StudyMember getSubLeader() {
+    public StudyMember getSubLeader() {
         return studyMembers.stream()
                 .filter(StudyMember::isSubLeader)
                 .findFirst()

--- a/src/main/java/com/tenten/studybadge/study/member/controller/StudyMemberController.java
+++ b/src/main/java/com/tenten/studybadge/study/member/controller/StudyMemberController.java
@@ -1,16 +1,16 @@
 package com.tenten.studybadge.study.member.controller;
 
 import com.tenten.studybadge.common.security.CustomUserDetails;
+import com.tenten.studybadge.study.member.dto.AssignRoleRequest;
 import com.tenten.studybadge.study.member.dto.StudyMembersResponse;
 import com.tenten.studybadge.study.member.service.StudyMemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,6 +25,18 @@ public class StudyMemberController {
             @AuthenticationPrincipal CustomUserDetails principal,
             @PathVariable Long studyChannelId) {
         return ResponseEntity.ok(studyMemberService.getStudyMembers(studyChannelId, principal.getId()));
+    }
+
+    @PostMapping("/api/study-channels/{studyChannelId}/members/assign-role")
+    @Operation(summary = "서브 리더 역할 부여", description = "스터디 멤버에게 서브 리더 역할을 부여해주는 API")
+    @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
+    @Parameter(name = "assignRoleRequest", description = "서브 리더 권한을 부여받을 스터디 멤버 정보", required = true)
+    public ResponseEntity<Void> assignSubLeaderRole(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable Long studyChannelId,
+            @Valid @RequestBody AssignRoleRequest assignRoleRequest) {
+        studyMemberService.assignStudyLeaderRole(studyChannelId, principal.getId(), assignRoleRequest.getStudyMemberId());
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/tenten/studybadge/study/member/domain/entity/StudyMember.java
+++ b/src/main/java/com/tenten/studybadge/study/member/domain/entity/StudyMember.java
@@ -22,6 +22,7 @@ public class StudyMember extends BaseEntity {
     @Column(name = "study_member_id")
     private Long id;
 
+    @Setter
     @Enumerated(EnumType.STRING)
     private StudyMemberRole studyMemberRole;
 

--- a/src/main/java/com/tenten/studybadge/study/member/dto/AssignRoleRequest.java
+++ b/src/main/java/com/tenten/studybadge/study/member/dto/AssignRoleRequest.java
@@ -1,0 +1,17 @@
+package com.tenten.studybadge.study.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AssignRoleRequest {
+
+    @NotNull(message = "스터디 멤버 ID는 필수입니다.")
+    private Long studyMemberId;
+}

--- a/src/main/java/com/tenten/studybadge/study/member/service/StudyMemberService.java
+++ b/src/main/java/com/tenten/studybadge/study/member/service/StudyMemberService.java
@@ -1,10 +1,16 @@
 package com.tenten.studybadge.study.member.service;
 
-import com.tenten.studybadge.common.exception.studychannel.NotStudyMemberException;
+import com.tenten.studybadge.common.exception.member.NotFoundMemberException;
+import com.tenten.studybadge.common.exception.studychannel.*;
+import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.member.domain.repository.MemberRepository;
+import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
+import com.tenten.studybadge.study.channel.domain.repository.StudyChannelRepository;
 import com.tenten.studybadge.study.member.domain.entity.StudyMember;
 import com.tenten.studybadge.study.member.domain.repository.StudyMemberRepository;
 import com.tenten.studybadge.study.member.dto.StudyMemberInfoResponse;
 import com.tenten.studybadge.study.member.dto.StudyMembersResponse;
+import com.tenten.studybadge.type.study.member.StudyMemberRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +21,8 @@ import java.util.List;
 public class StudyMemberService {
 
     private final StudyMemberRepository studyMemberRepository;
+    private final StudyChannelRepository studyChannelRepository;
+    private final MemberRepository memberRepository;
 
     public StudyMembersResponse getStudyMembers(Long studyChannelId, Long memberId) {
 
@@ -34,6 +42,38 @@ public class StudyMemberService {
                 .studyMembers(responses)
                 .isLeader(isLeader)
                 .build();
+    }
+
+    public void assignStudyLeaderRole(Long studyChannelId, Long memberId, Long studyMemberId) {
+
+        Member member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
+        StudyChannel studyChannel = studyChannelRepository.findByIdWithMember(studyChannelId).orElseThrow(NotFoundStudyChannelException::new);
+
+        checkLeader(studyChannel, member);
+
+        StudyMember subLeader = studyChannel.getSubLeader();
+        StudyMember target = getStudyMember(studyChannel, studyMemberId);
+
+        if (subLeader != null) {
+            throw new AlreadyExistsSubLeaderException();
+        }
+
+        target.setStudyMemberRole(StudyMemberRole.SUB_LEADER);
+        studyMemberRepository.save(target);
+
+    }
+
+    private StudyMember getStudyMember(StudyChannel studyChannel, Long studyMemberId) {
+        return studyChannel.getStudyMembers().stream()
+                .filter(studyMember -> studyMember.getId().equals(studyMemberId))
+                .findFirst()
+                .orElseThrow(NotStudyMemberException::new);
+    }
+
+    private void checkLeader(StudyChannel studyChannel, Member member) {
+        if (!studyChannel.isLeader(member)) {
+            throw new NotStudyLeaderException();
+        }
     }
 
 }

--- a/src/test/java/com/tenten/studybadge/study/member/service/StudyMemberServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/study/member/service/StudyMemberServiceTest.java
@@ -1,11 +1,19 @@
 package com.tenten.studybadge.study.member.service;
 
+import com.tenten.studybadge.common.exception.studychannel.AlreadyExistsSubLeaderException;
 import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.member.domain.repository.MemberRepository;
+import com.tenten.studybadge.study.channel.domain.entity.Recruitment;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
+import com.tenten.studybadge.study.channel.domain.entity.StudyDuration;
+import com.tenten.studybadge.study.channel.domain.repository.StudyChannelRepository;
 import com.tenten.studybadge.study.member.domain.entity.StudyMember;
 import com.tenten.studybadge.study.member.domain.repository.StudyMemberRepository;
 import com.tenten.studybadge.study.member.dto.StudyMembersResponse;
 import com.tenten.studybadge.type.member.BadgeLevel;
+import com.tenten.studybadge.type.study.channel.Category;
+import com.tenten.studybadge.type.study.channel.MeetingType;
+import com.tenten.studybadge.type.study.channel.RecruitmentStatus;
 import com.tenten.studybadge.type.study.member.StudyMemberRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,9 +24,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,6 +40,12 @@ class StudyMemberServiceTest {
 
     @Mock
     private StudyMemberRepository studyMemberRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private StudyChannelRepository studyChannelRepository;
 
     @DisplayName("[스터디 멤버 리스트 조회 테스트]")
     @Nested
@@ -119,6 +136,98 @@ class StudyMemberServiceTest {
 
         }
 
+    }
+
+    @DisplayName("[스터디 채널 서브 리더 권한 부여 기능 테스트]")
+    @Nested
+    class AssignSubLeaderRoleTest {
+
+        Member member1;
+        Member member2;
+        Member member3;
+
+        StudyChannel studyChannel;
+
+        @BeforeEach
+        void setUp() {
+            member1 = Member.builder().id(1L).name("회원 1").build();
+            member2 = Member.builder().id(2L).name("회원 2").build();
+            member3 = Member.builder().id(3L).name("회원 3").build();
+
+            LocalDate now = LocalDate.now();
+            studyChannel = StudyChannel.builder()
+                    .id(1L)
+                    .name("스터디명")
+                    .description("스터디 설명")
+                    .studyDuration(StudyDuration.builder()
+                            .studyStartDate(now.plusDays(2))
+                            .studyEndDate(now.plusMonths(4))
+                            .build())
+                    .recruitment(Recruitment.builder()
+                            .recruitmentNumber(6)
+                            .recruitmentStatus(RecruitmentStatus.RECRUITING)
+                            .build())
+                    .category(Category.IT)
+                    .region(null)
+                    .meetingType(MeetingType.ONLINE)
+                    .chattingUrl("오픈채팅방 URL")
+                    .deposit(10_000)
+                    .viewCnt(4)
+                    .build();
+        }
+
+        @DisplayName("정상적으로 서브 리더의 권한을 부여한다.")
+        @Test
+        void success_assignSubLeaderRole() {
+            StudyMember leader = StudyMember.builder()
+                    .id(1L)
+                    .studyChannel(studyChannel)
+                    .member(member1)
+                    .studyMemberRole(StudyMemberRole.LEADER)
+                    .build();
+            StudyMember studyMember = StudyMember.builder()
+                    .id(2L)
+                    .studyChannel(studyChannel)
+                    .member(member2)
+                    .studyMemberRole(StudyMemberRole.STUDY_MEMBER)
+                    .build();
+
+            studyChannel.getStudyMembers().addAll(List.of(leader, studyMember));
+
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member1));
+            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
+
+            studyMemberService.assignStudyLeaderRole(1L, 1L, 2L);
+
+            assertThat(studyMember.getStudyMemberRole()).isEqualTo(StudyMemberRole.SUB_LEADER);
+        }
+
+        @DisplayName("스터디 채널 내에 서브 리더가 있을 경우 예외가 발생한다.")
+        @Test
+        void fail_alreadyExistsSubLeader() {
+            StudyMember leader = StudyMember.builder()
+                    .id(1L)
+                    .studyChannel(studyChannel)
+                    .member(member1)
+                    .studyMemberRole(StudyMemberRole.LEADER)
+                    .build();
+            StudyMember studyMember = StudyMember.builder()
+                    .id(2L)
+                    .studyChannel(studyChannel)
+                    .member(member2)
+                    .studyMemberRole(StudyMemberRole.SUB_LEADER)
+                    .build();
+
+            studyChannel.getStudyMembers().addAll(List.of(leader, studyMember));
+
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member1));
+            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
+
+            assertThatThrownBy(() ->
+                studyMemberService.assignStudyLeaderRole(1L, 1L, 2L)
+            )
+            .isExactlyInstanceOf(AlreadyExistsSubLeaderException.class);
+        }
     }
 
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
- StudyChannel 내 getLeader, getSubLeader 메서드가 private 으로 선언.
**TO-BE**
- getLeader, getSubLeader 메서드의 접근 제어자를 public으로 수정

[기능]
- 리더가 특정 스터디 멤버에게 서브 리더 역할을 부여하는 기능을 구현.
- 스터디 채널 당 1명의 서브 리더를 부여할 수 있습니다.
  - 따라서 스터디 채널 내 서브 리더의 역할을 가진 스터디 멤버가 존재할 경우 예외가 발생합니다.

[문제 해결]
- AssignRoleRequest와 같이 하나의 값만 갖고 있는 DTO를  Object로 변환할 때 기본 생성자가 없을 경우 예외가 발생.
- 관련 이슈 : https://github.com/FasterXML/jackson-databind/issues/3085

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 