### PR TITLE
Feat: STD-29 결제 취소 기능 구현

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
         return http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests( requests -> requests
                         .requestMatchers("/api/members/sign-up", "/api/members/auth/**", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/api/members/login/**", "/error", "/health-check").permitAll()
-                        .requestMatchers("/api/token/oauth2/**", "/favicon.ico", "/oauth2/**").permitAll()
+                        .requestMatchers("/api/token/oauth2/**", "/favicon.ico", "/oauth2/**", "/api/payments/success/**", "/api/payments/cancel/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/study-channels", "/api/study-channels/{studyChannelId:\\d+}").permitAll()
                         .requestMatchers("/api/members/logout", "api/study-channels/*/places", "/api/study-channels/**", "/api/token/re-issue"
                                 , "/api/members/my-info", "/api/members/my-info/update", "/api/payments/**").hasRole("USER"))

--- a/src/main/java/com/tenten/studybadge/common/constant/PaymentConstant.java
+++ b/src/main/java/com/tenten/studybadge/common/constant/PaymentConstant.java
@@ -5,4 +5,8 @@ public class PaymentConstant {
     public static final String BASIC = "Basic ";
 
     public static final String COLON = ":";
+
+    public static final String CANCEL_URL = "/cancel";
+
+    public static final String CANCEL_REASON = "cancelReason";
 }

--- a/src/main/java/com/tenten/studybadge/common/exception/payment/NotEnoughPointException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/payment/NotEnoughPointException.java
@@ -1,0 +1,20 @@
+package com.tenten.studybadge.common.exception.payment;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class NotEnoughPointException extends AbstractException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+    @Override
+    public String getErrorCode() {
+        return "NOT_ENOUGH_POINT";
+    }
+    @Override
+    public String getMessage() {
+        return "포인트가 충분하지 않습니다.";
+    }
+}

--- a/src/main/java/com/tenten/studybadge/payment/controller/PaymentController.java
+++ b/src/main/java/com/tenten/studybadge/payment/controller/PaymentController.java
@@ -1,10 +1,7 @@
 package com.tenten.studybadge.payment.controller;
 
 import com.tenten.studybadge.common.security.CustomUserDetails;
-import com.tenten.studybadge.payment.dto.PaymentConfirmRequest;
-import com.tenten.studybadge.payment.dto.PaymentRequest;
-import com.tenten.studybadge.payment.dto.PaymentResponse;
-import com.tenten.studybadge.payment.dto.PaymentConfirm;
+import com.tenten.studybadge.payment.dto.*;
 import com.tenten.studybadge.payment.service.PaymentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -15,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/payments")
@@ -24,7 +23,8 @@ public class PaymentController {
     @Operation(summary = "결제 요청", description = "토스페이먼츠에 결제 요청할 API", security = @SecurityRequirement(name = "bearerToken"))
     @Parameter(name = "paymentRequest", description = "결제 요청을 위한 값들")
     @PostMapping("/toss")
-    public ResponseEntity<PaymentResponse> requestPayment(@AuthenticationPrincipal CustomUserDetails principal, @Valid @RequestBody PaymentRequest paymentRequest) {
+    public ResponseEntity<PaymentResponse> requestPayment(@AuthenticationPrincipal CustomUserDetails principal,
+                                                          @Valid @RequestBody PaymentRequest paymentRequest) {
 
         PaymentResponse response = paymentService.requestPayment(principal.getId(), paymentRequest);
 
@@ -35,9 +35,19 @@ public class PaymentController {
     @PostMapping("/success")
     public ResponseEntity<PaymentConfirm> confirmPayment(@Valid @RequestBody PaymentConfirmRequest confirmRequest) {
 
-        PaymentConfirm confirm = paymentService.paymentConfirm(confirmRequest);
+        PaymentConfirm confirm = paymentService.confirmPayment(confirmRequest);
 
         return ResponseEntity.ok(confirm);
 
+    }
+    @Operation(summary = "결제 취소", description = "토스페이먼츠에 결제 취소 요청할 API", security = @SecurityRequirement(name = "bearerToken"))
+    @Parameter(name = "cancelRequest", description = "결제 취소를 위한 요청 값(paymentKey, cancelReason)")
+    @PostMapping("/cancel")
+    public ResponseEntity<Map<String, Object>> cancelPayment(@AuthenticationPrincipal CustomUserDetails principal,
+                                                             @Valid @RequestBody PaymentCancelRequest cancelRequest) {
+
+        Map<String, Object> response = paymentService.cancelPayment(principal.getId(), cancelRequest);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/tenten/studybadge/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/tenten/studybadge/payment/domain/repository/PaymentRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     Optional<Payment> findByOrderId(String orderId);
+
+    Optional<Payment> findByPaymentKeyAndCustomerId(String paymentKey, Long memberId);
 }

--- a/src/main/java/com/tenten/studybadge/payment/dto/PaymentCancelRequest.java
+++ b/src/main/java/com/tenten/studybadge/payment/dto/PaymentCancelRequest.java
@@ -1,0 +1,18 @@
+package com.tenten.studybadge.payment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentCancelRequest {
+
+    @NotBlank
+    private String paymentKey;
+
+    @NotBlank
+    private String cancelReason;
+}

--- a/src/main/java/com/tenten/studybadge/payment/dto/PaymentConfirm.java
+++ b/src/main/java/com/tenten/studybadge/payment/dto/PaymentConfirm.java
@@ -2,7 +2,6 @@ package com.tenten.studybadge.payment.dto;
 
 import lombok.*;
 
-import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -19,9 +18,7 @@ public class PaymentConfirm {
 
     private String method;
 
-    private int totalAmount;
+    private String requestedAt;
 
-    private LocalDateTime requestedAt;
-
-    private LocalDateTime approvedAt;
+    private String approvedAt;
 }

--- a/src/main/java/com/tenten/studybadge/payment/service/PaymentService.java
+++ b/src/main/java/com/tenten/studybadge/payment/service/PaymentService.java
@@ -3,17 +3,16 @@ package com.tenten.studybadge.payment.service;
 import com.tenten.studybadge.common.config.PaymentConfig;
 import com.tenten.studybadge.common.exception.member.NotFoundMemberException;
 import com.tenten.studybadge.common.exception.payment.InvalidAmountException;
+import com.tenten.studybadge.common.exception.payment.NotEnoughPointException;
 import com.tenten.studybadge.common.exception.payment.NotFoundOrderException;
 import com.tenten.studybadge.common.exception.payment.NotMatchAmountException;
 import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.member.domain.repository.MemberRepository;
 import com.tenten.studybadge.payment.domain.entity.Payment;
 import com.tenten.studybadge.payment.domain.repository.PaymentRepository;
-import com.tenten.studybadge.payment.dto.PaymentConfirmRequest;
-import com.tenten.studybadge.payment.dto.PaymentRequest;
-import com.tenten.studybadge.payment.dto.PaymentResponse;
-import com.tenten.studybadge.payment.dto.PaymentConfirm;
+import com.tenten.studybadge.payment.dto.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
@@ -22,9 +21,10 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Collections;
+import java.util.Map;
 
-import static com.tenten.studybadge.common.constant.PaymentConstant.BASIC;
-import static com.tenten.studybadge.common.constant.PaymentConstant.COLON;
+import static com.tenten.studybadge.common.constant.PaymentConstant.*;
 
 @Service
 @RequiredArgsConstructor
@@ -53,10 +53,10 @@ public class PaymentService {
         return PaymentResponse.toResponse(savedPayment, paymentConfig.getSuccessUrl(), paymentConfig.getFailUrl());
     }
     @Transactional
-    public PaymentConfirm paymentConfirm(PaymentConfirmRequest confirmRequest) {
+    public PaymentConfirm confirmPayment(PaymentConfirmRequest confirmRequest) {
 
         Payment payment = verifyPayment(confirmRequest.getOrderId(), confirmRequest.getAmount());
-        PaymentConfirm result = requestPaymentAccept(confirmRequest);
+        PaymentConfirm result = requestAcceptPayment(confirmRequest);
 
         Member updatedCustomer = payment.getCustomer().toBuilder()
                 .point((int) (payment.getCustomer().getPoint() + confirmRequest.getAmount()))
@@ -71,6 +71,44 @@ public class PaymentService {
 
         return result;
     }
+    @Transactional
+    public Map<String, Object> cancelPayment(Long memberId, PaymentCancelRequest cancelRequest) {
+
+        Payment payment = paymentRepository
+                .findByPaymentKeyAndCustomerId(cancelRequest.getPaymentKey(), memberId)
+                .orElseThrow(NotFoundOrderException::new);
+
+        if (payment.getCustomer().getPoint() >= payment.getAmount()) {
+
+            Payment canceldPayment = payment.toBuilder()
+                    .cancelYN(true)
+                    .cancelReason(cancelRequest.getCancelReason())
+                    .build();
+            paymentRepository.save(canceldPayment);
+
+            Member updatedMember = payment.getCustomer().toBuilder()
+                    .point((int) (payment.getCustomer().getPoint() + payment.getAmount()))
+                    .build();
+            memberRepository.save(updatedMember);
+
+            return requestCancelPayment(cancelRequest);
+        }
+
+        throw new NotEnoughPointException();
+    }
+
+    public Map<String, Object> requestCancelPayment(PaymentCancelRequest cancelRequest) {
+
+        WebClient webClient = TossWebClient();
+
+        return webClient.post()
+                .uri(uriBuilder -> uriBuilder.path(cancelRequest.getPaymentKey() + CANCEL_URL)
+                .build())
+                .bodyValue(Collections.singletonMap(CANCEL_REASON, cancelRequest.getCancelReason()))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .block();
+    }
 
     public Payment verifyPayment(String orderId, Long amount) {
         Payment payment = paymentRepository.findByOrderId(orderId)
@@ -84,17 +122,13 @@ public class PaymentService {
         return payment;
     }
 
-    public PaymentConfirm requestPaymentAccept(PaymentConfirmRequest confirmRequest) {
+    public PaymentConfirm requestAcceptPayment(PaymentConfirmRequest confirmRequest) {
 
-        WebClient webClient = WebClient.builder()
-                .baseUrl(PaymentConfig.TOSS_URL)
-                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .defaultHeader(HttpHeaders.AUTHORIZATION, createAuthorizationHeader())
-                .build();
+        WebClient webClient = TossWebClient();
 
         return webClient.post()
                 .uri(uriBuilder -> uriBuilder.path(confirmRequest.getPaymentKey())
-                        .build())
+                .build())
                 .bodyValue(confirmRequest)
                 .retrieve()
                 .bodyToMono(PaymentConfirm.class)
@@ -104,8 +138,17 @@ public class PaymentService {
     private String createAuthorizationHeader() {
 
         String auth = paymentConfig.getTestSecretKey() + COLON;
-        byte[] encodedAuth = Base64.getEncoder().encode(auth.getBytes(StandardCharsets.UTF_8));
+        String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
 
-        return BASIC + new String(encodedAuth);
+        return BASIC + encodedAuth;
+    }
+
+    private WebClient TossWebClient() {
+
+        return WebClient.builder()
+                .baseUrl(PaymentConfig.TOSS_URL)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, createAuthorizationHeader())
+                .build();
     }
 }

--- a/src/main/java/com/tenten/studybadge/payment/service/PaymentService.java
+++ b/src/main/java/com/tenten/studybadge/payment/service/PaymentService.java
@@ -87,7 +87,7 @@ public class PaymentService {
             paymentRepository.save(canceldPayment);
 
             Member updatedMember = payment.getCustomer().toBuilder()
-                    .point((int) (payment.getCustomer().getPoint() + payment.getAmount()))
+                    .point((int) (payment.getCustomer().getPoint() - payment.getAmount()))
                     .build();
             memberRepository.save(updatedMember);
 
@@ -99,7 +99,7 @@ public class PaymentService {
 
     public Map<String, Object> requestCancelPayment(PaymentCancelRequest cancelRequest) {
 
-        WebClient webClient = TossWebClient();
+        WebClient webClient = tossWebClient();
 
         return webClient.post()
                 .uri(uriBuilder -> uriBuilder.path(cancelRequest.getPaymentKey() + CANCEL_URL)
@@ -124,7 +124,7 @@ public class PaymentService {
 
     public PaymentConfirm requestAcceptPayment(PaymentConfirmRequest confirmRequest) {
 
-        WebClient webClient = TossWebClient();
+        WebClient webClient = tossWebClient();
 
         return webClient.post()
                 .uri(uriBuilder -> uriBuilder.path(confirmRequest.getPaymentKey())
@@ -143,7 +143,7 @@ public class PaymentService {
         return BASIC + encodedAuth;
     }
 
-    private WebClient TossWebClient() {
+    private WebClient tossWebClient() {
 
         return WebClient.builder()
                 .baseUrl(PaymentConfig.TOSS_URL)


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 결제 재 테스트 시 오류가 발생하여 확인했더니, requestedAt, approvedAt를 LocalDateTime으로 바꾼게 문제였습니다.
- 토스 측에서 LocalDateTime 값이 아닌 String 값으로 정한 것을 잊고 피드백을 반영하고 바꿨었습니다.
- 서비스와 컨트롤러 메서드의 이름이 부자연스러운 상태였습니다.

**TO-BE**
- 결제 취소 기능을 추가했습니다.
- 결제 취소 시 토스 측에서 스마트폰으로 알림이 오는 것을 확인할 수 있습니다.
- ~At 값들을 토스 측 요구에 맞게 String으로 다시 바꾸었습니다.
- 서비스와 컨트롤러 메서드의 명을 자연스럽게 변경하였습니다
- Dto 명은 네이밍규칙에 맞게 유지하기로 했습니다.

***포인트 테이블이 추가로 생기면 변경사항이 있을 수 있습니다***

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 