### PR TITLE
feat: STD-30 일정 자세히 조회

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
@@ -43,7 +43,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/token/oauth2/**", "/favicon.ico", "/oauth2/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/study-channels", "/api/study-channels/{studyChannelId:\\d+}").permitAll()
                         .requestMatchers("/api/members/logout", "api/study-channels/*/places", "/api/study-channels/**", "/api/token/re-issue"
-                                , "/api/members/my-info", "/api/members/my-info/update", "/api/payments/**").hasRole("USER"))
+                                , "/api/members/my-info", "/api/members/my-info/update", "/api/payments/**",
+                            "/api/study-channels/*/schedules/**").hasRole("USER"))
 
                 .cors(cors -> new CorsConfig())
                 .headers(headers -> headers // h2-console 페이지 접속을 위한 설정

--- a/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
@@ -1,5 +1,9 @@
 package com.tenten.studybadge.schedule.controller;
 
+import com.tenten.studybadge.common.security.CustomUserDetails;
+import com.tenten.studybadge.schedule.domain.Schedule;
+import com.tenten.studybadge.schedule.domain.entity.RepeatSchedule;
+import com.tenten.studybadge.schedule.domain.entity.SingleSchedule;
 import com.tenten.studybadge.schedule.dto.RepeatScheduleCreateRequest;
 import com.tenten.studybadge.schedule.dto.ScheduleDeleteRequest;
 import com.tenten.studybadge.schedule.dto.ScheduleEditRequest;
@@ -16,6 +20,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -62,6 +67,30 @@ public class ScheduleController {
     @Parameter(name = "studyChannelId", description = "일정을 만드는 study channel의 id 값", required = true)
     public ResponseEntity<List<ScheduleResponse>> getSchedules(@PathVariable Long studyChannelId) {
         return ResponseEntity.ok(scheduleService.getSchedulesInStudyChannel(studyChannelId));
+    }
+
+    @GetMapping("/study-channels/{studyChannelId}/single-schedules/{scheduleId}")
+    @Operation(summary = "스터디 채널에 존재하는 단일 일정 자세히 조회", description = "스터디 채널에 존재하는 단일 일정 자세히 조회 api, 일정 등록 알림의 relate URL 관련" ,security = @SecurityRequirement(name = "bearerToken"))
+    @Parameter(name = "studyChannelId", description = "일정이 있는 study channel의 id 값", required = true)
+    @Parameter(name = "scheduleId", description = "단일 일정 schedule id 값", required = true)
+    public ResponseEntity<ScheduleResponse> getSingleScheduleDetail(
+        @AuthenticationPrincipal CustomUserDetails memberDetails,
+        @PathVariable Long studyChannelId, @PathVariable Long scheduleId) {
+        SingleSchedule singleSchedule = scheduleService.getSingleSchedule(memberDetails.getId(),
+            studyChannelId, scheduleId);
+        return ResponseEntity.ok(singleSchedule.toResponse());
+    }
+
+    @GetMapping("/study-channels/{studyChannelId}/repeat-schedules/{scheduleId}")
+    @Operation(summary = "스터디 채널에 존재하는 반복 일정 자세히 조회", description = "스터디 채널에 존재하는 반복 일정 자세히 조회 api, 일정 등록 알림의 relate URL 관련" ,security = @SecurityRequirement(name = "bearerToken"))
+    @Parameter(name = "studyChannelId", description = "일정이 있는 study channel의 id 값", required = true)
+    @Parameter(name = "scheduleId", description = "반복 일정 schedule id 값", required = true)
+    public ResponseEntity<ScheduleResponse> getRepeatScheduleDetail(
+        @AuthenticationPrincipal CustomUserDetails memberDetails,
+        @PathVariable Long studyChannelId, @PathVariable Long scheduleId) {
+        RepeatSchedule repeatSchedule = scheduleService.getRepeatSchedule(memberDetails.getId(),
+            studyChannelId, scheduleId);
+        return ResponseEntity.ok(repeatSchedule.toResponse());
     }
 
     @GetMapping("/study-channels/{studyChannelId}/schedules/date")

--- a/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
+++ b/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
@@ -13,6 +13,8 @@ import com.tenten.studybadge.common.exception.schedule.OutRangeScheduleException
 import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelException;
 import com.tenten.studybadge.common.exception.studychannel.NotStudyLeaderException;
 import com.tenten.studybadge.common.exception.studychannel.NotStudyMemberException;
+import com.tenten.studybadge.notification.service.NotificationService;
+import com.tenten.studybadge.schedule.domain.Schedule;
 import com.tenten.studybadge.schedule.domain.entity.RepeatSchedule;
 import com.tenten.studybadge.schedule.domain.entity.SingleSchedule;
 import com.tenten.studybadge.schedule.domain.repository.RepeatScheduleRepository;
@@ -28,6 +30,7 @@ import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
 import com.tenten.studybadge.study.channel.domain.repository.StudyChannelRepository;
 import com.tenten.studybadge.study.member.domain.entity.StudyMember;
 import com.tenten.studybadge.study.member.domain.repository.StudyMemberRepository;
+import com.tenten.studybadge.type.notification.NotificationType;
 import com.tenten.studybadge.type.schedule.RepeatCycle;
 import com.tenten.studybadge.type.schedule.RepeatSituation;
 import com.tenten.studybadge.type.schedule.ScheduleType;
@@ -37,8 +40,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ScheduleService {
@@ -47,14 +52,20 @@ public class ScheduleService {
     private final StudyChannelRepository studyChannelRepository;
     private final StudyMemberRepository studyMemberRepository;
 
+    private final NotificationService notificationService;
+
     public void postSingleSchedule(SingleScheduleCreateRequest singleScheduleCreateRequest, Long studyChannelId) {
         StudyChannel studyChannel =  studyChannelRepository.findById(studyChannelId)
             .orElseThrow(NotFoundStudyChannelException::new);
 
         validateStudyLeader(singleScheduleCreateRequest.getMemberId(), studyChannelId);
 
-        singleScheduleRepository.save(createSingleScheduleFromRequest(
+        SingleSchedule saveSingleSchedule = singleScheduleRepository.save(createSingleScheduleFromRequest(
             singleScheduleCreateRequest, studyChannel));
+        log.info("단일 일정이 생성 되었습니다. studyChannelId: {}", studyChannelId);
+        String url = String.format("/api/study-channels/%d/repeat-schedules/%d", studyChannelId, saveSingleSchedule.getId());
+        notificationService.sendNotificationToStudyChannel(studyChannelId,
+            NotificationType.SCHEDULE_CREATE, "새로운 단일 일정이 등록되었습니다.", url);
     }
 
     public void postRepeatSchedule(RepeatScheduleCreateRequest repeatScheduleCreateRequest, Long studyChannelId) {
@@ -68,7 +79,12 @@ public class ScheduleService {
 
         validateStudyLeader(repeatScheduleCreateRequest.getMemberId(), studyChannelId);
 
-        repeatScheduleRepository.save(createRepeatScheduleFromRequest(repeatScheduleCreateRequest, studyChannel));
+        RepeatSchedule saveRepeatSchedule = repeatScheduleRepository.save(
+            createRepeatScheduleFromRequest(repeatScheduleCreateRequest, studyChannel));
+        String url = String.format("/api/study-channels/%d/repeat-schedules/%d", studyChannelId, saveRepeatSchedule.getId());
+        log.info("반복 일정이 생성 되었습니다. studyChannelId: {}", studyChannelId);
+        notificationService.sendNotificationToStudyChannel(studyChannelId,
+            NotificationType.SCHEDULE_CREATE, "새로운 반복 일정이 등록되었습니다.", url);
     }
 
     public List<ScheduleResponse> getSchedulesInStudyChannel(Long studyChannelId) {
@@ -117,6 +133,24 @@ public class ScheduleService {
         scheduleResponses.addAll(singleScheduleResponses);
         scheduleResponses.addAll(repeatScheduleResponses);
         return scheduleResponses;
+    }
+
+    public SingleSchedule getSingleSchedule(Long memberId, Long studyChannelId, Long scheduleId) {
+
+        studyMemberRepository.findByMemberIdAndStudyChannelId(memberId, studyChannelId)
+            .orElseThrow(NotStudyMemberException::new);
+
+        return singleScheduleRepository.findById(scheduleId)
+            .orElseThrow(NotFoundSingleScheduleException::new);
+    }
+
+    public RepeatSchedule getRepeatSchedule(Long memberId, Long studyChannelId, Long scheduleId) {
+
+        studyMemberRepository.findByMemberIdAndStudyChannelId(memberId, studyChannelId)
+            .orElseThrow(NotStudyMemberException::new);
+
+        return repeatScheduleRepository.findById(scheduleId)
+            .orElseThrow(NotFoundSingleScheduleException::new);
     }
 
     public void putSchedule(Long studyChannelId, ScheduleEditRequest scheduleEditRequest) {

--- a/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
@@ -445,6 +445,7 @@ class ScheduleServiceTest {
     @DisplayName("일정 조회")
     @Nested
     class ScheduleGetTest {
+
         @Test
         @DisplayName("스터디 채널 내의 일정 전체 조회 성공")
         public void success_testGetSchedulesInStudyChannel() {
@@ -473,12 +474,13 @@ class ScheduleServiceTest {
             // given
             RepeatSchedule repeatSchedule2 =
                 RepeatSchedule.withoutIdBuilder()
-                .scheduleDate(LocalDate.of(2024, 5, 15))
-                .repeatEndDate(LocalDate.of(2024, 9, 15))
-                .studyChannel(studyChannel)
-                .build();
+                    .scheduleDate(LocalDate.of(2024, 5, 15))
+                    .repeatEndDate(LocalDate.of(2024, 9, 15))
+                    .studyChannel(studyChannel)
+                    .build();
             LocalDate selectMonthFirstDate = LocalDate.of(2024, 7, 1);
-            LocalDate selectMonthLastDate = selectMonthFirstDate.withDayOfMonth(selectMonthFirstDate.lengthOfMonth());
+            LocalDate selectMonthLastDate = selectMonthFirstDate.withDayOfMonth(
+                selectMonthFirstDate.lengthOfMonth());
 
             given(studyChannelRepository.findById(1L))
                 .willReturn(Optional.of(studyChannel));
@@ -493,17 +495,17 @@ class ScheduleServiceTest {
             // when
             List<ScheduleResponse> scheduleResponses =
                 scheduleService.getSchedulesInStudyChannelForYearAndMonth(
-                1L, 2024, 7);
+                    1L, 2024, 7);
 
             // then
             assertEquals(2, scheduleResponses.size());
             verify(studyChannelRepository, times(1)).findById(1L);
             verify(singleScheduleRepository, times(1))
                 .findAllByStudyChannelIdAndDateRange(
-                1L, selectMonthFirstDate, selectMonthLastDate);
+                    1L, selectMonthFirstDate, selectMonthLastDate);
             verify(repeatScheduleRepository, times(1))
                 .findAllByStudyChannelIdAndDate(
-                1L, selectMonthFirstDate);
+                    1L, selectMonthFirstDate);
         }
 
         @Test
@@ -515,7 +517,7 @@ class ScheduleServiceTest {
 
             // when & then
             assertThrows(NotFoundStudyChannelException.class, () -> {
-              scheduleService.getSchedulesInStudyChannel(1L);
+                scheduleService.getSchedulesInStudyChannel(1L);
             });
 
             // then
@@ -523,6 +525,41 @@ class ScheduleServiceTest {
             verify(singleScheduleRepository, times(0)).findAllByStudyChannelId(1L);
             verify(repeatScheduleRepository, times(0)).findAllByStudyChannelId(1L);
         }
+
+        @DisplayName("단일 일정 자세히 조회")
+        @Test
+        public void success_testGetSingleScheduleDetailInStudyChannel() {
+            // given
+            given(studyMemberRepository.findByMemberIdAndStudyChannelId(1L, 1L))
+                .willReturn(Optional.of(studyMemberNotLeader));
+            given(singleScheduleRepository.findById(1L))
+                .willReturn(Optional.of(singleScheduleWithoutPlace));
+
+            // when
+            SingleSchedule singleSchedule =
+                scheduleService.getSingleSchedule(1L, 1L, 1L);
+
+            // then
+            assertEquals(singleScheduleWithoutPlace, singleSchedule);
+        }
+
+        @DisplayName("반복 일정 자세히 조회")
+        @Test
+        public void success_testGetRepeatScheduleDetailInStudyChannel() {
+            // given
+            given(studyMemberRepository.findByMemberIdAndStudyChannelId(1L, 1L))
+                .willReturn(Optional.of(studyMemberNotLeader));
+            given(repeatScheduleRepository.findById(1L))
+                .willReturn(Optional.of(repeatScheduleWithoutPlace));
+
+            // when
+            RepeatSchedule repeatSchedule =
+                scheduleService.getRepeatSchedule(1L, 1L, 1L);
+
+            // then
+            assertEquals(repeatScheduleWithoutPlace, repeatSchedule);
+        }
+
     }
 
     @DisplayName("일정 수정: 단일 -> any | 반복 -> 반복")


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 일정 조회하는 것은 전체 조회 개념 밖에 없었습니다.

**TO-BE**
- 일정 자세히 조회를 추가하였습니다.
- 슬랙 채팅에 말씀드린대로 get요청시에는 @AuthenticationPrincipal으로 memberId를 메서드 매개변수로 넣었습니다.
    - 추후 머지가 되면 윤호님이 커스텀 어노테이션하신 것으로 수정하겠습니다. 
- 화면상 필요한 기능이기도 하고 알림 구현시 relate URL 필드를 주어 사용자가 알림을 확인할 때 관련된 url을 줄때 필요합니다.

- 우선 일정 관련한 알림에 relate URL은 다음과 같이 생각하고 있습니다.
    - 일정 등록: 특정 일정 자세히 조회 url 
    - 일정 수정/삭제: 일정 전체 url (별도로 확인하도록)

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
    - 일정 자세히 조회(단일/반복) 성공 service 테스트 코드만 구현 
- [X] API 테스트 