### PR TITLE
refactor: STD-17 일정 전체 조회 권한 검증 추가

### DIFF
--- a/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/tenten/studybadge/schedule/controller/ScheduleController.java
@@ -1,5 +1,6 @@
 package com.tenten.studybadge.schedule.controller;
 
+import com.tenten.studybadge.common.security.CustomUserDetails;
 import com.tenten.studybadge.schedule.dto.RepeatScheduleCreateRequest;
 import com.tenten.studybadge.schedule.dto.ScheduleDeleteRequest;
 import com.tenten.studybadge.schedule.dto.ScheduleEditRequest;
@@ -16,6 +17,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -60,8 +62,11 @@ public class ScheduleController {
     @GetMapping("/study-channels/{studyChannelId}/schedules")
     @Operation(summary = "스터디 채널에 존재하는 일정 전체 조회", description = "특정 스터디 채널에 존재하는 일정 전체 조회 api" ,security = @SecurityRequirement(name = "bearerToken"))
     @Parameter(name = "studyChannelId", description = "일정을 만드는 study channel의 id 값", required = true)
-    public ResponseEntity<List<ScheduleResponse>> getSchedules(@PathVariable Long studyChannelId) {
-        return ResponseEntity.ok(scheduleService.getSchedulesInStudyChannel(studyChannelId));
+    public ResponseEntity<List<ScheduleResponse>> getSchedules(
+        @AuthenticationPrincipal CustomUserDetails memberDetails,
+        @PathVariable Long studyChannelId) {;
+        return ResponseEntity.ok(scheduleService.getSchedulesInStudyChannel(
+            memberDetails.getId(), studyChannelId));
     }
 
     @GetMapping("/study-channels/{studyChannelId}/schedules/date")
@@ -69,10 +74,12 @@ public class ScheduleController {
     @Parameter(name = "studyChannelId", description = "일정을 만드는 study channel의 id 값", required = true)
     @Parameter(name = "year", description = "일정의 year 값", required = true)
     @Parameter(name = "month", description = "일정의 month 값", required = true)
-    public ResponseEntity<List<ScheduleResponse>> getSchedulesWithFormula(
+    public ResponseEntity<List<ScheduleResponse>> getSchedulesInStudyChannelForYearAndMonth(
+        @AuthenticationPrincipal CustomUserDetails memberDetails,
         @PathVariable Long studyChannelId,
         @RequestParam int year, @RequestParam int month) {
-        return ResponseEntity.ok(scheduleService.getSchedulesInStudyChannelForYearAndMonth( studyChannelId, year, month));
+        return ResponseEntity.ok(scheduleService.getSchedulesInStudyChannelForYearAndMonth(
+            memberDetails.getId(), studyChannelId, year, month));
     }
 
     @PutMapping("/study-channels/{studyChannelId}/schedules")

--- a/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
@@ -451,6 +451,8 @@ class ScheduleServiceTest {
             // given
             given(studyChannelRepository.findById(1L))
                 .willReturn(Optional.of(studyChannel));
+            given(studyMemberRepository.findByMemberIdAndStudyChannelId(1L, 1L))
+                .willReturn(Optional.of(studyMemberNotLeader));
             given(singleScheduleRepository.findAllByStudyChannelId(1L))
                 .willReturn(Arrays.asList(singleScheduleWithoutPlace));
             given(repeatScheduleRepository.findAllByStudyChannelId(1L))
@@ -458,7 +460,7 @@ class ScheduleServiceTest {
 
             // when
             List<ScheduleResponse> scheduleResponses =
-                scheduleService.getSchedulesInStudyChannel(1L);
+                scheduleService.getSchedulesInStudyChannel(1L,1L);
 
             // then
             assertEquals(2, scheduleResponses.size());
@@ -482,6 +484,8 @@ class ScheduleServiceTest {
 
             given(studyChannelRepository.findById(1L))
                 .willReturn(Optional.of(studyChannel));
+            given(studyMemberRepository.findByMemberIdAndStudyChannelId(1L, 1L))
+                .willReturn(Optional.of(studyMemberNotLeader));
             given(singleScheduleRepository.findAllByStudyChannelIdAndDateRange(
                 1L, selectMonthFirstDate, selectMonthLastDate))
                 .willReturn(Arrays.asList(singleScheduleWithoutPlace));
@@ -493,6 +497,7 @@ class ScheduleServiceTest {
             // when
             List<ScheduleResponse> scheduleResponses =
                 scheduleService.getSchedulesInStudyChannelForYearAndMonth(
+                    1L,
                 1L, 2024, 7);
 
             // then
@@ -515,7 +520,7 @@ class ScheduleServiceTest {
 
             // when & then
             assertThrows(NotFoundStudyChannelException.class, () -> {
-              scheduleService.getSchedulesInStudyChannel(1L);
+              scheduleService.getSchedulesInStudyChannel(1L,1L);
             });
 
             // then


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 일정 전체 조회시에 studyMember인지 권한 검증 추가하는 로직이 없었습니다.

**TO-BE**
- 마찬가지로 get요청이기에 @AuthenticationPrincipal으로 member Id를 가져와 서비스 로직에서 해당 스터디 채널의 멤버인지 검증하는 것을 추가하였습니다.
    - 커스텀 어노테이션으로 변경 예정 
- 존재하는 study channel인지 검증하는 로직을 validateStudyChannel메서드로 만들어 post/put/delete 로직에도 변경하였습니다.
- studyMember인지 검증하는 로직도 validateStudyMember 메서드로 만들었습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
- [X] API 테스트 