### PR TITLE
feat: STD-31 출석 체크 기능

### DIFF
--- a/src/main/java/com/tenten/studybadge/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/tenten/studybadge/attendance/controller/AttendanceController.java
@@ -3,8 +3,13 @@ package com.tenten.studybadge.attendance.controller;
 import com.tenten.studybadge.attendance.dto.AttendanceCheckRequest;
 import com.tenten.studybadge.attendance.service.AttendanceService;
 import com.tenten.studybadge.common.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,17 +18,22 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Attendance API", description = "출석과 관련된 기능을 제공하는 API")
 public class AttendanceController {
 
     private final AttendanceService attendanceService;
 
     @PostMapping("/api/study-channels/{studyChannelId}/check-attendance")
-    public void checkAttendance(
+    @Operation(summary = "출석 체크 및 갱신", description = "출석 체크와 출석 상태를 변경하는 API", security = @SecurityRequirement(name = "bearerToken"))
+    @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
+    @Parameter(name = "attendanceCheckRequest", description = "출석 체크를 위해 필요한 요청 데이터 모음", required = true)
+    public ResponseEntity<Void> checkAttendance(
             @AuthenticationPrincipal CustomUserDetails principal,
             @PathVariable Long studyChannelId,
             @Valid @RequestBody AttendanceCheckRequest attendanceCheckRequest) {
 
         attendanceService.checkAttendance(attendanceCheckRequest, principal.getId(), studyChannelId);
+        return ResponseEntity.ok().build();
 
     }
 }

--- a/src/main/java/com/tenten/studybadge/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/tenten/studybadge/attendance/controller/AttendanceController.java
@@ -1,0 +1,29 @@
+package com.tenten.studybadge.attendance.controller;
+
+import com.tenten.studybadge.attendance.dto.AttendanceCheckRequest;
+import com.tenten.studybadge.attendance.service.AttendanceService;
+import com.tenten.studybadge.common.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AttendanceController {
+
+    private final AttendanceService attendanceService;
+
+    @PostMapping("/api/study-channels/{studyChannelId}/check-attendance")
+    public void checkAttendance(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable Long studyChannelId,
+            @Valid @RequestBody AttendanceCheckRequest attendanceCheckRequest) {
+
+        attendanceService.checkAttendance(attendanceCheckRequest, principal.getId(), studyChannelId);
+
+    }
+}

--- a/src/main/java/com/tenten/studybadge/attendance/domain/entity/Attendance.java
+++ b/src/main/java/com/tenten/studybadge/attendance/domain/entity/Attendance.java
@@ -1,0 +1,36 @@
+package com.tenten.studybadge.attendance.domain.entity;
+
+import com.tenten.studybadge.common.BaseEntity;
+import com.tenten.studybadge.type.attendance.AttendanceStatus;
+import com.tenten.studybadge.type.schedule.ScheduleType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Attendance extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "attendance_id")
+    private Long id;
+    @Setter
+    private Long singleScheduleId;
+    @Setter
+    private Long repeatScheduleId;
+    private Long studyMemberId;
+    private LocalDateTime attendanceDateTime;
+
+    @Enumerated(EnumType.STRING)
+    private ScheduleType scheduleType;
+
+    @Setter
+    @Enumerated(EnumType.STRING)
+    private AttendanceStatus attendanceStatus;
+
+}

--- a/src/main/java/com/tenten/studybadge/attendance/domain/repository/AttendanceRepository.java
+++ b/src/main/java/com/tenten/studybadge/attendance/domain/repository/AttendanceRepository.java
@@ -1,0 +1,16 @@
+package com.tenten.studybadge.attendance.domain.repository;
+
+import com.tenten.studybadge.attendance.domain.entity.Attendance;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
+
+    List<Attendance> findAllBySingleScheduleId(long singleScheduleId);
+    List<Attendance> findAllByRepeatScheduleIdAndAttendanceDateTimeBetween(Long repeatScheduleId, LocalDateTime attendanceStartTime, LocalDateTime attendanceEndTime);
+
+}

--- a/src/main/java/com/tenten/studybadge/attendance/dto/AttendanceCheckRequest.java
+++ b/src/main/java/com/tenten/studybadge/attendance/dto/AttendanceCheckRequest.java
@@ -1,0 +1,22 @@
+package com.tenten.studybadge.attendance.dto;
+
+import com.tenten.studybadge.type.schedule.ScheduleType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class AttendanceCheckRequest {
+
+    private ScheduleType scheduleType;
+    private Long scheduleId;
+    private LocalDate attendanceCheckDate;
+    private List<AttendanceMember> attendanceMembers;
+
+}

--- a/src/main/java/com/tenten/studybadge/attendance/dto/AttendanceCheckRequest.java
+++ b/src/main/java/com/tenten/studybadge/attendance/dto/AttendanceCheckRequest.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 
 @Getter

--- a/src/main/java/com/tenten/studybadge/attendance/dto/AttendanceMember.java
+++ b/src/main/java/com/tenten/studybadge/attendance/dto/AttendanceMember.java
@@ -1,0 +1,15 @@
+package com.tenten.studybadge.attendance.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class AttendanceMember {
+    private Long studyMemberId;
+    private Boolean isAttendance;
+}
+

--- a/src/main/java/com/tenten/studybadge/attendance/service/AttendanceService.java
+++ b/src/main/java/com/tenten/studybadge/attendance/service/AttendanceService.java
@@ -1,0 +1,136 @@
+package com.tenten.studybadge.attendance.service;
+
+import com.tenten.studybadge.attendance.domain.entity.Attendance;
+import com.tenten.studybadge.attendance.domain.repository.AttendanceRepository;
+import com.tenten.studybadge.attendance.dto.AttendanceCheckRequest;
+import com.tenten.studybadge.attendance.dto.AttendanceMember;
+import com.tenten.studybadge.common.exception.schedule.NotFoundRepeatScheduleException;
+import com.tenten.studybadge.common.exception.schedule.NotFoundSingleScheduleException;
+import com.tenten.studybadge.common.exception.schedule.OutRangeScheduleException;
+import com.tenten.studybadge.common.exception.studychannel.NotStudyLeaderException;
+import com.tenten.studybadge.common.exception.studychannel.NotStudyMemberException;
+import com.tenten.studybadge.schedule.domain.entity.RepeatSchedule;
+import com.tenten.studybadge.schedule.domain.entity.SingleSchedule;
+import com.tenten.studybadge.schedule.domain.repository.RepeatScheduleRepository;
+import com.tenten.studybadge.schedule.domain.repository.SingleScheduleRepository;
+import com.tenten.studybadge.study.member.domain.entity.StudyMember;
+import com.tenten.studybadge.study.member.domain.repository.StudyMemberRepository;
+import com.tenten.studybadge.type.attendance.AttendanceStatus;
+import com.tenten.studybadge.type.schedule.ScheduleType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AttendanceService {
+
+    private final AttendanceRepository attendanceRepository;
+    private final StudyMemberRepository studyMemberRepository;
+    private final SingleScheduleRepository singleScheduleRepository;
+    private final RepeatScheduleRepository repeatScheduleRepository;
+
+    public void checkAttendance(AttendanceCheckRequest attendanceCheckRequest, Long memberId, Long studyChannelId) {
+        checkLeader(memberId, studyChannelId);
+        ScheduleType scheduleType = attendanceCheckRequest.getScheduleType();
+
+        if (scheduleType.equals(ScheduleType.SINGLE)) {
+            checkAttendanceForSingleSchedule(attendanceCheckRequest);
+        } else {
+            checkAttendanceForRepeatSchedule(attendanceCheckRequest);
+        }
+    }
+
+    private void checkAttendanceForSingleSchedule(AttendanceCheckRequest attendanceCheckRequest) {
+        SingleSchedule singleSchedule = singleScheduleRepository.findById(attendanceCheckRequest.getScheduleId()).orElseThrow(NotFoundSingleScheduleException::new);
+        LocalDate attendanceCheckDate = attendanceCheckRequest.getAttendanceCheckDate();
+        LocalDateTime currentTime = LocalDateTime.now();
+
+        if (!singleSchedule.getScheduleDate().equals(attendanceCheckDate) || !currentTime.toLocalDate().isEqual(attendanceCheckDate)) {
+            throw new IllegalArgumentException("해당 일정 당일에만 출석 체크가 가능합니다.");
+        }
+
+        List<Attendance> attendanceList = attendanceRepository.findAllBySingleScheduleId(attendanceCheckRequest.getScheduleId());
+
+        if (attendanceList.isEmpty()) {
+            saveAttendances(attendanceCheckRequest, ScheduleType.SINGLE, singleSchedule.getId());
+        } else {
+            updateAttendances(attendanceCheckRequest, attendanceList);
+        }
+    }
+
+    private void checkAttendanceForRepeatSchedule(AttendanceCheckRequest attendanceCheckRequest) {
+        RepeatSchedule repeatSchedule = repeatScheduleRepository.findById(attendanceCheckRequest.getScheduleId()).orElseThrow(NotFoundRepeatScheduleException::new);
+        LocalDate attendanceCheckDate = attendanceCheckRequest.getAttendanceCheckDate();
+        LocalDateTime currentTime = LocalDateTime.now();
+
+        if (repeatSchedule.getScheduleDate().isAfter(attendanceCheckDate) || repeatSchedule.getRepeatEndDate().isBefore(attendanceCheckDate)) {
+            throw new OutRangeScheduleException();
+        }
+
+        if (!currentTime.toLocalDate().isEqual(attendanceCheckDate)) {
+            throw new IllegalArgumentException("해당 일정 당일에만 출석 체크가 가능합니다.");
+        }
+
+        LocalDateTime startDateTime = attendanceCheckDate.atStartOfDay();
+        LocalDateTime endDateTime = startDateTime.plusDays(1);
+        List<Attendance> attendanceList = attendanceRepository.findAllByRepeatScheduleIdAndAttendanceDateTimeBetween(attendanceCheckRequest.getScheduleId(), startDateTime, endDateTime);
+
+        if (attendanceList.isEmpty()) {
+            saveAttendances(attendanceCheckRequest, ScheduleType.REPEAT, repeatSchedule.getId());
+        } else {
+            updateAttendances(attendanceCheckRequest, attendanceList);
+        }
+    }
+
+    private void updateAttendances(AttendanceCheckRequest attendanceCheckRequest, List<Attendance> attendanceList) {
+
+        Map<Long, AttendanceMember> attendanceMemberMap = attendanceCheckRequest.getAttendanceMembers().stream().collect(
+                Collectors.toMap(AttendanceMember::getStudyMemberId, Function.identity())
+        );
+
+        for (Attendance attendance : attendanceList) {
+            Long studyMemberId = attendance.getStudyMemberId();
+            AttendanceMember attendanceMember;
+            if (!attendanceMemberMap.containsKey(studyMemberId)) {
+                continue;
+            }
+            attendanceMember = attendanceMemberMap.get(studyMemberId);
+            attendance.setAttendanceStatus(attendanceMember.getIsAttendance() ? AttendanceStatus.ATTENDANCE : AttendanceStatus.ABSENCE);
+        }
+        attendanceRepository.saveAll(attendanceList);
+    }
+
+    private void saveAttendances(AttendanceCheckRequest attendanceCheckRequest, ScheduleType scheduleType, Long scheduleId) {
+
+        List<Attendance> attendances = attendanceCheckRequest.getAttendanceMembers().stream()
+                .map(attendanceMember -> Attendance.builder()
+                        .attendanceDateTime(LocalDateTime.now())
+                        .attendanceStatus(attendanceMember.getIsAttendance() ? AttendanceStatus.ATTENDANCE : AttendanceStatus.ABSENCE)
+                        .scheduleType(scheduleType)
+                        .studyMemberId(attendanceMember.getStudyMemberId())
+                        .build()
+                ).toList();
+
+        if (scheduleType.equals(ScheduleType.SINGLE)) {
+            attendances.forEach(attendance -> attendance.setSingleScheduleId(scheduleId));
+        } else {
+            attendances.forEach(attendance -> attendance.setRepeatScheduleId(scheduleId));
+        }
+        attendanceRepository.saveAll(attendances);
+    }
+
+
+    private void checkLeader(Long memberId, Long studyChannelId) {
+        StudyMember studyMember = studyMemberRepository.findByMemberIdAndStudyChannelId(memberId, studyChannelId).orElseThrow(NotStudyMemberException::new);
+        if (!studyMember.isLeader()) {
+            throw new NotStudyLeaderException();
+        }
+    }
+}

--- a/src/main/java/com/tenten/studybadge/attendance/service/AttendanceService.java
+++ b/src/main/java/com/tenten/studybadge/attendance/service/AttendanceService.java
@@ -4,6 +4,7 @@ import com.tenten.studybadge.attendance.domain.entity.Attendance;
 import com.tenten.studybadge.attendance.domain.repository.AttendanceRepository;
 import com.tenten.studybadge.attendance.dto.AttendanceCheckRequest;
 import com.tenten.studybadge.attendance.dto.AttendanceMember;
+import com.tenten.studybadge.common.exception.attendance.InvalidAttendanceCheckDateException;
 import com.tenten.studybadge.common.exception.schedule.NotFoundRepeatScheduleException;
 import com.tenten.studybadge.common.exception.schedule.NotFoundSingleScheduleException;
 import com.tenten.studybadge.common.exception.schedule.OutRangeScheduleException;
@@ -53,7 +54,7 @@ public class AttendanceService {
         LocalDateTime currentTime = LocalDateTime.now();
 
         if (!singleSchedule.getScheduleDate().equals(attendanceCheckDate) || !currentTime.toLocalDate().isEqual(attendanceCheckDate)) {
-            throw new IllegalArgumentException("해당 일정 당일에만 출석 체크가 가능합니다.");
+            throw new InvalidAttendanceCheckDateException();
         }
 
         List<Attendance> attendanceList = attendanceRepository.findAllBySingleScheduleId(attendanceCheckRequest.getScheduleId());
@@ -75,7 +76,7 @@ public class AttendanceService {
         }
 
         if (!currentTime.toLocalDate().isEqual(attendanceCheckDate)) {
-            throw new IllegalArgumentException("해당 일정 당일에만 출석 체크가 가능합니다.");
+            throw new InvalidAttendanceCheckDateException();
         }
 
         LocalDateTime startDateTime = attendanceCheckDate.atStartOfDay();

--- a/src/main/java/com/tenten/studybadge/common/exception/attendance/InvalidAttendanceCheckDateException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/attendance/InvalidAttendanceCheckDateException.java
@@ -1,0 +1,28 @@
+package com.tenten.studybadge.common.exception.attendance;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class InvalidAttendanceCheckDateException extends AbstractException {
+
+    private static final String ERROR_CODE = "INVALID_ATTENDANCE_CHECK_DATE";
+    private static final String ERROR_MESSAGE = "해당 일정 당일에만 출석 체크가 가능합니다.";
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return BAD_REQUEST;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public String getMessage() {
+        return ERROR_MESSAGE;
+    }
+
+}

--- a/src/main/java/com/tenten/studybadge/type/attendance/AttendanceStatus.java
+++ b/src/main/java/com/tenten/studybadge/type/attendance/AttendanceStatus.java
@@ -1,0 +1,6 @@
+package com.tenten.studybadge.type.attendance;
+
+public enum AttendanceStatus {
+    ATTENDANCE,
+    ABSENCE,
+}

--- a/src/test/java/com/tenten/studybadge/attendance/service/AttendanceServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/attendance/service/AttendanceServiceTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -42,7 +41,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/com/tenten/studybadge/attendance/service/AttendanceServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/attendance/service/AttendanceServiceTest.java
@@ -1,0 +1,250 @@
+package com.tenten.studybadge.attendance.service;
+
+import com.tenten.studybadge.attendance.domain.entity.Attendance;
+import com.tenten.studybadge.attendance.domain.repository.AttendanceRepository;
+import com.tenten.studybadge.attendance.dto.AttendanceCheckRequest;
+import com.tenten.studybadge.attendance.dto.AttendanceMember;
+import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.schedule.domain.entity.RepeatSchedule;
+import com.tenten.studybadge.schedule.domain.entity.SingleSchedule;
+import com.tenten.studybadge.schedule.domain.repository.RepeatScheduleRepository;
+import com.tenten.studybadge.schedule.domain.repository.SingleScheduleRepository;
+import com.tenten.studybadge.study.channel.domain.entity.Recruitment;
+import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
+import com.tenten.studybadge.study.channel.domain.entity.StudyDuration;
+import com.tenten.studybadge.study.member.domain.entity.StudyMember;
+import com.tenten.studybadge.study.member.domain.repository.StudyMemberRepository;
+import com.tenten.studybadge.type.member.BadgeLevel;
+import com.tenten.studybadge.type.schedule.RepeatCycle;
+import com.tenten.studybadge.type.schedule.RepeatSituation;
+import com.tenten.studybadge.type.schedule.ScheduleType;
+import com.tenten.studybadge.type.study.channel.Category;
+import com.tenten.studybadge.type.study.channel.MeetingType;
+import com.tenten.studybadge.type.study.channel.RecruitmentStatus;
+import com.tenten.studybadge.type.study.member.StudyMemberRole;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AttendanceServiceTest {
+
+    @InjectMocks
+    AttendanceService attendanceService;
+
+    @Mock
+    AttendanceRepository attendanceRepository;
+    @Mock
+    StudyMemberRepository studyMemberRepository;
+    @Mock
+    SingleScheduleRepository singleScheduleRepository;
+    @Mock
+    RepeatScheduleRepository repeatScheduleRepository;
+
+    @DisplayName("[스터디 채널 출석 체크 테스트]")
+    @Nested
+    class CheckAttendanceTest {
+        List<Member> members;
+        StudyChannel studyChannel;
+        RepeatSchedule repeatSchedule;
+        SingleSchedule singleSchedule;
+
+        @BeforeEach
+        void setUp() {
+            members = new ArrayList<>();
+            for (int i = 1; i <= 5; i++) {
+                Member member = Member.builder()
+                        .id((long) i)
+                        .name("회원" + i)
+                        .banCnt(2)
+                        .imgUrl("imageUrl")
+                        .badgeLevel(BadgeLevel.SILVER)
+                        .build();
+                members.add(member);
+            }
+            LocalDate now = LocalDate.now();
+            studyChannel = StudyChannel.builder()
+                    .id(1L)
+                    .name("스터디명")
+                    .description("스터디 설명")
+                    .studyDuration(StudyDuration.builder()
+                            .studyStartDate(now.plusDays(2))
+                            .studyEndDate(now.plusMonths(4))
+                            .build())
+                    .recruitment(Recruitment.builder()
+                            .recruitmentNumber(6)
+                            .recruitmentStatus(RecruitmentStatus.RECRUITING)
+                            .build())
+                    .category(Category.IT)
+                    .region("")
+                    .meetingType(MeetingType.ONLINE)
+                    .chattingUrl("오픈채팅방 URL")
+                    .deposit(10_000)
+                    .viewCnt(4)
+                    .build();
+
+            singleSchedule = SingleSchedule.withoutIdBuilder()
+                    .scheduleName("Single Meeting")
+                    .scheduleContent("Content for single meeting")
+                    .scheduleDate(now)
+                    .scheduleStartTime(LocalTime.of(10, 0))
+                    .scheduleEndTime(LocalTime.of(11, 0))
+                    .isRepeated(false)
+                    .studyChannel(studyChannel)
+                    .placeId(null)
+                    .build();
+
+            repeatSchedule = RepeatSchedule.withoutIdBuilder()
+                    .scheduleName("Repeat Meeting")
+                    .scheduleContent("Content for repeat meeting")
+                    .scheduleDate(now)
+                    .scheduleStartTime(LocalTime.of(10, 0))
+                    .scheduleEndTime(LocalTime.of(11, 0))
+                    .repeatCycle(RepeatCycle.WEEKLY)
+                    .repeatSituation(RepeatSituation.SUNDAY)
+                    .repeatEndDate(LocalDate.of(2024, 12, 29))
+                    .isRepeated(true)
+                    .studyChannel(studyChannel)
+                    .placeId(null)
+                    .build();
+
+        }
+
+        @DisplayName("[단일 일정] - 출석 체크를 정상적으로 수행한다.")
+        @Test
+        void success_checkAttendance() {
+
+            StudyMember leader = StudyMember.builder()
+                    .id(1L)
+                    .studyChannel(studyChannel)
+                    .member(members.get(0))
+                    .studyMemberRole(StudyMemberRole.LEADER)
+                    .build();
+
+            studyChannel.getStudyMembers().add(leader);
+
+            for (int i = 1; i < 5; i++) {
+                StudyMember studyMember = StudyMember.builder()
+                        .id((long) (i + 1))
+                        .studyChannel(studyChannel)
+                        .member(members.get(i))
+                        .studyMemberRole(StudyMemberRole.STUDY_MEMBER)
+                        .build();
+                studyChannel.getStudyMembers().add(studyMember);
+            }
+
+            List<AttendanceMember> attendanceMembers = studyChannel.getStudyMembers().stream()
+                    .map(studyMember -> AttendanceMember.builder()
+                            .isAttendance(true)
+                            .studyMemberId(studyMember.getId())
+                            .build()
+                    ).toList();
+
+
+            AttendanceCheckRequest attendanceCheckRequest = AttendanceCheckRequest.builder()
+                    .attendanceCheckDate(LocalDate.now())
+                    .scheduleId(1L)
+                    .scheduleType(ScheduleType.SINGLE)
+                    .attendanceMembers(attendanceMembers)
+                    .build();
+            given(studyMemberRepository.findByMemberIdAndStudyChannelId(1L, 1L))
+                    .willReturn(Optional.of(leader));
+            given(singleScheduleRepository.findById(1L)).willReturn(Optional.of(singleSchedule));
+            given(attendanceRepository.findAllBySingleScheduleId(1L)).willReturn(Collections.emptyList());
+
+            attendanceService.checkAttendance(attendanceCheckRequest, 1L, 1L);
+
+            ArgumentCaptor<List<Attendance>> attendanceCaptor = ArgumentCaptor.forClass(List.class);
+            verify(attendanceRepository, times(1)).saveAll(attendanceCaptor.capture());
+            List<Attendance> attendances = attendanceCaptor.getValue();
+            Assertions.assertThat(attendances).hasSize(5);
+
+            for (Attendance attendance: attendances) {
+                System.out.print(attendance.getStudyMemberId() + ", " + attendance.getSingleScheduleId() + ", " + attendance.getRepeatScheduleId()
+                + ", " + attendance.getAttendanceStatus() + ", " + attendance.getScheduleType() + ", " + attendance.getAttendanceDateTime());
+                System.out.println();
+            }
+        }
+
+        @DisplayName("[반복 일정] - 출석 체크를 정상적으로 수행한다.")
+        @Test
+        void success_checkAttendance_repeatSchedule() {
+
+            StudyMember leader = StudyMember.builder()
+                    .id(1L)
+                    .studyChannel(studyChannel)
+                    .member(members.get(0))
+                    .studyMemberRole(StudyMemberRole.LEADER)
+                    .build();
+
+            studyChannel.getStudyMembers().add(leader);
+
+            for (int i = 1; i < 5; i++) {
+                StudyMember studyMember = StudyMember.builder()
+                        .id((long) (i + 1))
+                        .studyChannel(studyChannel)
+                        .member(members.get(i))
+                        .studyMemberRole(StudyMemberRole.STUDY_MEMBER)
+                        .build();
+                studyChannel.getStudyMembers().add(studyMember);
+            }
+
+            List<AttendanceMember> attendanceMembers = studyChannel.getStudyMembers().stream()
+                    .map(studyMember -> AttendanceMember.builder()
+                            .isAttendance(true)
+                            .studyMemberId(studyMember.getId())
+                            .build()
+                    ).toList();
+
+
+            AttendanceCheckRequest attendanceCheckRequest = AttendanceCheckRequest.builder()
+                    .attendanceCheckDate(LocalDate.now())
+                    .scheduleId(1L)
+                    .scheduleType(ScheduleType.REPEAT)
+                    .attendanceMembers(attendanceMembers)
+                    .build();
+            LocalDate now = LocalDate.now();
+            LocalDateTime startDateTime = now.atStartOfDay();
+            LocalDateTime endDateTime = startDateTime.plusDays(1);
+            given(studyMemberRepository.findByMemberIdAndStudyChannelId(1L, 1L))
+                    .willReturn(Optional.of(leader));
+            given(repeatScheduleRepository.findById(1L)).willReturn(Optional.of(repeatSchedule));
+            given(attendanceRepository.findAllByRepeatScheduleIdAndAttendanceDateTimeBetween(1L, startDateTime, endDateTime)).willReturn(Collections.emptyList());
+
+            attendanceService.checkAttendance(attendanceCheckRequest, 1L, 1L);
+
+            ArgumentCaptor<List<Attendance>> attendanceCaptor = ArgumentCaptor.forClass(List.class);
+            verify(attendanceRepository, times(1)).saveAll(attendanceCaptor.capture());
+            List<Attendance> attendances = attendanceCaptor.getValue();
+            Assertions.assertThat(attendances).hasSize(5);
+
+            for (Attendance attendance: attendances) {
+                System.out.print(attendance.getStudyMemberId() + ", " + attendance.getSingleScheduleId() + ", " + attendance.getRepeatScheduleId()
+                        + ", " + attendance.getAttendanceStatus() + ", " + attendance.getScheduleType() + ", " + attendance.getAttendanceDateTime());
+                System.out.println();
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**

**TO-BE**
- 출석 체크 기능은 일정 당일에만 동작할 수 있도록 했습니다.
- 출석 체크 기능은 아래와 같이 2가지 기능이 있습니다.
   - 처음 출석 체크를 할 경우 프론트 쪽에서 스터디 멤버들의 출석 체크 정보를 한 번에 보냅니다. 따라서 첫 출석 체크일 경우 모든 스터디 멤버의 출석 정보를 한 번에 저장됩니다.
   - 이후 출석 상태를 변경(출석 취소 or 출석 체크)하게 될 경우 변경된 정보를 보내면 변경된 스터디 멤버의 출석 상태들을 반영하도록 했습니다.

예) 첫 출석 체크 - 스터디 멤버가 3명이라고 가정

```json
{
   attendanceMembers : [
                    {
                        "studyMemberId" : 11,
                        "isAttendance" : true
                    },
                    {
                        "studyMemberId" : 12,
                        "isAttendance" : false
                    },
                    {
                        "studyMemberId" : 13,
                        "isAttendance" : true
                    }

                ]
}
``` 
위와 같은 요청이 오면 백엔드에서는 존재하지 않는 출석 체크일 경우 출석 내역을 저장합니다.

예) 수정 할 때

```json
{
   attendanceMembers : [
                    {
                        "studyMemberId" : 12,
                        "isAttendance" : true
                    },

                ]
}
``` 
위와 같은 요청이 왔을 때 존재하는 출석 체크일 경우 해당 멤버의 출석 상태를 변경합니다.

[문제 해결]
- AttendanceMember 클래스 내부에 @Getter와 boolean의 변수명이 isAttendance로 되어 있습니다.
- 이때 변수명이 is_ 로 되어 있고 @Getter로 되어 있으면 해당 변수의 getter 메서드 명이 AttendanceMember.isAttendance()가 됩니다.
- ObjectMapper의 경우 get 으로 시작되는 메서드에 대해서만 동작하도록 되어 있기 때문에 모든 AttendanceMember  는 isAttendance가 false로 설정되어버립니다.

따라서 여러 방법 중 boolean -> Boolean으로 타입을 변경했습니다.

위 방법 대신 출석 체크 API, 출석 체크 취소 API를 만들어 프론트쪽에서 체크, 취소 할 때마다 API를 호출하는 방식으로도 구현할 수 있는데 일단은 근아님이 이해하신대로 구현하는게 나을 것 같아서 이렇게 구현했습니다.


 
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
   - 정상적인 동작에 대한 테스트 코드만 작성했습니다.
- [x] API 테스트 