### PR TITLE
Refactor: STD-6 커스텀 어노테이션, 핸들러 추가

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
@@ -3,7 +3,10 @@ package com.tenten.studybadge.common.config;
 import com.tenten.studybadge.common.jwt.JwtTokenFilter;
 import com.tenten.studybadge.common.jwt.JwtTokenProvider;
 import com.tenten.studybadge.common.oauth2.CustomOAuth2UserService;
+import com.tenten.studybadge.common.oauth2.OAuth2FailureHandler;
 import com.tenten.studybadge.common.oauth2.OAuth2SuccessHandler;
+import com.tenten.studybadge.common.security.CustomAuthenticationEntryPoint;
+import com.tenten.studybadge.common.security.LoginUserArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,16 +23,23 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
-public class SecurityConfig {
+public class SecurityConfig implements WebMvcConfigurer {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisTemplate redisTemplate;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
+    private final LoginUserArgumentResolver loginUserArgumentResolver;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -45,7 +55,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/members/logout", "api/study-channels/*/places", "/api/study-channels/**", "/api/token/re-issue"
                                 , "/api/members/my-info", "/api/members/my-info/update", "/api/payments/**",
                             "/api/study-channels/*/schedules/**").hasRole("USER"))
-
+                .exceptionHandling(exception -> exception.authenticationEntryPoint(authenticationEntryPoint))
                 .cors(cors -> new CorsConfig())
                 .headers(headers -> headers // h2-console 페이지 접속을 위한 설정
                         .frameOptions(HeadersConfigurer.FrameOptionsConfig::disable)
@@ -54,13 +64,12 @@ public class SecurityConfig {
 
                 .oauth2Login(oauth2Login ->
                         oauth2Login
-
-                                .failureUrl("/login")
                                 .redirectionEndpoint( endpoint -> endpoint.baseUri("/oauth2/callback/*"))
                                 .userInfoEndpoint(userInfoEndpoint ->
                                         userInfoEndpoint.userService(customOAuth2UserService)
                                 )
                                 .successHandler(oAuth2SuccessHandler)
+                                .failureHandler(oAuth2FailureHandler)
                 )
 
                 .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(
@@ -73,5 +82,10 @@ public class SecurityConfig {
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig) throws Exception {
         return authConfig.getAuthenticationManager();
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(loginUserArgumentResolver);
     }
 }

--- a/src/main/java/com/tenten/studybadge/common/config/WebMvcConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package com.tenten.studybadge.common.config;
+
+import com.tenten.studybadge.common.security.LoginUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final LoginUserArgumentResolver loginUserArgumentResolver;
+
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+
+        resolvers.add(loginUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/tenten/studybadge/common/constant/Oauth2Contant.java
+++ b/src/main/java/com/tenten/studybadge/common/constant/Oauth2Contant.java
@@ -27,4 +27,10 @@ public class Oauth2Contant {
     public static final String LOGIN_REDIRECT_URI = "/api/token/oauth2";
 
     public static final String SIGN_UP_REDIRECT_URI = "/oauth2/sign-up";
+
+    public static final String OAUTH2_ERROR_MESSAGE = "OAuth2 인증에 실패하였습니다: ";
+
+    public static final String OAUTH2_ERROR_MESSAGE_NAME = "errorMessage";
+
+    public static final String OAUTH2_REDIRECT_PATH = "/login";
 }

--- a/src/main/java/com/tenten/studybadge/common/oauth2/OAuth2FailureHandler.java
+++ b/src/main/java/com/tenten/studybadge/common/oauth2/OAuth2FailureHandler.java
@@ -1,0 +1,29 @@
+package com.tenten.studybadge.common.oauth2;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.tenten.studybadge.common.constant.Oauth2Contant.*;
+
+@Slf4j
+@Component
+public class OAuth2FailureHandler implements AuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+
+        String errorMessage = OAUTH2_ERROR_MESSAGE + exception.getMessage();
+        log.info(errorMessage);
+        request.setAttribute(OAUTH2_ERROR_MESSAGE_NAME, errorMessage);
+
+        response.sendRedirect(request.getContextPath() + OAUTH2_REDIRECT_PATH);
+    }
+}

--- a/src/main/java/com/tenten/studybadge/common/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/tenten/studybadge/common/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,21 @@
+package com.tenten.studybadge.common.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private static final String UNAUTHORIZED = "Unauthorized";
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/tenten/studybadge/common/security/LoginUser.java
+++ b/src/main/java/com/tenten/studybadge/common/security/LoginUser.java
@@ -1,0 +1,10 @@
+package com.tenten.studybadge.common.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {}

--- a/src/main/java/com/tenten/studybadge/common/security/LoginUserArgumentResolver.java
+++ b/src/main/java/com/tenten/studybadge/common/security/LoginUserArgumentResolver.java
@@ -1,0 +1,40 @@
+package com.tenten.studybadge.common.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+@Component
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+
+    public boolean supportsParameter(MethodParameter parameter) {
+
+        return parameter.getParameterAnnotation(LoginUser.class) != null
+                && Long.class.isAssignableFrom(parameter.getParameterType());
+    }
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null && authentication.getPrincipal() instanceof CustomUserDetails customUserDetails) {
+
+            return customUserDetails.getId();
+        }
+
+        return null;
+
+    }
+}

--- a/src/main/java/com/tenten/studybadge/member/controller/MemberController.java
+++ b/src/main/java/com/tenten/studybadge/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.tenten.studybadge.member.controller;
 
 import com.tenten.studybadge.common.security.CustomUserDetails;
+import com.tenten.studybadge.common.security.LoginUser;
 import com.tenten.studybadge.common.token.dto.TokenCreateDto;
 import com.tenten.studybadge.common.token.dto.TokenDto;
 import com.tenten.studybadge.common.utils.CookieUtils;
@@ -77,28 +78,27 @@ public class MemberController {
     }
     @Operation(summary = "내 정보", description = "회원의 나의 정보", security = @SecurityRequirement(name = "bearerToken"))
     @GetMapping("/my-info")
-    public ResponseEntity<MemberResponse> getMyInfo(@AuthenticationPrincipal CustomUserDetails principal) {
+    public ResponseEntity<MemberResponse> getMyInfo(@LoginUser Long memberId) {
 
-        MemberResponse memberResponse = memberService.getMyInfo(principal.getId());
+        MemberResponse memberResponse = memberService.getMyInfo(memberId);
 
         return ResponseEntity.ok(memberResponse);
     }
     @PutMapping("/my-info/update")
-    public ResponseEntity<MemberResponse> memberUpdate(@AuthenticationPrincipal CustomUserDetails principal,
+    public ResponseEntity<MemberResponse> memberUpdate(@LoginUser Long memberId,
                                                  @RequestPart("updateRequest") MemberUpdateRequest updateRequest,
                                                  @RequestPart(value = "file", required = false) MultipartFile profile) {
 
-        memberService.memberUpdate(principal.getId(), updateRequest, profile);
+        memberService.memberUpdate(memberId, updateRequest, profile);
 
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @DeleteMapping("/withdrawal")
-    public ResponseEntity<Void> withdrawal(@AuthenticationPrincipal CustomUserDetails principal) {
+    public ResponseEntity<Void> withdrawal(@LoginUser Long memberId) {
 
-        memberService.withdrawal(principal.getId());
+        memberService.withdrawal(memberId);
 
         return ResponseEntity.status(HttpStatus.OK).build();
-
     }
 }

--- a/src/main/java/com/tenten/studybadge/payment/controller/PaymentController.java
+++ b/src/main/java/com/tenten/studybadge/payment/controller/PaymentController.java
@@ -1,6 +1,7 @@
 package com.tenten.studybadge.payment.controller;
 
 import com.tenten.studybadge.common.security.CustomUserDetails;
+import com.tenten.studybadge.common.security.LoginUser;
 import com.tenten.studybadge.payment.dto.*;
 import com.tenten.studybadge.payment.service.PaymentService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,10 +24,10 @@ public class PaymentController {
     @Operation(summary = "결제 요청", description = "토스페이먼츠에 결제 요청할 API", security = @SecurityRequirement(name = "bearerToken"))
     @Parameter(name = "paymentRequest", description = "결제 요청을 위한 값들")
     @PostMapping("/toss")
-    public ResponseEntity<PaymentResponse> requestPayment(@AuthenticationPrincipal CustomUserDetails principal,
+    public ResponseEntity<PaymentResponse> requestPayment(@LoginUser Long memberId,
                                                           @Valid @RequestBody PaymentRequest paymentRequest) {
 
-        PaymentResponse response = paymentService.requestPayment(principal.getId(), paymentRequest);
+        PaymentResponse response = paymentService.requestPayment(memberId, paymentRequest);
 
         return ResponseEntity.ok(response);
     }
@@ -52,10 +53,10 @@ public class PaymentController {
     @Operation(summary = "결제 취소", description = "토스페이먼츠에 결제 취소 요청할 API", security = @SecurityRequirement(name = "bearerToken"))
     @Parameter(name = "cancelRequest", description = "결제 취소를 위한 요청 값(paymentKey, cancelReason)")
     @PostMapping("/cancel")
-    public ResponseEntity<Map<String, Object>> cancelPayment(@AuthenticationPrincipal CustomUserDetails principal,
+    public ResponseEntity<Map<String, Object>> cancelPayment(@LoginUser Long memberId,
                                                              @Valid @RequestBody PaymentCancelRequest cancelRequest) {
 
-        Map<String, Object> response = paymentService.cancelPayment(principal.getId(), cancelRequest);
+        Map<String, Object> response = paymentService.cancelPayment(memberId, cancelRequest);
 
         return ResponseEntity.ok(response);
     }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 컨트롤러에서 `@AuthenticationPrincipal principal` -> `(principal.getId)` 로 memberId를 가져왔었습니다. 
- 토큰을 넣지 않거나 유효하지 않은 토큰을 헤더에 넣어 API 호출했을 때, Oauth2 기본 로그인 페이지가 응답했었습니다.
- Oauth2 실패 핸들러가 구현되지 않았었습니다.

**TO-BE**
- 멘토링 피드백을 반영하여 커스텀 어노테이션을 만들었습니다. **이 방식이 맞는지는 잘 모르겠습니다만**, 컨트롤러 역할 분리와
  '아주 아주' 약간 편리해졌다는 점이 있는 것 같습니다. ( 멘토님이 말씀하신건, 제가 찾아본 바로는 stateful 서버에서 세션에서 유저정보를 인터셉트 하여 커스텀 어노테이션을 만들어서  memberId를 받아오는 걸로 생각하고 있습니다. 
  (**제 생각이 맞다는게 아닙니다^^** )
    - 컨트롤러에서 `@LoginUser Long memberId` -> `(memberId)` 로 memberId를 받아오시면 되겠습니다.
    - 혹여나 `-parameter` 에러 발생 시 인텔리제이 설정에서 빌드를 IntelliJ에서 Gradle로 변경해주시면 됩니다.

- 토큰을 넣지 않거나 유효하지 않은 토큰을 헤더에 넣어 API 호출했을 때, 401에러가 발생하도록 핸들러를 추가하였습니다.
- Oauth2 실패 핸들러를 추가하였습니다 -> 인증 실패시 현재는 임시로 "/login" 으로 이동하게 설정해놓았습니다.

***커스텀 어노테이션 적용함에 따라, 추가 커밋으로 그에 맞게 컨트롤러가 변경될 예정입니다.***

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 