### PR TITLE
feat: STD-32 스터디 채널 내 출석 현황 조회 기능

### DIFF
--- a/src/main/java/com/tenten/studybadge/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/tenten/studybadge/attendance/controller/AttendanceController.java
@@ -39,7 +39,7 @@ public class AttendanceController {
 
     @GetMapping("/api/study-channels/{studyChannelId}/attendances")
     public ResponseEntity<List<AttendanceInfoResponse>> getAttendanceRatio(@PathVariable Long studyChannelId, @AuthenticationPrincipal CustomUserDetails principal) {
-        return ResponseEntity.ok(attendanceService.getAttendanceRatio(studyChannelId, principal.getId()));
+        return ResponseEntity.ok(attendanceService.getAttendanceRatioForStudyChannel(studyChannelId, principal.getId()));
     }
 
 }

--- a/src/main/java/com/tenten/studybadge/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/tenten/studybadge/attendance/controller/AttendanceController.java
@@ -38,6 +38,8 @@ public class AttendanceController {
     }
 
     @GetMapping("/api/study-channels/{studyChannelId}/attendances")
+    @Operation(summary = "출석 현황 조회", description = "스터디 채널 내 멤버별 출석 현황을 조회하는 API", security = @SecurityRequirement(name = "bearerToken"))
+    @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
     public ResponseEntity<List<AttendanceInfoResponse>> getAttendanceRatio(@PathVariable Long studyChannelId, @AuthenticationPrincipal CustomUserDetails principal) {
         return ResponseEntity.ok(attendanceService.getAttendanceRatioForStudyChannel(studyChannelId, principal.getId()));
     }

--- a/src/main/java/com/tenten/studybadge/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/tenten/studybadge/attendance/controller/AttendanceController.java
@@ -1,6 +1,7 @@
 package com.tenten.studybadge.attendance.controller;
 
 import com.tenten.studybadge.attendance.dto.AttendanceCheckRequest;
+import com.tenten.studybadge.attendance.dto.AttendanceInfoResponse;
 import com.tenten.studybadge.attendance.service.AttendanceService;
 import com.tenten.studybadge.common.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,10 +12,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -36,4 +36,10 @@ public class AttendanceController {
         return ResponseEntity.ok().build();
 
     }
+
+    @GetMapping("/api/study-channels/{studyChannelId}/attendances")
+    public ResponseEntity<List<AttendanceInfoResponse>> getAttendanceRatio(@PathVariable Long studyChannelId, @AuthenticationPrincipal CustomUserDetails principal) {
+        return ResponseEntity.ok(attendanceService.getAttendanceRatio(studyChannelId, principal.getId()));
+    }
+
 }

--- a/src/main/java/com/tenten/studybadge/attendance/domain/repository/AttendanceRepository.java
+++ b/src/main/java/com/tenten/studybadge/attendance/domain/repository/AttendanceRepository.java
@@ -11,6 +11,7 @@ import java.util.List;
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
 
     List<Attendance> findAllBySingleScheduleId(long singleScheduleId);
+    List<Attendance> findAllByRepeatScheduleId(long repeatScheduleId);
     List<Attendance> findAllByRepeatScheduleIdAndAttendanceDateTimeBetween(Long repeatScheduleId, LocalDateTime attendanceStartTime, LocalDateTime attendanceEndTime);
 
 }

--- a/src/main/java/com/tenten/studybadge/attendance/dto/AttendanceInfoResponse.java
+++ b/src/main/java/com/tenten/studybadge/attendance/dto/AttendanceInfoResponse.java
@@ -1,0 +1,19 @@
+package com.tenten.studybadge.attendance.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class AttendanceInfoResponse {
+
+    private Long memberId;
+    private Long studyMemberId;
+    private String name;
+    private String imageUrl;
+    private long attendanceCount;
+    private double attendanceRatio;
+
+}

--- a/src/main/java/com/tenten/studybadge/attendance/service/AttendanceService.java
+++ b/src/main/java/com/tenten/studybadge/attendance/service/AttendanceService.java
@@ -64,6 +64,8 @@ public class AttendanceService {
 
         // 스터디 멤버 별 총 출석 일수
         Map<Long, Long> studyMemberAttendanceCountMap = new HashMap<>();
+
+        // 반복 일정
         for (RepeatSchedule repeatSchedule : repeatSchedules) {
             List<Attendance> repeatScheduleAttendances = attendanceRepository.findAllByRepeatScheduleId(repeatSchedule.getId());
             Map<Long, List<Attendance>> listMap = repeatScheduleAttendances.stream().collect(Collectors.groupingBy(Attendance::getStudyMemberId));
@@ -75,8 +77,20 @@ public class AttendanceService {
                 long count = attendances.stream().filter(attendance -> attendance.getAttendanceStatus().equals(AttendanceStatus.ATTENDANCE)).count();
                 studyMemberAttendanceCountMap.put(studyMemberId, studyMemberAttendanceCountMap.getOrDefault(studyMemberId, 0L) + count);
             }
-
         }
+
+        // 단일 일정
+        for (SingleSchedule singleSchedule : singleSchedules) {
+            List<Attendance> singleScheduleAttendances = attendanceRepository.findAllBySingleScheduleId(singleSchedule.getId());
+            singleScheduleAttendances.stream()
+                    .filter(attendance -> attendance.getAttendanceStatus().equals(AttendanceStatus.ATTENDANCE))
+                    .forEach(attendance -> {
+                        studyMemberAttendanceCountMap.put(
+                                attendance.getStudyMemberId(),
+                                studyMemberAttendanceCountMap.getOrDefault(attendance.getStudyMemberId(), 0L) + 1);
+                    });
+        }
+
         List<AttendanceInfoResponse> attendanceInfoResponses = new ArrayList<>();
 
         for (StudyMember studyMember : studyMembers) {


### PR DESCRIPTION
### 변경사항
**AS-IS**

**TO-BE**
- 스터디 채널 내 스터디 멤버별 출석 현황(출석률, 멤버명, 이미지)를 조회하는 기능입니다.
- 출석률을 계산하는 방법
   -  전체 일정의 총 일수(단일 일정의 경우 단일 일정 당 1일, 반복 일정의 경우 반복 주기를 통해 계산)
       - 단일 일정 : 단일 일정이 2개 있을 경우 단일 일정의 총 일수는 2일입니다.
       - 반복 일정 : 반복 주기가 "주" 일 경우 시작 날짜부터 종료날짜까지 "주" 단위로 몇 번 반복하는지 카운트
   -  각 일정 별 스터디 멤버들의 출석 상태가 "출석(ATTENDANCE)" 일 경우에만 출석한 날로 인정됩니다.

현재는 좀 복잡하게 애플리케이션 내부에서 필터링과 카운팅을 하고 있습니다.
하나의 일정에 대한 스터디 멤버들의 출석 일수를 구하는 쿼리를 직접 작성해서 native query로 할지
이대로 진행할 지 고민중입니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 