### PR TITLE
feat: 특정 스터디 채널 조회 시 리더 여부에 대한 정보 추가

### DIFF
--- a/src/main/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannel.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannel.java
@@ -66,7 +66,7 @@ public class StudyChannel extends BaseEntity {
     }
 
     public boolean isLeader(Member member) {
-        return studyMembers.stream()
+        return (member != null) && studyMembers.stream()
                 .anyMatch(studyMember -> studyMember.getMember().getId().equals(member.getId()) && studyMember.isLeader());
     }
 
@@ -123,6 +123,7 @@ public class StudyChannel extends BaseEntity {
                 .startDate(this.studyDuration.getStudyStartDate())
                 .endDate(this.studyDuration.getStudyEndDate())
                 .capacity(this.recruitment.getRecruitmentNumber())
+                .isLeader(isLeader(member))
                 .leaderName(leader.getMember().getName())
                 .subLeaderName(Objects.requireNonNullElse(subLeader, leader).getMember().getName());
 

--- a/src/main/java/com/tenten/studybadge/study/channel/dto/StudyChannelDetailsResponse.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/dto/StudyChannelDetailsResponse.java
@@ -26,5 +26,6 @@ public class StudyChannelDetailsResponse {
     private int deposit;
     private String leaderName;
     private String subLeaderName;
+    private boolean isLeader;
 
 }

--- a/src/test/java/com/tenten/studybadge/study/channel/service/StudyChannelServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/study/channel/service/StudyChannelServiceTest.java
@@ -321,6 +321,7 @@ class StudyChannelServiceTest {
             assertThat(response.getMeetingType()).isEqualTo(MeetingType.ONLINE);
             assertThat(response.getRegion()).isNull();
             assertThat(response.getDeposit()).isEqualTo(10_000);
+            assertThat(response.isLeader()).isTrue();
             assertThat(response.getLeaderName()).isEqualTo("회원 1");
             assertThat(response.getSubLeaderName()).isEqualTo("회원 1");
 
@@ -350,6 +351,7 @@ class StudyChannelServiceTest {
             assertThat(response.getMeetingType()).isEqualTo(MeetingType.ONLINE);
             assertThat(response.getRegion()).isNull();
             assertThat(response.getDeposit()).isEqualTo(10_000);
+            assertThat(response.isLeader()).isFalse();
             assertThat(response.getLeaderName()).isEqualTo("회원 1");
             assertThat(response.getSubLeaderName()).isEqualTo("회원 1");
 
@@ -386,6 +388,7 @@ class StudyChannelServiceTest {
             assertThat(response.getMeetingType()).isEqualTo(MeetingType.ONLINE);
             assertThat(response.getRegion()).isNull();
             assertThat(response.getDeposit()).isEqualTo(10_000);
+            assertThat(response.isLeader()).isTrue();
             assertThat(response.getLeaderName()).isEqualTo("회원 1");
             assertThat(response.getSubLeaderName()).isEqualTo("회원 2");
 


### PR DESCRIPTION
### 변경사항
**AS-IS**
* 특정 스터디 채널조회 시 리더인지 여부를 판단할 수 있는 값이 존재하지 않음.


**TO-BE**

* 특정 스터디 채널 조회 시 리더인지 여부를 판단할 수 있는 값을 추가
* isLeader() 에서 member 가 null 일 경우 false로 반환하도록 코드 추가

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 