### PR TITLE
feat: STD-33 특정 일정의 스터디 멤버 목록 조회 기능

### DIFF
--- a/src/main/java/com/tenten/studybadge/attendance/domain/entity/Attendance.java
+++ b/src/main/java/com/tenten/studybadge/attendance/domain/entity/Attendance.java
@@ -33,4 +33,8 @@ public class Attendance extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private AttendanceStatus attendanceStatus;
 
+    public boolean isAttendance() {
+        return this.attendanceStatus.equals(AttendanceStatus.ATTENDANCE);
+    }
+
 }

--- a/src/main/java/com/tenten/studybadge/study/member/controller/StudyMemberController.java
+++ b/src/main/java/com/tenten/studybadge/study/member/controller/StudyMemberController.java
@@ -45,6 +45,9 @@ public class StudyMemberController {
     }
 
     @GetMapping("/api/study-channels/{studyChannelId}/single-schedules/{scheduleId}/members")
+    @Operation(summary = "특정 단일 일정의 스터디 멤버 정보 조회", description = "특정 단일 일정에 대한 스터디 멤버의 목록을 조회하는 API")
+    @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
+    @Parameter(name = "scheduleId", description = "단일 일정 ID", deprecated = true)
     public ResponseEntity<List<ScheduleStudyMemberResponse>> getStudyMembersSingleSchedule(
             @AuthenticationPrincipal CustomUserDetails principal,
             @PathVariable Long studyChannelId,
@@ -56,6 +59,10 @@ public class StudyMemberController {
     }
 
     @GetMapping("/api/study-channels/{studyChannelId}/repeat-schedules/{scheduleId}/members")
+    @Operation(summary = "특정 반복 일정의 스터디 멤버 정보 조회", description = "특정 반복 일정에 대한 스터디 멤버의 목록을 조회하는 API")
+    @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
+    @Parameter(name = "scheduleId", description = "반복 일정 ID", required = true)
+    @Parameter(name = "date", description = "특정 일정 날짜", required = true)
     public ResponseEntity<List<ScheduleStudyMemberResponse>> getStudyMembersRepeatSchedule(
             @AuthenticationPrincipal CustomUserDetails principal,
             @PathVariable Long studyChannelId,

--- a/src/main/java/com/tenten/studybadge/study/member/controller/StudyMemberController.java
+++ b/src/main/java/com/tenten/studybadge/study/member/controller/StudyMemberController.java
@@ -2,15 +2,20 @@ package com.tenten.studybadge.study.member.controller;
 
 import com.tenten.studybadge.common.security.CustomUserDetails;
 import com.tenten.studybadge.study.member.dto.AssignRoleRequest;
+import com.tenten.studybadge.study.member.dto.ScheduleStudyMemberResponse;
 import com.tenten.studybadge.study.member.dto.StudyMembersResponse;
 import com.tenten.studybadge.study.member.service.StudyMemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,6 +42,29 @@ public class StudyMemberController {
             @Valid @RequestBody AssignRoleRequest assignRoleRequest) {
         studyMemberService.assignStudyLeaderRole(studyChannelId, principal.getId(), assignRoleRequest.getStudyMemberId());
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/api/study-channels/{studyChannelId}/single-schedules/{scheduleId}/members")
+    public ResponseEntity<List<ScheduleStudyMemberResponse>> getStudyMembersSingleSchedule(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable Long studyChannelId,
+            @PathVariable Long scheduleId) {
+
+        return ResponseEntity.ok(
+                studyMemberService.getStudyMembersSingleSchedule(studyChannelId, scheduleId, principal.getId())
+        );
+    }
+
+    @GetMapping("/api/study-channels/{studyChannelId}/repeat-schedules/{scheduleId}/members")
+    public ResponseEntity<List<ScheduleStudyMemberResponse>> getStudyMembersRepeatSchedule(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable Long studyChannelId,
+            @PathVariable Long scheduleId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE, pattern = "yyyy-MM-dd") LocalDate date) {
+
+        return ResponseEntity.ok(
+                studyMemberService.getStudyMembersRepeatSchedule(studyChannelId, scheduleId, principal.getId(), date)
+        );
     }
 
 }

--- a/src/main/java/com/tenten/studybadge/study/member/dto/ScheduleStudyMemberResponse.java
+++ b/src/main/java/com/tenten/studybadge/study/member/dto/ScheduleStudyMemberResponse.java
@@ -1,0 +1,20 @@
+package com.tenten.studybadge.study.member.dto;
+
+import com.tenten.studybadge.type.attendance.AttendanceStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class ScheduleStudyMemberResponse {
+    private Long memberId;
+    private Long studyMemberId;
+    private String name;
+    private String imageUrl;
+    private AttendanceStatus attendanceStatus;
+    private boolean isAttendance;
+}

--- a/src/main/java/com/tenten/studybadge/study/member/dto/ScheduleStudyMemberResponse.java
+++ b/src/main/java/com/tenten/studybadge/study/member/dto/ScheduleStudyMemberResponse.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Getter
-@Setter
 @AllArgsConstructor
 @Builder
 public class ScheduleStudyMemberResponse {
@@ -15,6 +14,8 @@ public class ScheduleStudyMemberResponse {
     private Long studyMemberId;
     private String name;
     private String imageUrl;
+    @Setter
     private AttendanceStatus attendanceStatus;
+    @Setter
     private boolean isAttendance;
 }

--- a/src/main/java/com/tenten/studybadge/study/member/service/StudyMemberService.java
+++ b/src/main/java/com/tenten/studybadge/study/member/service/StudyMemberService.java
@@ -1,20 +1,40 @@
 package com.tenten.studybadge.study.member.service;
 
+import com.tenten.studybadge.attendance.domain.entity.Attendance;
+import com.tenten.studybadge.attendance.domain.repository.AttendanceRepository;
 import com.tenten.studybadge.common.exception.member.NotFoundMemberException;
-import com.tenten.studybadge.common.exception.studychannel.*;
+import com.tenten.studybadge.common.exception.schedule.NotFoundRepeatScheduleException;
+import com.tenten.studybadge.common.exception.schedule.NotFoundSingleScheduleException;
+import com.tenten.studybadge.common.exception.studychannel.AlreadyExistsSubLeaderException;
+import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelException;
+import com.tenten.studybadge.common.exception.studychannel.NotStudyLeaderException;
+import com.tenten.studybadge.common.exception.studychannel.NotStudyMemberException;
 import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.member.domain.repository.MemberRepository;
+import com.tenten.studybadge.schedule.domain.entity.RepeatSchedule;
+import com.tenten.studybadge.schedule.domain.entity.SingleSchedule;
+import com.tenten.studybadge.schedule.domain.repository.RepeatScheduleRepository;
+import com.tenten.studybadge.schedule.domain.repository.SingleScheduleRepository;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
 import com.tenten.studybadge.study.channel.domain.repository.StudyChannelRepository;
 import com.tenten.studybadge.study.member.domain.entity.StudyMember;
 import com.tenten.studybadge.study.member.domain.repository.StudyMemberRepository;
+import com.tenten.studybadge.study.member.dto.ScheduleStudyMemberResponse;
 import com.tenten.studybadge.study.member.dto.StudyMemberInfoResponse;
 import com.tenten.studybadge.study.member.dto.StudyMembersResponse;
+import com.tenten.studybadge.type.schedule.RepeatCycle;
+import com.tenten.studybadge.type.schedule.RepeatSituation;
 import com.tenten.studybadge.type.study.member.StudyMemberRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +43,9 @@ public class StudyMemberService {
     private final StudyMemberRepository studyMemberRepository;
     private final StudyChannelRepository studyChannelRepository;
     private final MemberRepository memberRepository;
+    private final SingleScheduleRepository singleScheduleRepository;
+    private final AttendanceRepository attendanceRepository;
+    private final RepeatScheduleRepository repeatScheduleRepository;
 
     public StudyMembersResponse getStudyMembers(Long studyChannelId, Long memberId) {
 
@@ -63,6 +86,92 @@ public class StudyMemberService {
 
     }
 
+    public List<ScheduleStudyMemberResponse> getStudyMembersSingleSchedule(Long studyChannelId, Long scheduleId, Long memberId) {
+        studyMemberRepository.findByMemberIdAndStudyChannelId(studyChannelId, memberId).orElseThrow(NotStudyMemberException::new);
+        SingleSchedule singleSchedule = singleScheduleRepository.findById(scheduleId).orElseThrow(NotFoundSingleScheduleException::new);
+        LocalDate scheduleDate = singleSchedule.getScheduleDate();
+        LocalDate currentDate = LocalDate.now();
+
+        List<StudyMember> studyMembers = studyMemberRepository.findAllByStudyChannelIdWithMember(studyChannelId);
+
+        if (scheduleDate.isBefore(currentDate)) {
+            List<Attendance> attendances = attendanceRepository.findAllBySingleScheduleId(scheduleId);
+            return response(studyMembers, attendances);
+        }
+        return response(studyMembers, Collections.emptyList());
+    }
+
+    public List<ScheduleStudyMemberResponse> getStudyMembersRepeatSchedule(Long studyChannelId, Long scheduleId, Long memberId, LocalDate date) {
+        studyMemberRepository.findByMemberIdAndStudyChannelId(studyChannelId, memberId).orElseThrow(NotStudyMemberException::new);
+        RepeatSchedule repeatSchedule = repeatScheduleRepository.findById(scheduleId).orElseThrow(NotFoundRepeatScheduleException::new);
+        validate(repeatSchedule, date);
+        LocalDate currentDate = LocalDate.now();
+
+        List<StudyMember> studyMembers = studyMemberRepository.findAllByStudyChannelIdWithMember(studyChannelId);
+
+        if (date.isBefore(currentDate)) {
+            LocalDateTime startDateTime = date.atStartOfDay();
+            LocalDateTime endDateTime = startDateTime.plusDays(1);
+            List<Attendance> attendances = attendanceRepository.findAllByRepeatScheduleIdAndAttendanceDateTimeBetween(scheduleId, startDateTime, endDateTime);
+            return response(studyMembers, attendances);
+        }
+        return response(studyMembers, Collections.emptyList());
+    }
+
+    private void validate(RepeatSchedule repeatSchedule, LocalDate date) {
+        LocalDate startDate = repeatSchedule.getScheduleDate();
+        LocalDate endDate = repeatSchedule.getRepeatEndDate();
+        RepeatCycle repeatCycle = repeatSchedule.getRepeatCycle();
+        RepeatSituation repeatSituation = repeatSchedule.getRepeatSituation();
+        validateInRange(date, startDate, endDate);
+        LocalDate currentDate = startDate;
+        boolean isMatched = false;
+        while (currentDate.isBefore(endDate) || currentDate.isEqual(endDate)) {
+            if (currentDate.isEqual(date)) {
+                isMatched = true;
+                break;
+            }
+            switch (repeatCycle) {
+                case DAILY: {
+                    currentDate = currentDate.plusDays(1);
+                    break;
+                }
+                case WEEKLY: {
+                    currentDate = currentDate.plusWeeks(1);
+                    break;
+                }
+                case MONTHLY: {
+                    currentDate = currentDate.plusMonths((Integer) repeatSituation.getDescription());
+                    break;
+                }
+            }
+        }
+        if (!isMatched) {
+            throw new NotFoundRepeatScheduleException();
+        }
+    }
+
+    private List<ScheduleStudyMemberResponse> response(List<StudyMember> studyMembers, List<Attendance> attendances) {
+        List<ScheduleStudyMemberResponse> responses = studyMembers.stream()
+                .map((studyMember -> ScheduleStudyMemberResponse.builder()
+                        .memberId(studyMember.getMember().getId())
+                        .studyMemberId(studyMember.getId())
+                        .name(studyMember.getMember().getName())
+                        .imageUrl(studyMember.getMember().getImgUrl())
+                        .build()
+                ))
+                .toList();
+        if (attendances.isEmpty()) {
+            return responses;
+        }
+        Map<Long, Attendance> attendanceMap = attendances.stream().collect(Collectors.toMap(Attendance::getStudyMemberId, Function.identity()));
+        responses.forEach((response) -> {
+            response.setAttendanceStatus(attendanceMap.get(response.getStudyMemberId()).getAttendanceStatus());
+            response.setAttendance(attendanceMap.get(response.getStudyMemberId()).isAttendance());
+        });
+        return responses;
+    }
+
     private StudyMember getStudyMember(StudyChannel studyChannel, Long studyMemberId) {
         return studyChannel.getStudyMembers().stream()
                 .filter(studyMember -> studyMember.getId().equals(studyMemberId))
@@ -73,6 +182,12 @@ public class StudyMemberService {
     private void checkLeader(StudyChannel studyChannel, Member member) {
         if (!studyChannel.isLeader(member)) {
             throw new NotStudyLeaderException();
+        }
+    }
+
+    private void validateInRange(LocalDate date, LocalDate startDate, LocalDate endDate) {
+        if (date.isBefore(startDate) || date.isAfter(endDate)) {
+            throw new NotFoundRepeatScheduleException();
         }
     }
 


### PR DESCRIPTION
### 변경사항

**AS-IS**

**TO-BE**
특정 일정에서의 스터디 멤버 목록을 조회하는 기능입니다.
조회할 때 다음과 같은 요구사항이 있습니다.
* 오늘을 기준으로 이전 날짜에 대한 일정(출석이 완료된)의 경우 회원 정보와 출석 정보를 함께 전송한다.
* 오늘을 기준으로 이후 날짜에 대한 일정(출석이 되지 않은)의 경우 회원 정보만 조회.

단일 일정의 경우 해당 단일 일정 ID 만으로 출석 여부나 이전 날짜인지를 판단할 수 있습니다.
하지만 반복 일정의 경우 반복 일정 ID가 있더라도 반복 일정 내 특정 날짜를 기준으로 출석을 하기 때문에 일정 날짜를 파라미터로 함께 보내도록 했습니다.
 
예) 반복 일정 : 2024-07-01 ~ 2024-07-29 일 경우
- 오늘 : 2024-07-10 이라고 가정
  -   07-01 일정에서의 스터디 멤버 정보를 조회할 경우 이미 출석 체크된 지난 일정이기 때문에 출석 정보를 함께 조회
  -   07-15 일정에서의 스터디 멤버 정보를 조회할 경우 아직 출석 체크되지 않은 일정이기 때문에 스터디 멤버 정보만 조회

[예시 응답]
## 응답

**이미 지난(출석 체크된) 일정의 경우**

```json
{
	"memberId" : "회원 ID",
	"studyMemberId" : "스터디 멤버 ID",
	"name" : "이름",
	"imageUrl" : "이미지 경로",
	"attendance_status" : "ATTENDANCE" 또는 "ABSENCE",
	"isAttendance" : true 또는 false
}
, 
// ...
```

**아직 지나지 않은(출석 체크하지 않은)일정의 경우**

```json
{
	"memberId" : "회원 ID",
	"studyMemberId" : "스터디 멤버 ID",
	"name" : "이름",
	"imageUrl" : "이미지 경로",
	"attendance_status" : null,
	"isAttendance" : false 
},
// ...
```
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 