### PR TITLE
feat: STD-20 알림 기능 

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/config/CorsConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/CorsConfig.java
@@ -20,7 +20,7 @@ public class CorsConfig {
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     CorsConfiguration config = new CorsConfiguration();
     config.setAllowCredentials(true);
-    config.setAllowedOrigins(Arrays.asList(domain));
+    config.setAllowedOrigins(Arrays.asList(domain, "http://localhost:5173"));
     config.setAllowedHeaders(Arrays.asList("*"));
     config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE"));
     config.addExposedHeader("Authorization");

--- a/src/main/java/com/tenten/studybadge/common/config/RedisConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.tenten.studybadge.common.config;
 
+import com.tenten.studybadge.common.redis.RedisSubscriber;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -7,6 +8,9 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -31,5 +35,19 @@ public class RedisConfig {
         redisTemplate.setValueSerializer(new StringRedisSerializer());
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         return redisTemplate;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisContainer(RedisConnectionFactory connectionFactory,
+        MessageListenerAdapter listenerAdapter) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(listenerAdapter, new PatternTopic("member-*"));
+        return container;
+    }
+
+    @Bean
+    public MessageListenerAdapter listenerAdapter(RedisSubscriber subscriber) {
+        return new MessageListenerAdapter(subscriber, "onMessage");
     }
 }

--- a/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
@@ -41,6 +41,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests( requests -> requests
                         .requestMatchers("/api/members/sign-up", "/api/members/auth/**", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/api/members/login/**", "/error", "/health-check").permitAll()
                         .requestMatchers("/api/token/oauth2/**", "/favicon.ico", "/oauth2/**").permitAll()
+                    // TODO : 로그인이 연결되면 user 권한으로 이동
+                    .requestMatchers("/api/notifications/subscribe").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/study-channels", "/api/study-channels/{studyChannelId:\\d+}").permitAll()
                         .requestMatchers("/api/members/logout", "api/study-channels/*/places", "/api/study-channels/**", "/api/token/re-issue"
                                 , "/api/members/my-info", "/api/members/my-info/update", "/api/payments/**",

--- a/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
@@ -41,12 +41,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests( requests -> requests
                         .requestMatchers("/api/members/sign-up", "/api/members/auth/**", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/api/members/login/**", "/error", "/health-check").permitAll()
                         .requestMatchers("/api/token/oauth2/**", "/favicon.ico", "/oauth2/**").permitAll()
-                    // TODO : 로그인이 연결되면 user 권한으로 이동
-                    .requestMatchers("/api/notifications/subscribe").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/study-channels", "/api/study-channels/{studyChannelId:\\d+}").permitAll()
                         .requestMatchers("/api/members/logout", "api/study-channels/*/places", "/api/study-channels/**", "/api/token/re-issue"
                                 , "/api/members/my-info", "/api/members/my-info/update", "/api/payments/**",
-                            "/api/study-channels/*/schedules/**").hasRole("USER"))
+                            "/api/study-channels/*/schedules/**", "/api/notifications/subscribe").hasRole("USER"))
 
                 .cors(cors -> new CorsConfig())
                 .headers(headers -> headers // h2-console 페이지 접속을 위한 설정

--- a/src/main/java/com/tenten/studybadge/common/constant/NotificationConstant.java
+++ b/src/main/java/com/tenten/studybadge/common/constant/NotificationConstant.java
@@ -1,0 +1,17 @@
+package com.tenten.studybadge.common.constant;
+
+public class NotificationConstant {
+  public static final String SINGLE_SCHEDULE_CREATE = "스터디 채널 id: %d의  %s 새로운 단일 일정이 생성되었습니다.";
+  public static final String REPEAT_SCHEDULE_CREATE = "스터디 채널 id: %d의  %s 새로운 반복 일정이 생성되었습니다.";
+  public static final String SINGLE_SCHEDULE_URL = "/api/study-channels/%d/single-schedules/%d";
+  public static final String REPEAT_SCHEDULE_URL = "/api/study-channels/%d/repeat-schedules/%d";
+
+  public static final String SCHEDULE_UPDATE_FOR_SINGLE_TO_SINGLE = "스터디 채널 id: %d의  %s 단일 일정이 수정되었습니다.";
+  public static final String SCHEDULE_UPDATE_FOR_SINGLE_TO_REPEAT = "스터디 채널 id: %d의  %s 단일 일정이 반복 일정으로 수정되었습니다.";
+  public static final String SCHEDULE_UPDATE_FOR_REPEAT_TO_REPEAT = "스터디 채널 id: %d의  %s 반복 일정이 수정되었습니다.";
+  public static final String SCHEDULE_UPDATE_FOR_REPEAT_TO_SINGLE = "스터디 채널 id: %d의  %s 반복 일정이 단일 일정으로 수정되었습니다.";
+
+
+  public static final String SINGLE_SCHEDULE_DELETE= "스터디 채널 id: %d의  %s 단일 일정이 삭제되었습니다.";
+  public static final String REPEAT_SCHEDULE_DELETE = "스터디 채널 id: %d의  %s 반복 일정이 삭제되었습니다.";
+}

--- a/src/main/java/com/tenten/studybadge/common/exception/notification/NotificationContentEmptyException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/notification/NotificationContentEmptyException.java
@@ -1,0 +1,28 @@
+package com.tenten.studybadge.common.exception.notification;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class NotificationContentEmptyException extends AbstractException {
+
+    private static final String ERROR_CODE = "NOTIFICATION_CONTENT_EMPTY";
+    private static final String ERROR_MESSAGE = "알림 내용이 비어있습니다.";
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return BAD_REQUEST ;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public String getMessage() {
+        return ERROR_MESSAGE;
+    }
+}

--- a/src/main/java/com/tenten/studybadge/common/exception/notification/NotificationContentLengthOverException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/notification/NotificationContentLengthOverException.java
@@ -1,0 +1,27 @@
+package com.tenten.studybadge.common.exception.notification;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class NotificationContentLengthOverException extends AbstractException {
+
+    private static final String ERROR_CODE = "NOTIFICATION_CONTENT_LENGTH_OVER";
+    private static final String ERROR_MESSAGE = "알림 내용이 한글기준 50자를 초과했습니다.";
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return BAD_REQUEST ;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public String getMessage() {
+        return ERROR_MESSAGE;
+    }
+}

--- a/src/main/java/com/tenten/studybadge/common/redis/RedisPublisher.java
+++ b/src/main/java/com/tenten/studybadge/common/redis/RedisPublisher.java
@@ -1,0 +1,21 @@
+package com.tenten.studybadge.common.redis;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class RedisPublisher {
+
+    private final StringRedisTemplate redisTemplate;
+
+    public RedisPublisher(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void publish(String channel, String message) {
+        redisTemplate.convertAndSend(channel, message);
+        log.info("redis publisher channel {} message 발행", channel, message);
+    }
+}

--- a/src/main/java/com/tenten/studybadge/common/redis/RedisSubscriber.java
+++ b/src/main/java/com/tenten/studybadge/common/redis/RedisSubscriber.java
@@ -1,0 +1,27 @@
+package com.tenten.studybadge.common.redis;
+
+import com.tenten.studybadge.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisSubscriber implements MessageListener {
+
+    private final NotificationService notificationService;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String channel = new String(message.getChannel());
+        String messageBody = new String(message.getBody());
+
+        // 채널 이름에서 memberId를 추출하여 해당 클라이언트에게 메시지 전송
+        String memberId = channel.split("-")[1];
+        log.info("member id: {} 알림 proccess 전송 message {}", memberId, messageBody);
+        notificationService.processNotification(memberId, messageBody);
+    }
+}

--- a/src/main/java/com/tenten/studybadge/notification/controller/NotificationController.java
+++ b/src/main/java/com/tenten/studybadge/notification/controller/NotificationController.java
@@ -10,7 +10,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/com/tenten/studybadge/notification/controller/NotificationController.java
+++ b/src/main/java/com/tenten/studybadge/notification/controller/NotificationController.java
@@ -28,6 +28,6 @@ public class NotificationController {
     @Parameter(name = "Last-Event-ID", description = "마지막 event id, 필수는 아님" )
     public SseEmitter subscribe(@AuthenticationPrincipal CustomUserDetails memberDetails,
         @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
-        return notificationService.subscribe(2L, lastEventId);
+        return notificationService.subscribe(memberDetails.getId(), lastEventId);
     }
 }

--- a/src/main/java/com/tenten/studybadge/notification/controller/NotificationController.java
+++ b/src/main/java/com/tenten/studybadge/notification/controller/NotificationController.java
@@ -1,6 +1,7 @@
 package com.tenten.studybadge.notification.controller;
 
 import com.tenten.studybadge.common.security.CustomUserDetails;
+import com.tenten.studybadge.common.security.LoginUser;
 import com.tenten.studybadge.notification.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -26,8 +27,8 @@ public class NotificationController {
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "세션 연결", description = "클라이언트 측에서 세션 연결하는 api")
     @Parameter(name = "Last-Event-ID", description = "마지막 event id, 필수는 아님" )
-    public SseEmitter subscribe(@AuthenticationPrincipal CustomUserDetails memberDetails,
+    public SseEmitter subscribe(@LoginUser Long memberId,
         @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
-        return notificationService.subscribe(memberDetails.getId(), lastEventId);
+        return notificationService.subscribe(memberId, lastEventId);
     }
 }

--- a/src/main/java/com/tenten/studybadge/notification/controller/NotificationController.java
+++ b/src/main/java/com/tenten/studybadge/notification/controller/NotificationController.java
@@ -1,0 +1,34 @@
+package com.tenten.studybadge.notification.controller;
+
+import com.tenten.studybadge.common.security.CustomUserDetails;
+import com.tenten.studybadge.notification.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Notification API", description = "알림 API")
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    // 세션 연결
+    @GetMapping(value = "/api/notifications/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "세션 연결", description = "클라이언트 측에서 세션 연결하는 api")
+    @Parameter(name = "Last-Event-ID", description = "마지막 event id, 필수는 아님" )
+    public SseEmitter subscribe(@AuthenticationPrincipal CustomUserDetails memberDetails,
+        @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
+        return notificationService.subscribe(2L, lastEventId);
+    }
+}

--- a/src/main/java/com/tenten/studybadge/notification/domain/NotificationContent.java
+++ b/src/main/java/com/tenten/studybadge/notification/domain/NotificationContent.java
@@ -1,0 +1,28 @@
+package com.tenten.studybadge.notification.domain;
+
+import com.tenten.studybadge.common.exception.notification.NotificationContentEmptyException;
+import com.tenten.studybadge.common.exception.notification.NotificationContentLengthOverException;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+@Embeddable
+@Getter
+public class NotificationContent {
+    private String content;
+
+    protected NotificationContent() {}
+
+    public NotificationContent(String content) {
+        validateContent(content);
+        this.content = content;
+    }
+
+    private void validateContent(String content) {
+        if (content == null || content.trim().isEmpty()) {
+            throw new NotificationContentEmptyException();
+        }
+        if (content.length() > 150) {
+            throw new NotificationContentLengthOverException();
+        }
+    }
+}

--- a/src/main/java/com/tenten/studybadge/notification/domain/RelatedUrl.java
+++ b/src/main/java/com/tenten/studybadge/notification/domain/RelatedUrl.java
@@ -1,0 +1,16 @@
+package com.tenten.studybadge.notification.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+@Embeddable
+@Getter
+public class RelatedUrl {
+    private String url;
+
+    protected RelatedUrl() {}
+
+    public RelatedUrl(String url) {
+      this.url = url;
+    }
+}

--- a/src/main/java/com/tenten/studybadge/notification/domain/entitiy/Notification.java
+++ b/src/main/java/com/tenten/studybadge/notification/domain/entitiy/Notification.java
@@ -19,10 +19,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
+@Getter
+@ToString
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseEntity {
@@ -68,7 +72,7 @@ public class Notification extends BaseEntity {
 
     public NotificationResponse toResponse() {
         return NotificationResponse.builder()
-            .id(this.id)
+            .notificationId(this.id)
             .receiverId(this.receiver.getId())
             .notificationType(this.notificationType.getDescription())
             .content(this.getContent())

--- a/src/main/java/com/tenten/studybadge/notification/domain/entitiy/Notification.java
+++ b/src/main/java/com/tenten/studybadge/notification/domain/entitiy/Notification.java
@@ -1,0 +1,79 @@
+package com.tenten.studybadge.notification.domain.entitiy;
+
+import com.tenten.studybadge.common.BaseEntity;
+import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.notification.domain.NotificationContent;
+import com.tenten.studybadge.notification.domain.RelatedUrl;
+import com.tenten.studybadge.notification.dto.NotificationResponse;
+import com.tenten.studybadge.type.notification.NotificationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    @Embedded
+    private NotificationContent content;
+
+    @Embedded
+    private RelatedUrl url;
+
+    @Column(nullable = false)
+    private Boolean isRead;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType notificationType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Member receiver;
+
+    @Builder
+    public Notification(Member receiver, NotificationType notificationType, String content, String url, Boolean isRead) {
+        this.receiver = receiver;
+        this.notificationType = notificationType;
+        this.content = new NotificationContent(content);
+        this.url = new RelatedUrl(url);
+        this.isRead = isRead;
+    }
+
+    public String getContent() {
+      return content.getContent();
+    }
+
+    public String getUrl() {
+      return url.getUrl();
+    }
+
+    public NotificationResponse toResponse() {
+        return NotificationResponse.builder()
+            .id(this.id)
+            .receiverId(this.receiver.getId())
+            .notificationType(this.notificationType.getDescription())
+            .content(this.getContent())
+            .url(this.getUrl())
+            .isRead(this.isRead)
+            .build();
+    }
+}

--- a/src/main/java/com/tenten/studybadge/notification/domain/repository/EmitterRepository.java
+++ b/src/main/java/com/tenten/studybadge/notification/domain/repository/EmitterRepository.java
@@ -1,0 +1,12 @@
+package com.tenten.studybadge.notification.domain.repository;
+
+import java.util.Map;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface EmitterRepository {
+    SseEmitter save(String emitterId, SseEmitter sseEmitter);
+    void saveEventCache(String emitterId, Object event);
+    Map<String, SseEmitter> findAllEmitterStartWithByMemberId(String memberId);
+    Map<String, Object> findAllEventCacheStartWithByMemberId(String memberId);
+    void deleteById(String id);
+}

--- a/src/main/java/com/tenten/studybadge/notification/domain/repository/EmitterRepositoryImpl.java
+++ b/src/main/java/com/tenten/studybadge/notification/domain/repository/EmitterRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.tenten.studybadge.notification.domain.repository;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Repository
+@NoArgsConstructor
+public class EmitterRepositoryImpl implements EmitterRepository {
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
+
+    @Override
+    public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
+        emitters.put(emitterId, sseEmitter);
+        return sseEmitter;
+    }
+
+    @Override
+    public void saveEventCache(String eventCacheId, Object event) {
+        eventCache.put(eventCacheId, event);
+    }
+
+    @Override
+    public Map<String, SseEmitter> findAllEmitterStartWithByMemberId(String memberId) {
+        return emitters.entrySet().stream()
+            .filter(entry -> entry.getKey().startsWith(memberId))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public Map<String, Object> findAllEventCacheStartWithByMemberId(String memberId) {
+        return eventCache.entrySet().stream()
+            .filter(entry -> entry.getKey().startsWith(memberId))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public void deleteById(String id) {
+        emitters.remove(id);
+    }
+}

--- a/src/main/java/com/tenten/studybadge/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/tenten/studybadge/notification/domain/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package com.tenten.studybadge.notification.domain.repository;
+
+import com.tenten.studybadge.notification.domain.entitiy.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/src/main/java/com/tenten/studybadge/notification/dto/DummyData.java
+++ b/src/main/java/com/tenten/studybadge/notification/dto/DummyData.java
@@ -1,0 +1,14 @@
+package com.tenten.studybadge.notification.dto;
+
+import lombok.Getter;
+
+@Getter
+public class DummyData {
+    private String message;
+    private Boolean isDummy;
+
+    public DummyData(String message) {
+        this.message = message;
+        this.isDummy = true;
+    }
+}

--- a/src/main/java/com/tenten/studybadge/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/tenten/studybadge/notification/dto/NotificationResponse.java
@@ -1,0 +1,19 @@
+package com.tenten.studybadge.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class NotificationResponse {
+    private Long notificationId;
+    private Long receiverId;
+    private String notificationType;
+    private String content;
+    private String url;
+    private Boolean isRead;
+}

--- a/src/main/java/com/tenten/studybadge/notification/service/NotificationService.java
+++ b/src/main/java/com/tenten/studybadge/notification/service/NotificationService.java
@@ -1,0 +1,138 @@
+package com.tenten.studybadge.notification.service;
+
+import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.notification.domain.entitiy.Notification;
+import com.tenten.studybadge.notification.domain.repository.EmitterRepository;
+import com.tenten.studybadge.notification.domain.repository.NotificationRepository;
+import com.tenten.studybadge.study.member.domain.entity.StudyMember;
+import com.tenten.studybadge.study.member.domain.repository.StudyMemberRepository;
+import com.tenten.studybadge.type.notification.NotificationType;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+    private final long timeout = 60 * 1000L; // 1분 타임아웃
+    private final EmitterRepository emitterRepository;
+    private final NotificationRepository notificationRepository;
+    private final StudyMemberRepository studyMemberRepository;
+
+    public SseEmitter subscribe(Long memberId, String lastEventId) {
+        String emitterId = makeTimeIncludeId(memberId);
+        SseEmitter sseEmitter = emitterRepository.save(emitterId, new SseEmitter(timeout));
+
+        sseEmitter.onCompletion(() -> {
+            log.info("onCompletion 콜백, 이벤트 전송 성공 => 이벤트 삭제 emitterId: {}", emitterId);
+            emitterRepository.deleteById(emitterId);
+        });
+        sseEmitter.onTimeout(() -> {
+            log.info("timeOut 콜백, 이벤트 스트림 연결 끊김 => 이벤트 삭제 emitterId: {}", emitterId);
+            emitterRepository.deleteById(emitterId);
+        });
+        sseEmitter.onError((throwable) -> {
+            log.error("에러 발생: {}", throwable.getMessage());
+            emitterRepository.deleteById(emitterId);
+        });
+
+        // 503 에러를 방지하기 위한 더미 이벤트 전송
+        String eventId = makeTimeIncludeId(memberId);
+        sendNotification(sseEmitter, eventId, emitterId, "알림 서버 연결 성공, EventStream 생성. [memberId=" + memberId + "]");
+
+        // 하트비트 전송
+        sendHeartbeat(sseEmitter, emitterId);
+
+        // 클라이언트가 미수신한 Event 목록이 존재할 경우 전송하여 Event 유실을 예방
+        if (hasLostData(lastEventId)) {
+            sendLostData(lastEventId, memberId, emitterId, sseEmitter);
+        }
+
+        return sseEmitter;
+    }
+
+    private String makeTimeIncludeId(Long memberId) {
+        return memberId + "_" + System.currentTimeMillis();
+    }
+
+    private void sendNotification(SseEmitter emitter, String eventId, String emitterId, Object data) {
+        try {
+            emitter.send(SseEmitter.event().id(eventId).data(data));
+        } catch (IOException exception) {
+            emitterRepository.deleteById(emitterId);
+            log.error("알림 전송 실패. EmitterId: {}, Exception: {}", emitterId, exception.getMessage());
+        }
+    }
+
+    private boolean hasLostData(String lastEventId) {
+        return lastEventId != null && !lastEventId.isEmpty();
+    }
+
+    private void sendLostData(String lastEventId, Long memberId, String emitterId, SseEmitter emitter) {
+        Map<String, Object> eventCaches = emitterRepository.findAllEventCacheStartWithByMemberId(String.valueOf(memberId));
+        eventCaches.entrySet().stream()
+            .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+            .forEach(entry -> sendNotification(emitter, entry.getKey(), emitterId, entry.getValue()));
+        log.info("전송 받지 못한 알림 전송. lastEventId: {}", lastEventId);
+    }
+
+    private void sendHeartbeat(SseEmitter sseEmitter, String emitterId) {
+        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
+            try {
+                sseEmitter.send(SseEmitter.event()
+                    .id("heartbeat")
+                    .name("heartbeat")
+                    .data("heartbeat"));
+                log.info("주기적인 하트비트가 전송되었습니다.");
+            } catch (IOException e) {
+                log.error("Error sending heartbeat: {}", e.getMessage());
+                emitterRepository.deleteById(emitterId);
+            }
+        }, 0, timeout / 2, TimeUnit.MILLISECONDS); // 30초 간격으로 하트비트 전송
+    }
+
+    public void sendNotificationToStudyChannel(Long studyChannelId,
+        NotificationType notificationType, String content, String url) {
+
+        List<Member> members = studyMemberRepository.findAllByStudyChannelIdWithMember(studyChannelId)
+            .stream()
+            .map(StudyMember::getMember)
+            .collect(Collectors.toList());
+
+        for (Member member : members) {
+            send(member, notificationType, content, url);
+        }
+    }
+
+    public void send(Member receiver, NotificationType notificationType, String content, String url) {
+        Notification notification = notificationRepository.save(
+            createNotification(receiver, notificationType, content, url));
+
+        String receiverId = String.valueOf(receiver.getId());
+        String eventId = receiverId + "_" + System.currentTimeMillis();
+        Map<String, SseEmitter> emitters = emitterRepository.findAllEmitterStartWithByMemberId(receiverId);
+        emitters.forEach((key, emitter) -> {
+            emitterRepository.saveEventCache(key, notification);
+            sendNotification(emitter, eventId, key, notification.toResponse());
+        });
+        log.info("Notification sent to memberId: {}, notificationType: {}, content: {}, url: {}", receiver.getId(), notificationType, content, url);
+    }
+
+    private Notification createNotification(Member receiver, NotificationType notificationType, String content, String url) {
+        return Notification.builder()
+            .receiver(receiver)
+            .notificationType(notificationType)
+            .content(content)
+            .url(url)
+            .isRead(false)
+            .build();
+    }
+}

--- a/src/main/java/com/tenten/studybadge/notification/service/NotificationService.java
+++ b/src/main/java/com/tenten/studybadge/notification/service/NotificationService.java
@@ -13,9 +13,7 @@ import com.tenten.studybadge.study.member.domain.entity.StudyMember;
 import com.tenten.studybadge.study.member.domain.repository.StudyMemberRepository;
 import com.tenten.studybadge.type.notification.NotificationType;
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -96,15 +94,10 @@ public class NotificationService {
     public void sendNotificationToStudyChannel(Long studyChannelId,
         NotificationType notificationType, String content, String url) {
 
-        List<Member> members = studyMemberRepository.findAllByStudyChannelIdWithMember(
-                studyChannelId)
+        studyMemberRepository.findAllByStudyChannelIdWithMember(studyChannelId)
             .stream()
             .map(StudyMember::getMember)
-            .collect(Collectors.toList());
-
-        for (Member member : members) {
-            send(member, notificationType, content, url);
-        }
+            .forEach((member) -> send(member, notificationType, content, url));
     }
 
     public void send(Member receiver, NotificationType notificationType, String content,

--- a/src/main/java/com/tenten/studybadge/notification/service/NotificationService.java
+++ b/src/main/java/com/tenten/studybadge/notification/service/NotificationService.java
@@ -1,17 +1,19 @@
 package com.tenten.studybadge.notification.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tenten.studybadge.common.redis.RedisPublisher;
 import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.notification.domain.entitiy.Notification;
 import com.tenten.studybadge.notification.domain.repository.EmitterRepository;
 import com.tenten.studybadge.notification.domain.repository.NotificationRepository;
+import com.tenten.studybadge.notification.dto.NotificationResponse;
 import com.tenten.studybadge.study.member.domain.entity.StudyMember;
 import com.tenten.studybadge.study.member.domain.repository.StudyMemberRepository;
 import com.tenten.studybadge.type.notification.NotificationType;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,14 +24,17 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
-    private final long timeout = 60 * 1000L; // 1분 타임아웃
+
+    private final long timeout = 2 * 60 * 1000L; // 2분 타임아웃
     private final EmitterRepository emitterRepository;
     private final NotificationRepository notificationRepository;
     private final StudyMemberRepository studyMemberRepository;
+    private final RedisPublisher redisPublisher;
+    private final ObjectMapper objectMapper;
 
     public SseEmitter subscribe(Long memberId, String lastEventId) {
         String emitterId = makeTimeIncludeId(memberId);
-        SseEmitter sseEmitter = emitterRepository.save(emitterId, new SseEmitter(timeout));
+        SseEmitter sseEmitter = new SseEmitter(timeout);
 
         sseEmitter.onCompletion(() -> {
             log.info("onCompletion 콜백, 이벤트 전송 성공 => 이벤트 삭제 emitterId: {}", emitterId);
@@ -44,12 +49,11 @@ public class NotificationService {
             emitterRepository.deleteById(emitterId);
         });
 
+        emitterRepository.save(emitterId, sseEmitter);
+
         // 503 에러를 방지하기 위한 더미 이벤트 전송
         String eventId = makeTimeIncludeId(memberId);
         sendNotification(sseEmitter, eventId, emitterId, "알림 서버 연결 성공, EventStream 생성. [memberId=" + memberId + "]");
-
-        // 하트비트 전송
-        sendHeartbeat(sseEmitter, emitterId);
 
         // 클라이언트가 미수신한 Event 목록이 존재할 경우 전송하여 Event 유실을 예방
         if (hasLostData(lastEventId)) {
@@ -63,9 +67,11 @@ public class NotificationService {
         return memberId + "_" + System.currentTimeMillis();
     }
 
-    private void sendNotification(SseEmitter emitter, String eventId, String emitterId, Object data) {
+    private void sendNotification(SseEmitter emitter, String eventId, String emitterId,
+        Object data) {
         try {
-            emitter.send(SseEmitter.event().id(eventId).data(data));
+            String jsonString = objectMapper.writeValueAsString(data);
+            emitter.send(SseEmitter.event().id(eventId).data(jsonString));
         } catch (IOException exception) {
             emitterRepository.deleteById(emitterId);
             log.error("알림 전송 실패. EmitterId: {}, Exception: {}", emitterId, exception.getMessage());
@@ -76,7 +82,8 @@ public class NotificationService {
         return lastEventId != null && !lastEventId.isEmpty();
     }
 
-    private void sendLostData(String lastEventId, Long memberId, String emitterId, SseEmitter emitter) {
+    private void sendLostData(String lastEventId, Long memberId, String emitterId,
+        SseEmitter emitter) {
         Map<String, Object> eventCaches = emitterRepository.findAllEventCacheStartWithByMemberId(String.valueOf(memberId));
         eventCaches.entrySet().stream()
             .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
@@ -84,25 +91,11 @@ public class NotificationService {
         log.info("전송 받지 못한 알림 전송. lastEventId: {}", lastEventId);
     }
 
-    private void sendHeartbeat(SseEmitter sseEmitter, String emitterId) {
-        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
-            try {
-                sseEmitter.send(SseEmitter.event()
-                    .id("heartbeat")
-                    .name("heartbeat")
-                    .data("heartbeat"));
-                log.info("주기적인 하트비트가 전송되었습니다.");
-            } catch (IOException e) {
-                log.error("Error sending heartbeat: {}", e.getMessage());
-                emitterRepository.deleteById(emitterId);
-            }
-        }, 0, timeout / 2, TimeUnit.MILLISECONDS); // 30초 간격으로 하트비트 전송
-    }
-
     public void sendNotificationToStudyChannel(Long studyChannelId,
         NotificationType notificationType, String content, String url) {
 
-        List<Member> members = studyMemberRepository.findAllByStudyChannelIdWithMember(studyChannelId)
+        List<Member> members = studyMemberRepository.findAllByStudyChannelIdWithMember(
+                studyChannelId)
             .stream()
             .map(StudyMember::getMember)
             .collect(Collectors.toList());
@@ -112,21 +105,54 @@ public class NotificationService {
         }
     }
 
-    public void send(Member receiver, NotificationType notificationType, String content, String url) {
+    public void send(Member receiver, NotificationType notificationType, String content,
+        String url) {
         Notification notification = notificationRepository.save(
             createNotification(receiver, notificationType, content, url));
 
         String receiverId = String.valueOf(receiver.getId());
         String eventId = receiverId + "_" + System.currentTimeMillis();
-        Map<String, SseEmitter> emitters = emitterRepository.findAllEmitterStartWithByMemberId(receiverId);
+        Map<String, SseEmitter> emitters = emitterRepository.findAllEmitterStartWithByMemberId(
+            receiverId);
         emitters.forEach((key, emitter) -> {
             emitterRepository.saveEventCache(key, notification);
             sendNotification(emitter, eventId, key, notification.toResponse());
         });
-        log.info("Notification sent to memberId: {}, notificationType: {}, content: {}, url: {}", receiver.getId(), notificationType, content, url);
+        log.info("Notification sent to memberId: {}, notificationType: {}, content: {}, url: {}",
+            receiver.getId(), notificationType, content, url);
+
+        // Redis Pub/Sub을 통해 메시지 발행
+        try {
+            String message = objectMapper.writeValueAsString(notification.toResponse());
+            redisPublisher.publish("member-" + receiverId, message);
+        } catch (JsonProcessingException e) {
+            log.error("메시지 변환 실패: {}", e.getMessage());
+        }
     }
 
-    private Notification createNotification(Member receiver, NotificationType notificationType, String content, String url) {
+    public void processNotification(String memberId, String message) {
+        try {
+            // 메시지 파싱
+            NotificationResponse notificationResponse = objectMapper.readValue(message,
+                NotificationResponse.class);
+
+            String eventId = memberId + "_" + System.currentTimeMillis();
+
+            // SSE를 통해 알림 전송
+            Map<String, SseEmitter> emitters = emitterRepository.findAllEmitterStartWithByMemberId(
+                memberId);
+            emitters.forEach((key, emitter) -> {
+                sendNotification(emitter, eventId, key, notificationResponse);
+            });
+
+            log.info("알림 메시지 process: {}", message);
+        } catch (JsonProcessingException e) {
+            log.error("알림 메시지 process 실패: {}", message, e);
+        }
+    }
+
+    private Notification createNotification(Member receiver, NotificationType notificationType,
+        String content, String url) {
         return Notification.builder()
             .receiver(receiver)
             .notificationType(notificationType)

--- a/src/main/java/com/tenten/studybadge/notification/service/NotificationService.java
+++ b/src/main/java/com/tenten/studybadge/notification/service/NotificationService.java
@@ -7,6 +7,7 @@ import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.notification.domain.entitiy.Notification;
 import com.tenten.studybadge.notification.domain.repository.EmitterRepository;
 import com.tenten.studybadge.notification.domain.repository.NotificationRepository;
+import com.tenten.studybadge.notification.dto.DummyData;
 import com.tenten.studybadge.notification.dto.NotificationResponse;
 import com.tenten.studybadge.study.member.domain.entity.StudyMember;
 import com.tenten.studybadge.study.member.domain.repository.StudyMemberRepository;
@@ -53,7 +54,8 @@ public class NotificationService {
 
         // 503 에러를 방지하기 위한 더미 이벤트 전송
         String eventId = makeTimeIncludeId(memberId);
-        sendNotification(sseEmitter, eventId, emitterId, "알림 서버 연결 성공, EventStream 생성. [memberId=" + memberId + "]");
+        sendNotification(sseEmitter, eventId, emitterId,
+            new DummyData("알림 서버 연결 성공, EventStream 생성. [memberId=" + memberId + "]"));
 
         // 클라이언트가 미수신한 Event 목록이 존재할 경우 전송하여 Event 유실을 예방
         if (hasLostData(lastEventId)) {

--- a/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
+++ b/src/main/java/com/tenten/studybadge/schedule/service/ScheduleService.java
@@ -1,5 +1,13 @@
 package com.tenten.studybadge.schedule.service;
 
+import static com.tenten.studybadge.common.constant.NotificationConstant.REPEAT_SCHEDULE_CREATE;
+import static com.tenten.studybadge.common.constant.NotificationConstant.REPEAT_SCHEDULE_DELETE;
+import static com.tenten.studybadge.common.constant.NotificationConstant.REPEAT_SCHEDULE_URL;
+import static com.tenten.studybadge.common.constant.NotificationConstant.SINGLE_SCHEDULE_CREATE;
+import static com.tenten.studybadge.common.constant.NotificationConstant.SINGLE_SCHEDULE_DELETE;
+import static com.tenten.studybadge.common.constant.NotificationConstant.SINGLE_SCHEDULE_URL;
+
+import com.tenten.studybadge.common.constant.NotificationConstant;
 import com.tenten.studybadge.common.exception.schedule.CanNotDeleteForBeforeDateException;
 import com.tenten.studybadge.common.exception.schedule.IllegalArgumentForRepeatScheduleEditRequestException;
 import com.tenten.studybadge.common.exception.schedule.IllegalArgumentForRepeatSituationException;
@@ -14,7 +22,6 @@ import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelE
 import com.tenten.studybadge.common.exception.studychannel.NotStudyLeaderException;
 import com.tenten.studybadge.common.exception.studychannel.NotStudyMemberException;
 import com.tenten.studybadge.notification.service.NotificationService;
-import com.tenten.studybadge.schedule.domain.Schedule;
 import com.tenten.studybadge.schedule.domain.entity.RepeatSchedule;
 import com.tenten.studybadge.schedule.domain.entity.SingleSchedule;
 import com.tenten.studybadge.schedule.domain.repository.RepeatScheduleRepository;
@@ -36,6 +43,7 @@ import com.tenten.studybadge.type.schedule.RepeatSituation;
 import com.tenten.studybadge.type.schedule.ScheduleType;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -61,10 +69,9 @@ public class ScheduleService {
 
         SingleSchedule saveSingleSchedule = singleScheduleRepository.save(createSingleScheduleFromRequest(
             singleScheduleCreateRequest, studyChannel));
-        log.info("단일 일정이 생성 되었습니다. studyChannelId: {}", studyChannelId);
-        String url = String.format("/api/study-channels/%d/repeat-schedules/%d", studyChannelId, saveSingleSchedule.getId());
-        notificationService.sendNotificationToStudyChannel(studyChannelId,
-            NotificationType.SCHEDULE_CREATE, "새로운 단일 일정이 등록되었습니다.", url);
+        sendNotificationForScheduleCreate(studyChannelId, saveSingleSchedule.getId(),
+            saveSingleSchedule.getScheduleDate(), NotificationType.SCHEDULE_CREATE,
+            SINGLE_SCHEDULE_URL, SINGLE_SCHEDULE_CREATE);
     }
 
     public void postRepeatSchedule(RepeatScheduleCreateRequest repeatScheduleCreateRequest, Long studyChannelId) {
@@ -79,10 +86,10 @@ public class ScheduleService {
 
         RepeatSchedule saveRepeatSchedule = repeatScheduleRepository.save(
             createRepeatScheduleFromRequest(repeatScheduleCreateRequest, studyChannel));
-        String url = String.format("/api/study-channels/%d/repeat-schedules/%d", studyChannelId, saveRepeatSchedule.getId());
-        log.info("반복 일정이 생성 되었습니다. studyChannelId: {}", studyChannelId);
-        notificationService.sendNotificationToStudyChannel(studyChannelId,
-            NotificationType.SCHEDULE_CREATE, "새로운 반복 일정이 등록되었습니다.", url);
+
+        sendNotificationForScheduleCreate(studyChannelId, saveRepeatSchedule.getId(),
+            saveRepeatSchedule.getScheduleDate(), NotificationType.SCHEDULE_CREATE,
+            REPEAT_SCHEDULE_URL, REPEAT_SCHEDULE_CREATE);
     }
 
     public List<ScheduleResponse> getSchedulesInStudyChannel(
@@ -192,6 +199,10 @@ public class ScheduleService {
 
         singleSchedule.updateSingleSchedule(editRequestToSingleSchedule);
         singleScheduleRepository.save(singleSchedule);
+
+        sendNotificationForScheduleUpdateOrDelete(singleSchedule.getStudyChannel().getId(),
+            singleSchedule.getScheduleDate(), NotificationType.SCHEDULE_UPDATE,
+            NotificationConstant.SCHEDULE_UPDATE_FOR_SINGLE_TO_SINGLE);
     }
 
     public void putScheduleSingleToRepeat(RepeatScheduleEditRequest editRequestToRepeatSchedule) {
@@ -209,6 +220,10 @@ public class ScheduleService {
             editRequestToRepeatSchedule, singleSchedule.getStudyChannel()));
 
         singleScheduleRepository.deleteById(editRequestToRepeatSchedule.getScheduleId());
+
+        sendNotificationForScheduleUpdateOrDelete(singleSchedule.getStudyChannel().getId(),
+            singleSchedule.getScheduleDate(), NotificationType.SCHEDULE_UPDATE,
+            NotificationConstant.SCHEDULE_UPDATE_FOR_SINGLE_TO_REPEAT);
     }
 
     public void putScheduleRepeatToRepeat(RepeatScheduleEditRequest editRequestToRepeatSchedule) {
@@ -237,6 +252,10 @@ public class ScheduleService {
 
         repeatSchedule.updateRepeatSchedule(editRequestToRepeatSchedule);
         repeatScheduleRepository.save(repeatSchedule);
+
+        sendNotificationForScheduleUpdateOrDelete(repeatSchedule.getStudyChannel().getId(),
+            repeatSchedule.getScheduleDate(), NotificationType.SCHEDULE_UPDATE,
+            NotificationConstant.SCHEDULE_UPDATE_FOR_REPEAT_TO_REPEAT);
     }
 
     public void putScheduleRepeatToSingle(
@@ -274,6 +293,10 @@ public class ScheduleService {
         } else {
             throw new IllegalArgumentForScheduleRequestException();
         }
+
+        sendNotificationForScheduleUpdateOrDelete(repeatSchedule.getStudyChannel().getId(),
+            repeatSchedule.getScheduleDate(), NotificationType.SCHEDULE_UPDATE,
+            NotificationConstant.SCHEDULE_UPDATE_FOR_REPEAT_TO_SINGLE);
     }
 
     public void putScheduleRepeatToSingleAfterEventYes(RepeatSchedule repeatSchedule, SingleScheduleEditRequest singleScheduleEditRequest) {
@@ -353,6 +376,9 @@ public class ScheduleService {
         }
         validateStudyLeader(scheduleDeleteRequest.getMemberId(), studyChannelId);
         singleScheduleRepository.deleteById(scheduleDeleteRequest.getScheduleId());
+
+        sendNotificationForScheduleUpdateOrDelete(studyChannelId, scheduleDeleteRequest.getSelectedDate(),
+            NotificationType.SCHEDULE_DELETE, SINGLE_SCHEDULE_DELETE);
     }
 
     public void deleteRepeatSchedule(Long studyChannelId, Boolean isAfterEventSame, ScheduleDeleteRequest scheduleDeleteRequest) {
@@ -381,6 +407,9 @@ public class ScheduleService {
         } else if (!isAfterEventSame) {
             deleteRepeatScheduleAfterEventSameNo(selectedDate, repeatSchedule);
         }
+
+        sendNotificationForScheduleUpdateOrDelete(studyChannelId, scheduleDeleteRequest.getSelectedDate(),
+            NotificationType.SCHEDULE_DELETE, REPEAT_SCHEDULE_DELETE);
     }
 
     public void deleteRepeatScheduleAfterEventSameYes(LocalDate selectedDate, RepeatSchedule repeatSchedule) {
@@ -625,5 +654,42 @@ public class ScheduleService {
             .placeId(singleScheduleCreateRequest.getPlaceId())
             .isRepeated(false)
             .build();
+    }
+
+    private void sendNotificationForScheduleCreate(Long studyChannelId, Long scheduleId,
+        LocalDate scheduleDate, NotificationType notificationType,
+        String relateUrlFormat, String notificationFormatMessage) {
+        // 로그 메시지 및 알림 메시지에 사용할 날짜 포맷터
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 M월 d일");
+        // 단일 일정 날짜를 포맷팅
+        String formattedDate = scheduleDate.format(formatter);
+        // 알림 메시지 생성
+        String notificationMessage = String.format(notificationFormatMessage, studyChannelId, formattedDate);
+        // 관련 URL 생성
+        String relateUrl = String.format(relateUrlFormat, studyChannelId, scheduleId);
+        notificationService.sendNotificationToStudyChannel(studyChannelId,
+            notificationType, notificationMessage, relateUrl);
+        // 로그 메시지
+        log.info(notificationMessage);
+    }
+
+
+    private void sendNotificationForScheduleUpdateOrDelete(Long studyChannelId, LocalDate scheduleDate,
+        NotificationType notificationType, String notificationFormatMessage) {
+        // 로그 메시지 및 알림 메시지에 사용할 날짜 포맷터
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 M월 d일");
+        // 단일 일정 날짜를 포맷팅
+        String formattedDate = scheduleDate.format(formatter);
+        // 알림 메시지 생성
+        String notificationMessage = String.format(notificationFormatMessage, studyChannelId, formattedDate);
+        // 관련 URL 생성
+        int scheduleYear = scheduleDate.getYear();
+        int scheduleMonth = scheduleDate.getMonthValue();
+        String relateUrl = String.format("/api/study-channels/%d/schedules/date?year=%d&month=%d",
+            studyChannelId, scheduleYear, scheduleMonth);
+        notificationService.sendNotificationToStudyChannel(studyChannelId,
+            notificationType, notificationMessage, relateUrl);
+        // 로그 메시지
+        log.info(notificationMessage);
     }
 }

--- a/src/main/java/com/tenten/studybadge/type/notification/NotificationType.java
+++ b/src/main/java/com/tenten/studybadge/type/notification/NotificationType.java
@@ -1,0 +1,17 @@
+package com.tenten.studybadge.type.notification;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public enum NotificationType {
+  SCHEDULE_CREATE("일정 생성"),
+  SCHEDULE_UPDATE("일정 변경"),
+  SCHEDULE_DELETE("일정 삭제"),
+  TEN_MINUTES_BEFORE_ATTENDANCE("출석 체크 10분 전");
+
+  private String description;
+}

--- a/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
@@ -15,6 +15,7 @@ import com.tenten.studybadge.common.exception.schedule.OutRangeScheduleException
 import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelException;
 import com.tenten.studybadge.common.exception.studychannel.NotStudyLeaderException;
 import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.notification.service.NotificationService;
 import com.tenten.studybadge.schedule.domain.entity.RepeatSchedule;
 import com.tenten.studybadge.schedule.domain.entity.SingleSchedule;
 import com.tenten.studybadge.schedule.domain.repository.RepeatScheduleRepository;
@@ -58,6 +59,9 @@ class ScheduleServiceTest {
     private RepeatScheduleRepository repeatScheduleRepository;
     @Mock
     private StudyChannelRepository studyChannelRepository;
+    @Mock
+    private NotificationService notificationService;
+
 
     @Mock
     private StudyMemberRepository studyMemberRepository;
@@ -749,20 +753,24 @@ class ScheduleServiceTest {
     @Nested
     class ScheduleEditTest2 {
 
-        private RepeatSchedule repeatDailySchedule =
-            RepeatSchedule.withoutIdBuilder()
-            .scheduleName("7월 1일 부터 15일까지 매일 반복 일정")
-            .scheduleContent("Content for repeat meeting")
-            .scheduleDate(LocalDate.of(2024, 9, 1))
-            .scheduleStartTime(LocalTime.of(10, 0))
-            .scheduleEndTime(LocalTime.of(11, 0))
-            .repeatCycle(RepeatCycle.DAILY)
-            .repeatSituation(RepeatSituation.EVERYDAY)
-            .repeatEndDate(LocalDate.of(2024, 12, 29))
-            .isRepeated(true)
-            .studyChannel(studyChannel)
-            .placeId(null)
-            .build();
+        private RepeatSchedule repeatDailySchedule;
+
+        @BeforeEach
+        public void setUp() {
+            repeatDailySchedule = RepeatSchedule.withoutIdBuilder()
+                .scheduleName("7월 1일 부터 15일까지 매일 반복 일정")
+                .scheduleContent("Content for repeat meeting")
+                .scheduleDate(LocalDate.of(2024, 9, 1))
+                .scheduleStartTime(LocalTime.of(10, 0))
+                .scheduleEndTime(LocalTime.of(11, 0))
+                .repeatCycle(RepeatCycle.DAILY)
+                .repeatSituation(RepeatSituation.EVERYDAY)
+                .repeatEndDate(LocalDate.of(2024, 12, 29))
+                .isRepeated(true)
+                .studyChannel(studyChannel) // Ensure studyChannel is set
+                .placeId(null)
+                .build();
+        }
 
         @Test
         @DisplayName("일정 수정 실패(반복 일정 -> 단일 일정) - 스터디 리더가 아님")


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
- 하트 비트 없이 클라이언트와 서버의 연결 time out 시간을 2분으로 설정했습니다.
    - 클라이언트와 서버의 연결이 자꾸 끊기고 알 수 없는 (501 에러, 서버에서 close 된 에러 X) 에러로 인해 하트비트를 설정했으나 연결이 끊기는 것은 마찬가지여서 삭제하고 2분으로 늘렸습니다. 혹시라도 sse에 대해 제가 잘못 구현한 부분이 있으면 언제든지 말씀해주세요. 
- sse 알림 부분이 미숙해 시간이 너무 오래 지나 일단 서버 연동이 멀티 WAS가 아님에도 redis pub/sub을 적용해놨습니다.
    - 이 부분은 오버 엔지니어링이 될 수 있음을 인정합니다. 
- 일정 등록/수정/삭제 시에 해당 스터디 채널 멤버의 실시간 알림이 가는 것을 확인했습니다.
- 만일 해당 스터디 채널의 멤버가 아니면 알림이 생성되더라도 알림이 안 가는 것을 확인했습니다.

![image](https://github.com/user-attachments/assets/8a7264bb-dbde-490c-8baa-992f5d7dba58)

- 프론트의 요구로 더미데이터를 isDummy true로 주기 위해 클래스를 새로 만들었습니다. (연결 후 아무것도 전송하지 않으면 503에러 발생때문) 


**TO-DO**
- 관련 url은 추후 클라이언트의 api 경로로 수정해야합니다.
- 클라이언트에서 클릭할 때의 기능이 구현되면 그때 수정하겠습니다.
- 현재 로그인 후 access token이 알림 세션 연결때는 이어지지 않아 따로 token 값을 넣어주면서 확인했습니다. 그래서 다른 브라우저에서의 알림 비교를 하지 못했습니다. 해당 부분은 이어지면 다시 확인하도록 하겠습니다. 
- 다음과 같은 api 기능이 추가 될 예정입니다.
    - 전체 알림 List를 get
    - 안읽은 알림 List get
    - 읽음 처리 patch
 - 우선 프론트 분과 이야기를 했을 때 출석체크가 되었을 때가 아닌 출석 체크 하기 10분전 알림을 보내는 것으로 의논이 되었는데 아직 구현이 안되었습니다. 

***제가 jira가 STD-20인데 30으로 어느 순간 썼습니다 😢 다행히 해당 STD-30도 제 Jira여서 다른분들의 피해는 없지만 죄송합니다!!***

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 