### PR TITLE
feat: STD-35 참가 신청 승인 기능에 포인트 및 예치금 관련 기능 추가

### DIFF
--- a/src/main/java/com/tenten/studybadge/study/deposit/domain/entity/StudyChannelDeposit.java
+++ b/src/main/java/com/tenten/studybadge/study/deposit/domain/entity/StudyChannelDeposit.java
@@ -1,0 +1,44 @@
+package com.tenten.studybadge.study.deposit.domain.entity;
+
+import com.tenten.studybadge.common.BaseEntity;
+import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
+import com.tenten.studybadge.type.study.deposit.DepositStatus;
+import com.tenten.studybadge.type.study.member.StudyMemberStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class StudyChannelDeposit extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_channel_deposit_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_channel_id")
+    private StudyChannel studyChannel;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+    private Double attendanceRatio;
+
+    @Enumerated(EnumType.STRING)
+    private DepositStatus depositStatus;
+
+    @Enumerated(EnumType.STRING)
+    private StudyMemberStatus studyMemberStatus;
+    private Long amount;                    // 예치한 금액
+    private LocalDateTime depositAt;        // 예치한 날짜
+
+
+}
+

--- a/src/main/java/com/tenten/studybadge/study/deposit/domain/repository/StudyChannelDepositRepository.java
+++ b/src/main/java/com/tenten/studybadge/study/deposit/domain/repository/StudyChannelDepositRepository.java
@@ -1,0 +1,9 @@
+package com.tenten.studybadge.study.deposit.domain.repository;
+
+import com.tenten.studybadge.study.deposit.domain.entity.StudyChannelDeposit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StudyChannelDepositRepository extends JpaRepository<StudyChannelDeposit, Long> {
+}

--- a/src/main/java/com/tenten/studybadge/type/study/deposit/DepositStatus.java
+++ b/src/main/java/com/tenten/studybadge/type/study/deposit/DepositStatus.java
@@ -1,0 +1,6 @@
+package com.tenten.studybadge.type.study.deposit;
+
+public enum DepositStatus {
+    DEPOSIT,        // 예치
+    REFUND,         // 환급
+}

--- a/src/main/java/com/tenten/studybadge/type/study/member/StudyMemberStatus.java
+++ b/src/main/java/com/tenten/studybadge/type/study/member/StudyMemberStatus.java
@@ -1,0 +1,7 @@
+package com.tenten.studybadge.type.study.member;
+
+public enum StudyMemberStatus {
+        PARTICIPATING,  // 참가중
+        LEAVE,          // 나감
+        BAN             // 퇴출
+}


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 기존 참가 신청 승인 로직의 경우 참가 신청 내역의 상태를 "승인" 상태로 변경 후 스터디 멤버에 등록하는 2개의 과정만 존재.
- 참가 신청 승인 기능의 경우 @Transactional이 붙어져 있었다.

**TO-BE**
- @Transactional 제거
- 스터디 채널에 스터디 채널 예치금 내역(**StudyChannelDeposit**) 이라는 엔티티를 설계
   -  예치금 내역의 경우 해당 스터디 채널 내에 현재 어떤 회원이 얼마의 예치금을 넣어놨는지 기록
   - 그리고 추후 출석률에 따른 환급 금액을 계산하거나, 퇴출, 나가기를 했을 때 예치금을 관리하는 목적

**[최종 참가 신청 승인 시나리오]**
-  (기존) 참가 신청 내역을 "승인" 상태로 변경
- (기존) 스터디 채널 멤버로 등록
- (**추가**) **포인트 내역 기록** 
- (**추가**) **회원 보유 포인트 차감**
- (**추가**) **스터디 채널 예치금 내역 기록**

[고민인 부분]
현재 위 단계에서 트랜잭션의 범위를 어떻게 나눠야하는지 고민중입니다.

### 테스트
- [x] 테스트 코드
   - 참가 신청 승인 테스트 내에 추가된 테스트
   - 1. 스터디 멤버로 등록되었는가
   - 2. 포인트 내역이 기록되었는가
   - 3. 회원의 보유 포인트가 차감되었는가
   - 4. 스터디 채널 예치금 내역이 기록되었는가 
- [x] API 테스트 