### PR TITLE
feat: STD-38 스터디 채널 나가기 기능

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/exception/studychannel/LeaveStudyLeaderException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/studychannel/LeaveStudyLeaderException.java
@@ -1,0 +1,28 @@
+package com.tenten.studybadge.common.exception.studychannel;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class LeaveStudyLeaderException extends AbstractException {
+
+    private static final String ERROR_CODE = "LEAVE_STUDY_LEADER_EXCEPTION";
+    private static final String ERROR_MESSAGE = "리더는 스터디 채널에서 나갈 수 없습니다.";
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return BAD_REQUEST;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public String getMessage() {
+        return ERROR_MESSAGE;
+    }
+
+}

--- a/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
+++ b/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
@@ -163,7 +163,6 @@ public class StudyChannelParticipationService {
                 .studyChannel(channel)
                 .member(member)
                 .attendanceRatio(0.0)
-                .studyMemberStatus(StudyMemberStatus.PARTICIPATING)
                 .build();
         studyChannelDepositRepository.save(deposit);
     }

--- a/src/main/java/com/tenten/studybadge/study/deposit/domain/entity/StudyChannelDeposit.java
+++ b/src/main/java/com/tenten/studybadge/study/deposit/domain/entity/StudyChannelDeposit.java
@@ -4,7 +4,6 @@ import com.tenten.studybadge.common.BaseEntity;
 import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
 import com.tenten.studybadge.type.study.deposit.DepositStatus;
-import com.tenten.studybadge.type.study.member.StudyMemberStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -34,11 +33,8 @@ public class StudyChannelDeposit extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private DepositStatus depositStatus;
 
-    @Enumerated(EnumType.STRING)
-    private StudyMemberStatus studyMemberStatus;
     private Long amount;                    // 예치한 금액
     private LocalDateTime depositAt;        // 예치한 날짜
-
 
 }
 

--- a/src/main/java/com/tenten/studybadge/study/member/controller/StudyMemberController.java
+++ b/src/main/java/com/tenten/studybadge/study/member/controller/StudyMemberController.java
@@ -1,6 +1,7 @@
 package com.tenten.studybadge.study.member.controller;
 
 import com.tenten.studybadge.common.security.CustomUserDetails;
+import com.tenten.studybadge.common.security.LoginUser;
 import com.tenten.studybadge.study.member.dto.AssignRoleRequest;
 import com.tenten.studybadge.study.member.dto.ScheduleStudyMemberResponse;
 import com.tenten.studybadge.study.member.dto.StudyMembersResponse;
@@ -72,6 +73,18 @@ public class StudyMemberController {
         return ResponseEntity.ok(
                 studyMemberService.getStudyMembersRepeatSchedule(studyChannelId, scheduleId, principal.getId(), date)
         );
+    }
+
+    @DeleteMapping("/api/study-channels/{studyChannelId}/members/{studyMemberId}")
+    @Operation(summary = "스터디 채널 나가기", description = "스터디 채널을 나가기 위한 API")
+    @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
+    @Parameter(name = "studyMemberId", description = "스터디 멤버 ID", required = true)
+    public ResponseEntity<Void> leaveStudyChannel(
+            @LoginUser Long memberId,
+            @PathVariable Long studyChannelId,
+            @PathVariable Long studyMemberId) {
+        studyMemberService.leaveStudyChannel(studyChannelId, studyMemberId, memberId);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/tenten/studybadge/study/member/domain/entity/StudyMember.java
+++ b/src/main/java/com/tenten/studybadge/study/member/domain/entity/StudyMember.java
@@ -32,8 +32,6 @@ public class StudyMember extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private StudyMemberStatus studyMemberStatus;
 
-    private Integer balance;
-
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -46,7 +44,6 @@ public class StudyMember extends BaseEntity {
         return StudyMember.builder()
                 .member(member)
                 .studyChannel(studyChannel)
-                .balance(0)
                 .studyMemberRole(LEADER)
                 .studyMemberStatus(StudyMemberStatus.PARTICIPATING)
                 .build();
@@ -56,7 +53,6 @@ public class StudyMember extends BaseEntity {
         return StudyMember.builder()
                 .member(member)
                 .studyChannel(studyChannel)
-                .balance(0)
                 .studyMemberRole(STUDY_MEMBER)
                 .studyMemberStatus(StudyMemberStatus.PARTICIPATING)
                 .build();

--- a/src/main/java/com/tenten/studybadge/study/member/domain/entity/StudyMember.java
+++ b/src/main/java/com/tenten/studybadge/study/member/domain/entity/StudyMember.java
@@ -5,8 +5,10 @@ import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
 import com.tenten.studybadge.study.member.dto.StudyMemberInfoResponse;
 import com.tenten.studybadge.type.study.member.StudyMemberRole;
+import com.tenten.studybadge.type.study.member.StudyMemberStatus;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
 
 import static com.tenten.studybadge.type.study.member.StudyMemberRole.*;
 import static jakarta.persistence.FetchType.LAZY;
@@ -16,6 +18,7 @@ import static jakarta.persistence.FetchType.LAZY;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@SQLDelete(sql = "UPDATE STUDY_MEMBER SET study_member_status = 'LEAVE' WHERE study_member_id = ?")
 public class StudyMember extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,6 +28,9 @@ public class StudyMember extends BaseEntity {
     @Setter
     @Enumerated(EnumType.STRING)
     private StudyMemberRole studyMemberRole;
+
+    @Enumerated(EnumType.STRING)
+    private StudyMemberStatus studyMemberStatus;
 
     private Integer balance;
 
@@ -42,6 +48,7 @@ public class StudyMember extends BaseEntity {
                 .studyChannel(studyChannel)
                 .balance(0)
                 .studyMemberRole(LEADER)
+                .studyMemberStatus(StudyMemberStatus.PARTICIPATING)
                 .build();
     }
 
@@ -51,6 +58,7 @@ public class StudyMember extends BaseEntity {
                 .studyChannel(studyChannel)
                 .balance(0)
                 .studyMemberRole(STUDY_MEMBER)
+                .studyMemberStatus(StudyMemberStatus.PARTICIPATING)
                 .build();
     }
 

--- a/src/main/java/com/tenten/studybadge/study/member/service/StudyMemberService.java
+++ b/src/main/java/com/tenten/studybadge/study/member/service/StudyMemberService.java
@@ -5,10 +5,7 @@ import com.tenten.studybadge.attendance.domain.repository.AttendanceRepository;
 import com.tenten.studybadge.common.exception.member.NotFoundMemberException;
 import com.tenten.studybadge.common.exception.schedule.NotFoundRepeatScheduleException;
 import com.tenten.studybadge.common.exception.schedule.NotFoundSingleScheduleException;
-import com.tenten.studybadge.common.exception.studychannel.AlreadyExistsSubLeaderException;
-import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelException;
-import com.tenten.studybadge.common.exception.studychannel.NotStudyLeaderException;
-import com.tenten.studybadge.common.exception.studychannel.NotStudyMemberException;
+import com.tenten.studybadge.common.exception.studychannel.*;
 import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.member.domain.repository.MemberRepository;
 import com.tenten.studybadge.schedule.domain.entity.RepeatSchedule;
@@ -116,6 +113,20 @@ public class StudyMemberService {
             return response(studyMembers, attendances);
         }
         return response(studyMembers, Collections.emptyList());
+    }
+
+    public void leaveStudyChannel(Long studyChannelId, Long studyMemberId, Long memberId) {
+        StudyMember studyMember = studyMemberRepository.findById(studyMemberId).orElseThrow(NotStudyMemberException::new);
+        if (!studyMember.getStudyChannel().getId().equals(studyChannelId)) {
+            throw new NotStudyMemberException();
+        }
+        if (!studyMember.getMember().getId().equals(memberId)) {
+            throw new NotStudyMemberException();
+        }
+        if (studyMember.isLeader()) {
+            throw new LeaveStudyLeaderException();
+        }
+        studyMemberRepository.delete(studyMember);
     }
 
     private void validate(RepeatSchedule repeatSchedule, LocalDate date) {


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 스터디 채널 예치금 엔티티에 스터디 멤버 상태가 존재

**TO-BE**
- 스터디 채널 예치금 엔티티에 스터디 멤버 상태 제거
- 스터디 멤버에 스터디 멤버 상태 추가

[스터디 채널 나가기]
- 스터디 채널을 나갈 때 리더의 경우 나갈 수 없도록 했습니다.
- SOFT DELETE를 위해 @SqlDelete 적용

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 