### PR TITLE
feat: STD-40 알림 전체 조회 기능

### DIFF
--- a/src/main/java/com/tenten/studybadge/StudyBadgeApplication.java
+++ b/src/main/java/com/tenten/studybadge/StudyBadgeApplication.java
@@ -2,10 +2,8 @@ package com.tenten.studybadge;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class StudyBadgeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/tenten/studybadge/common/config/JpaConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.tenten.studybadge.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
@@ -56,7 +56,7 @@ public class SecurityConfig implements WebMvcConfigurer {
                         .requestMatchers(HttpMethod.GET, "/api/study-channels", "/api/study-channels/{studyChannelId:\\d+}").permitAll()
                         .requestMatchers("/api/members/logout", "api/study-channels/*/places", "/api/study-channels/**", "/api/token/re-issue"
                                 , "/api/members/my-info", "/api/members/my-info/update", "/api/payments/**",
-                            "/api/study-channels/*/schedules/**", "/api/points/my-point/**", "/api/members/my-apply/**", "/api/notifications/subscribe").hasRole("USER"))
+                            "/api/study-channels/*/schedules/**", "/api/points/my-point/**", "/api/members/my-apply/**", "/api/notifications/**").hasRole("USER"))
                 .exceptionHandling(exception -> exception.authenticationEntryPoint(authenticationEntryPoint))
 
                 .cors(cors -> new CorsConfig())

--- a/src/main/java/com/tenten/studybadge/notification/controller/NotificationController.java
+++ b/src/main/java/com/tenten/studybadge/notification/controller/NotificationController.java
@@ -2,33 +2,55 @@ package com.tenten.studybadge.notification.controller;
 
 import com.tenten.studybadge.common.security.CustomUserDetails;
 import com.tenten.studybadge.common.security.LoginUser;
+import com.tenten.studybadge.notification.domain.entitiy.Notification;
+import com.tenten.studybadge.notification.dto.NotificationResponse;
 import com.tenten.studybadge.notification.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/notifications")
 @Tag(name = "Notification API", description = "알림 API")
 public class NotificationController {
     private final NotificationService notificationService;
 
     // 세션 연결
-    @GetMapping(value = "/api/notifications/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "세션 연결", description = "클라이언트 측에서 세션 연결하는 api")
     @Parameter(name = "Last-Event-ID", description = "마지막 event id, 필수는 아님" )
     public SseEmitter subscribe(@LoginUser Long memberId,
         @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
         return notificationService.subscribe(memberId, lastEventId);
+    }
+
+    // 알림 전체 조회
+    @GetMapping()
+    @Operation(summary = "알림 전체 조회", description = "사용자에게 온 알림 전체 조회 api")
+    public ResponseEntity<List<NotificationResponse>> getNotifications(
+        @LoginUser Long memberId) {
+        List<Notification> notificationList =
+            notificationService.getNotifications(memberId);
+
+        List<NotificationResponse> responseList = notificationList.stream()
+            .map(Notification::toResponse)
+            .collect(Collectors.toList());
+
+        return ResponseEntity.ok(responseList);
     }
 }

--- a/src/main/java/com/tenten/studybadge/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/tenten/studybadge/notification/domain/repository/NotificationRepository.java
@@ -1,10 +1,11 @@
 package com.tenten.studybadge.notification.domain.repository;
 
 import com.tenten.studybadge.notification.domain.entitiy.Notification;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-
+    List<Notification> findAllByReceiverId(Long receiverId);
 }

--- a/src/main/java/com/tenten/studybadge/notification/service/NotificationService.java
+++ b/src/main/java/com/tenten/studybadge/notification/service/NotificationService.java
@@ -13,6 +13,7 @@ import com.tenten.studybadge.study.member.domain.entity.StudyMember;
 import com.tenten.studybadge.study.member.domain.repository.StudyMemberRepository;
 import com.tenten.studybadge.type.notification.NotificationType;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +31,11 @@ public class NotificationService {
     private final StudyMemberRepository studyMemberRepository;
     private final RedisPublisher redisPublisher;
     private final ObjectMapper objectMapper;
+
+    public List<Notification> getNotifications(Long memberId) {
+        // 특정 사용자의 모든 알림을 조회
+        return notificationRepository.findAllByReceiverId(memberId);
+    }
 
     public SseEmitter subscribe(Long memberId, String lastEventId) {
         String emitterId = makeTimeIncludeId(memberId);

--- a/src/test/java/com/tenten/studybadge/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/tenten/studybadge/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,132 @@
+package com.tenten.studybadge.notification.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.tenten.studybadge.common.jwt.JwtTokenProvider;
+import com.tenten.studybadge.common.oauth2.CustomOAuth2UserService;
+import com.tenten.studybadge.common.oauth2.OAuth2FailureHandler;
+import com.tenten.studybadge.common.oauth2.OAuth2SuccessHandler;
+import com.tenten.studybadge.common.security.CustomAuthenticationEntryPoint;
+import com.tenten.studybadge.common.security.CustomUserDetails;
+import com.tenten.studybadge.common.security.LoginUserArgumentResolver;
+import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.member.domain.type.MemberRole;
+import com.tenten.studybadge.notification.domain.entitiy.Notification;
+import com.tenten.studybadge.notification.dto.NotificationResponse;
+import com.tenten.studybadge.notification.service.NotificationService;
+import com.tenten.studybadge.type.notification.NotificationType;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@WebMvcTest(NotificationController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+public class NotificationControllerTest {
+
+    @MockBean
+    private NotificationService notificationService;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+    @MockBean
+    private RedisTemplate<?, ?> redisTemplate;
+    @MockBean
+    private CustomOAuth2UserService oAuth2UserService;
+    @MockBean
+    private OAuth2SuccessHandler oAuth2SuccessHandler;
+    @MockBean
+    private OAuth2FailureHandler oAuth2FailureHandler;
+    @MockBean
+    private LoginUserArgumentResolver loginUserArgumentResolver;
+    @MockBean
+    private CustomAuthenticationEntryPoint authenticationEntryPoint;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Mock
+    private CustomUserDetails customUserDetails;
+    @Mock
+    private Authentication authentication;
+    @Mock
+    private SecurityContext securityContext;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        mockMvc = MockMvcBuilders.
+            standaloneSetup(new NotificationController(notificationService))
+            .setCustomArgumentResolvers(loginUserArgumentResolver)
+            .build();
+
+        when(authentication.getPrincipal()).thenReturn(customUserDetails);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        SecurityContextHolder.setContext(securityContext);
+    }
+
+    @Test
+    @DisplayName("특정 사용자(member id: 1의 전체 알림 조회 성공")
+    @WithMockUser(username = "testuser", roles = "USER")
+    public void testGetNotifications() throws Exception {
+        // given
+        Long memberId = 1L;
+        Notification notification1 = Notification.builder()
+            .content("일정 생성 알림")
+            .url("관련 url")
+            .isRead(false)
+            .notificationType(NotificationType.SCHEDULE_CREATE)
+            .receiver(Member.builder()
+                .id(memberId)
+                .role(MemberRole.USER)
+                .build())
+            .build();
+        Notification notification2 = Notification.builder()
+            .content("일정 삭제 알림")
+            .url("관련 url")
+            .isRead(false)
+            .notificationType(NotificationType.SCHEDULE_DELETE)
+            .receiver(Member.builder()
+                .id(memberId)
+                .role(MemberRole.USER)
+                .build())
+            .build();
+
+        List<Notification> notifications = Arrays.asList(notification1, notification2);
+        List<NotificationResponse> notificationResponses = notifications.stream()
+            .map(Notification::toResponse)
+            .collect(Collectors.toList());
+
+        when(loginUserArgumentResolver.supportsParameter(any())).thenReturn(true);
+        when(loginUserArgumentResolver.resolveArgument(any(), any(), any(), any()))
+            .thenReturn(1L);
+        when(customUserDetails.getId()).thenReturn(memberId);
+        when(notificationService.getNotifications(memberId))
+            .thenReturn(notifications);
+
+        // when & then
+        mockMvc.perform(get("/api/notifications"))
+              .andExpect(status().isOk())
+              .andExpect(jsonPath("$[0].content").value("일정 생성 알림"))
+              .andExpect(jsonPath("$[1].content").value("일정 삭제 알림"));
+    }
+}

--- a/src/test/java/com/tenten/studybadge/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/notification/service/NotificationServiceTest.java
@@ -1,0 +1,66 @@
+package com.tenten.studybadge.notification.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.notification.domain.entitiy.Notification;
+import com.tenten.studybadge.notification.domain.repository.NotificationRepository;
+import com.tenten.studybadge.type.notification.NotificationType;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    @Test
+    @DisplayName("전체 알림 조회 성공")
+    void getNotifications_success() {
+        Long memberId = 1L;
+
+        Notification notification1 = Notification.builder()
+            .content("일정 생성 알림")
+            .url("관련 url")
+            .isRead(false)
+            .notificationType(NotificationType.SCHEDULE_CREATE)
+            .receiver(Member.builder()
+                .id(memberId).build())
+            .build();
+        Notification notification2 = Notification.builder()
+            .content("일정 삭제 알림")
+            .url("관련 url")
+            .isRead(false)
+            .notificationType(NotificationType.SCHEDULE_DELETE)
+            .receiver(Member.builder()
+                .id(memberId).build())
+            .build();
+
+        List<Notification> notifications = Arrays.asList(notification1, notification2);
+
+        when(notificationRepository.findAllByReceiverId(memberId)).thenReturn(notifications);
+
+        List<Notification> result = notificationService.getNotifications(memberId);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals(notification1, result.get(0));
+        assertEquals(notification2, result.get(1));
+
+        verify(notificationRepository, times(1))
+            .findAllByReceiverId(memberId);
+    }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- SpringBootApplication 위에 EnableJpaAuditing 어노테이션 존재

**TO-BE**
- 알림 전체 조회 기능 구현
- Jpa 관련 JpaConfig 설정 클래스로 분리해 해당 클래스에 EnableJpaAuditing 어노테이션 존재 
    - controller test:  WebMvcTest할 때는 Service, Repository, Component 등은 빈으로 등록하지 않는데 main에 EnableJpaAuditing이 있으면 JPA 관련 빈을 찾으려 하기 때문에 에러가 남

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
- [X] API 테스트 