### PR TITLE
feat: STD-20 알림 기능: 일정의 출석체크 하기 10분전 스터디 멤버에게 알림 전송

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,8 @@ dependencies {
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
 
+	// Quartz
+	implementation 'org.springframework.boot:spring-boot-starter-quartz'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/tenten/studybadge/common/config/QuartzConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/QuartzConfig.java
@@ -1,0 +1,69 @@
+package com.tenten.studybadge.common.config;
+
+import com.tenten.studybadge.common.quartz.AutowiringSpringBeanJobFactory;
+import com.tenten.studybadge.common.quartz.SchedulerJobListener;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import org.quartz.Scheduler;
+import org.quartz.spi.JobFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.boot.autoconfigure.quartz.QuartzDataSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuartzConfig {
+
+    private final AutowireCapableBeanFactory beanFactory;
+
+    @Value("${spring.quartz.properties.org.quartz.database.quartzDataSource.url}")
+    private String quartzDataSourceUrl;
+
+    @Value("${spring.quartz.properties.org.quartz.database.quartzDataSource.driver-class-name}")
+    private String quartzDataSourceDriverClassName;
+
+    @Value("${spring.quartz.properties.org.quartz.database.quartzDataSource.username}")
+    private String quartzDataSourceUsername;
+
+    @Value("${spring.quartz.properties.org.quartz.database.quartzDataSource.password}")
+    private String quartzDataSourcePassword;
+
+    @Bean
+    public JobFactory jobFactory() {
+      return new AutowiringSpringBeanJobFactory(beanFactory);
+    }
+
+    @Bean
+    public SchedulerFactoryBean schedulerFactoryBean(JobFactory jobFactory, DataSource quartzDataSource, SchedulerJobListener jobListener) {
+        SchedulerFactoryBean factory = new SchedulerFactoryBean();
+        factory.setJobFactory(jobFactory);
+        factory.setDataSource(quartzDataSource);
+        factory.setGlobalJobListeners(jobListener);
+        return factory;
+    }
+
+    @Bean
+    @QuartzDataSource
+    public DataSource quartzDataSource() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName(quartzDataSourceDriverClassName);
+        dataSource.setUrl(quartzDataSourceUrl);
+        dataSource.setUsername(quartzDataSourceUsername);
+        dataSource.setPassword(quartzDataSourcePassword);
+        return dataSource;
+    }
+
+    @Bean
+    public Scheduler scheduler(SchedulerFactoryBean schedulerFactoryBean) throws Exception {
+        return schedulerFactoryBean.getScheduler();
+    }
+
+    @Bean
+    public SchedulerJobListener jobListener() {
+        return new SchedulerJobListener();
+    }
+}

--- a/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
@@ -56,6 +56,7 @@ public class SecurityConfig implements WebMvcConfigurer {
                         .requestMatchers(HttpMethod.GET, "/api/study-channels", "/api/study-channels/{studyChannelId:\\d+}").permitAll()
                         .requestMatchers("/api/members/logout", "api/study-channels/*/places", "/api/study-channels/**", "/api/token/re-issue"
                                 , "/api/members/my-info", "/api/members/my-info/update", "/api/payments/**",
+                            "/api/study-channels/*/single-schedules/**", "/api/study-channels/*/repeat-schedules/**",
                             "/api/study-channels/*/schedules/**", "/api/points/my-point/**", "/api/members/my-apply/**", "/api/notifications/**").hasRole("USER"))
                 .exceptionHandling(exception -> exception.authenticationEntryPoint(authenticationEntryPoint))
 

--- a/src/main/java/com/tenten/studybadge/common/constant/NotificationConstant.java
+++ b/src/main/java/com/tenten/studybadge/common/constant/NotificationConstant.java
@@ -1,18 +1,18 @@
 package com.tenten.studybadge.common.constant;
 
 public class NotificationConstant {
-  public static final String SINGLE_SCHEDULE_CREATE = "스터디 채널 id: %d의  %s 새로운 단일 일정이 생성되었습니다.";
-  public static final String REPEAT_SCHEDULE_CREATE = "스터디 채널 id: %d의  %s 새로운 반복 일정이 생성되었습니다.";
-  public static final String SINGLE_SCHEDULE_URL = "/api/study-channels/%d/single-schedules/%d";
-  public static final String REPEAT_SCHEDULE_URL = "/api/study-channels/%d/repeat-schedules/%d";
+    public static final String SINGLE_SCHEDULE_CREATE = "스터디 채널 id: %d의  %s 새로운 단일 일정이 생성되었습니다.";
+    public static final String REPEAT_SCHEDULE_CREATE = "스터디 채널 id: %d의  %s 새로운 반복 일정이 생성되었습니다.";
+    public static final String SINGLE_SCHEDULE_URL = "/api/study-channels/%d/single-schedules/%d";
+    public static final String REPEAT_SCHEDULE_URL = "/api/study-channels/%d/repeat-schedules/%d";
 
-  public static final String SCHEDULE_UPDATE_FOR_SINGLE_TO_SINGLE = "스터디 채널 id: %d의  %s 단일 일정이 수정되었습니다.";
-  public static final String SCHEDULE_UPDATE_FOR_SINGLE_TO_REPEAT = "스터디 채널 id: %d의  %s 단일 일정이 반복 일정으로 수정되었습니다.";
-  public static final String SCHEDULE_UPDATE_FOR_REPEAT_TO_REPEAT = "스터디 채널 id: %d의  %s 반복 일정이 수정되었습니다.";
-  public static final String SCHEDULE_UPDATE_FOR_REPEAT_TO_SINGLE = "스터디 채널 id: %d의  %s 반복 일정이 단일 일정으로 수정되었습니다.";
+    public static final String SCHEDULE_UPDATE_FOR_SINGLE_TO_SINGLE = "스터디 채널 id: %d의  %s 단일 일정이 수정되었습니다.";
+    public static final String SCHEDULE_UPDATE_FOR_SINGLE_TO_REPEAT = "스터디 채널 id: %d의  %s 단일 일정이 반복 일정으로 수정되었습니다.";
+    public static final String SCHEDULE_UPDATE_FOR_REPEAT_TO_REPEAT = "스터디 채널 id: %d의  %s 반복 일정이 수정되었습니다.";
+    public static final String SCHEDULE_UPDATE_FOR_REPEAT_TO_SINGLE = "스터디 채널 id: %d의  %s 반복 일정이 단일 일정으로 수정되었습니다.";
 
-  public static final String SINGLE_SCHEDULE_DELETE= "스터디 채널 id: %d의  %s 단일 일정이 삭제되었습니다.";
-  public static final String REPEAT_SCHEDULE_DELETE = "스터디 채널 id: %d의  %s 반복 일정이 삭제되었습니다.";
+    public static final String SINGLE_SCHEDULE_DELETE= "스터디 채널 id: %d의  %s 단일 일정이 삭제되었습니다.";
+    public static final String REPEAT_SCHEDULE_DELETE = "스터디 채널 id: %d의  %s 반복 일정이 삭제되었습니다.";
 
-  public static final String TEN_MINUTES_BEFORE_SCHEDULE_START = "%s 일정 시작 10분 전입니다.";
+    public static final String TEN_MINUTES_BEFORE_SCHEDULE_START = "%s 일정 시작 10분 전입니다.";
 }

--- a/src/main/java/com/tenten/studybadge/common/constant/NotificationConstant.java
+++ b/src/main/java/com/tenten/studybadge/common/constant/NotificationConstant.java
@@ -11,7 +11,8 @@ public class NotificationConstant {
   public static final String SCHEDULE_UPDATE_FOR_REPEAT_TO_REPEAT = "스터디 채널 id: %d의  %s 반복 일정이 수정되었습니다.";
   public static final String SCHEDULE_UPDATE_FOR_REPEAT_TO_SINGLE = "스터디 채널 id: %d의  %s 반복 일정이 단일 일정으로 수정되었습니다.";
 
-
   public static final String SINGLE_SCHEDULE_DELETE= "스터디 채널 id: %d의  %s 단일 일정이 삭제되었습니다.";
   public static final String REPEAT_SCHEDULE_DELETE = "스터디 채널 id: %d의  %s 반복 일정이 삭제되었습니다.";
+
+  public static final String TEN_MINUTES_BEFORE_SCHEDULE_START = "%s 일정 시작 10분 전입니다.";
 }

--- a/src/main/java/com/tenten/studybadge/common/quartz/AutowiringSpringBeanJobFactory.java
+++ b/src/main/java/com/tenten/studybadge/common/quartz/AutowiringSpringBeanJobFactory.java
@@ -1,0 +1,19 @@
+package com.tenten.studybadge.common.quartz;
+
+import lombok.AllArgsConstructor;
+import org.quartz.spi.TriggerFiredBundle;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.scheduling.quartz.SpringBeanJobFactory;
+
+@AllArgsConstructor
+public class AutowiringSpringBeanJobFactory extends SpringBeanJobFactory {
+
+    private final AutowireCapableBeanFactory beanFactory;
+
+    @Override
+    protected Object createJobInstance(TriggerFiredBundle bundle) throws Exception {
+        final Object job = super.createJobInstance(bundle);
+        beanFactory.autowireBean(job);
+        return job;
+    }
+}

--- a/src/main/java/com/tenten/studybadge/common/quartz/RepeatScheduleNotificationJob.java
+++ b/src/main/java/com/tenten/studybadge/common/quartz/RepeatScheduleNotificationJob.java
@@ -1,0 +1,41 @@
+package com.tenten.studybadge.common.quartz;
+
+import static com.tenten.studybadge.common.constant.NotificationConstant.REPEAT_SCHEDULE_URL;
+import static com.tenten.studybadge.common.constant.NotificationConstant.TEN_MINUTES_BEFORE_SCHEDULE_START;
+
+import com.tenten.studybadge.notification.service.NotificationService;
+import com.tenten.studybadge.type.notification.NotificationType;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RepeatScheduleNotificationJob implements Job {
+
+    private final NotificationService notificationService;
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        Long scheduleId = context.getMergedJobDataMap().getLong("scheduleId");
+        String scheduleName = context.getMergedJobDataMap().getString("scheduleName");
+        LocalDateTime startTime = (LocalDateTime) context.getMergedJobDataMap().get("startTime");
+        Long studyChannelId = context.getMergedJobDataMap().getLong("studyChannelId");
+
+        String content = String.format(TEN_MINUTES_BEFORE_SCHEDULE_START, scheduleName);
+        String relateUrl = String.format(REPEAT_SCHEDULE_URL, studyChannelId, scheduleId);
+
+        log.info("RepeatScheduleNotificationJob 실행 for scheduleId: {}", scheduleId);
+        log.info("스케줄 이름: {}, 시작 시간: {}, 스터디 채널 id: {}", scheduleName, startTime, studyChannelId);
+
+        notificationService.sendNotificationToStudyChannel(
+            studyChannelId, NotificationType.SCHEDULE_REMINDER, content, relateUrl);
+
+        log.info("scheduleId: {} 일정 Reminder & 출석 체크하기 10분 전 알림 전송 from RepeatScheduleNotificationJob", scheduleId);
+    }
+}

--- a/src/main/java/com/tenten/studybadge/common/quartz/SchedulerJobListener.java
+++ b/src/main/java/com/tenten/studybadge/common/quartz/SchedulerJobListener.java
@@ -1,0 +1,31 @@
+package com.tenten.studybadge.common.quartz;
+
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobListener;
+
+@Slf4j
+public class SchedulerJobListener implements JobListener {
+
+    @Override
+    public String getName() {
+        return "Quartz Job Listener";
+    }
+
+
+    @Override
+    public void jobToBeExecuted(JobExecutionContext jobExecutionContext) {
+        log.info("=============Job이 실행되기전 수행됩니다=============");
+    }
+
+    @Override
+    public void jobExecutionVetoed(JobExecutionContext jobExecutionContext) {
+      log.info("=============Job이 실행 취소된 시점 수행됩니다.=============");
+    }
+
+    @Override
+    public void jobWasExecuted(JobExecutionContext jobExecutionContext, JobExecutionException e) {
+      log.info("=============Job이 실행 완료된 시점 수행됩니다.=============");
+    }
+}

--- a/src/main/java/com/tenten/studybadge/common/quartz/SingleScheduleNotificationJob.java
+++ b/src/main/java/com/tenten/studybadge/common/quartz/SingleScheduleNotificationJob.java
@@ -1,0 +1,41 @@
+package com.tenten.studybadge.common.quartz;
+
+import static com.tenten.studybadge.common.constant.NotificationConstant.SINGLE_SCHEDULE_URL;
+import static com.tenten.studybadge.common.constant.NotificationConstant.TEN_MINUTES_BEFORE_SCHEDULE_START;
+
+import com.tenten.studybadge.notification.service.NotificationService;
+import com.tenten.studybadge.type.notification.NotificationType;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@AllArgsConstructor
+public class SingleScheduleNotificationJob implements Job {
+
+    private final NotificationService notificationService;
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        Long scheduleId = context.getMergedJobDataMap().getLong("scheduleId");
+        String scheduleName = context.getMergedJobDataMap().getString("scheduleName");
+        LocalDateTime startTime = (LocalDateTime) context.getMergedJobDataMap().get("startTime");
+        Long studyChannelId = context.getMergedJobDataMap().getLong("studyChannelId");
+
+        String content = String.format(TEN_MINUTES_BEFORE_SCHEDULE_START, scheduleName);
+        String relateUrl = String.format(SINGLE_SCHEDULE_URL, studyChannelId, scheduleId);
+
+        log.info("SingleScheduleNotificationJob 실행 for scheduleId: {}", scheduleId);
+        log.info("스케줄 이름: {}, 시작 시간: {}, 스터디 채널 id: {}", scheduleName, startTime, studyChannelId);
+
+        notificationService.sendNotificationToStudyChannel(
+            studyChannelId, NotificationType.SCHEDULE_REMINDER, content, relateUrl);
+
+        log.info("scheduleId: {} 일정 Reminder 출석 체크하기 10분 전 알림 전송 from SingleScheduleNotificationJob", scheduleId);
+    }
+}

--- a/src/main/java/com/tenten/studybadge/notification/service/NotificationSchedulerService.java
+++ b/src/main/java/com/tenten/studybadge/notification/service/NotificationSchedulerService.java
@@ -1,0 +1,157 @@
+package com.tenten.studybadge.notification.service;
+
+import com.tenten.studybadge.common.quartz.RepeatScheduleNotificationJob;
+import com.tenten.studybadge.common.quartz.SingleScheduleNotificationJob;
+import com.tenten.studybadge.common.exception.schedule.IllegalArgumentForScheduleRequestException;
+import com.tenten.studybadge.schedule.domain.entity.RepeatSchedule;
+import com.tenten.studybadge.schedule.domain.entity.SingleSchedule;
+import com.tenten.studybadge.type.schedule.RepeatCycle;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.quartz.TriggerKey;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationSchedulerService {
+
+    private final Scheduler scheduler;
+
+    // 알림 스케줄링 (단일 일정)
+    public void schedulingSingleScheduleNotification(SingleSchedule singleSchedule) {
+        LocalDateTime notificationTime = LocalDateTime.of(
+            singleSchedule.getScheduleDate(), singleSchedule.getScheduleStartTime()).minusMinutes(10);
+        Date notificationDate = Date.from(notificationTime.atZone(ZoneId.systemDefault()).toInstant());
+
+        JobDataMap jobDataMap = new JobDataMap();
+        jobDataMap.put("scheduleId", singleSchedule.getId());
+        jobDataMap.put("scheduleName", singleSchedule.getScheduleName());
+        jobDataMap.put("startTime", LocalDateTime.of(
+            singleSchedule.getScheduleDate(), singleSchedule.getScheduleStartTime()));
+        jobDataMap.put("studyChannelId", singleSchedule.getStudyChannel().getId());
+
+        JobDetail jobDetail = JobBuilder.newJob(SingleScheduleNotificationJob.class)
+            .withIdentity("singleScheduleNotificationJob-" + singleSchedule.getId(), "single-schedule-notifications")
+            .usingJobData(jobDataMap)
+            .build();
+
+        TriggerKey triggerKey = new TriggerKey("singleScheduleNotificationTrigger-" + singleSchedule.getId(), "single-schedule-notifications");
+
+        Trigger trigger = TriggerBuilder.newTrigger()
+            .withIdentity(triggerKey)
+            .startAt(notificationDate)
+            .withSchedule(SimpleScheduleBuilder.simpleSchedule().withMisfireHandlingInstructionFireNow())
+            .build();
+
+        try {
+            scheduler.scheduleJob(jobDetail, trigger);
+            log.info("Scheduled single schedule notification: JobKey={}, TriggerKey={}", jobDetail.getKey(), triggerKey);
+        } catch (SchedulerException e) {
+            log.error("Error scheduling single schedule notification", e);
+        }
+    }
+
+    // 알림 스케줄링 (반복 일정)
+    public void schedulingRepeatScheduleNotification(RepeatSchedule repeatSchedule) {
+        LocalDateTime startDateTime = LocalDateTime.of(repeatSchedule.getScheduleDate(), repeatSchedule.getScheduleStartTime()).minusMinutes(10);
+        String cronExpression = getCronExpression(repeatSchedule.getRepeatCycle(), startDateTime);
+
+        JobDataMap jobDataMap = new JobDataMap();
+        jobDataMap.put("scheduleId", repeatSchedule.getId());
+        jobDataMap.put("scheduleName", repeatSchedule.getScheduleName());
+        jobDataMap.put("startTime", LocalDateTime.of(repeatSchedule.getScheduleDate(), repeatSchedule.getScheduleStartTime()));
+        jobDataMap.put("studyChannelId", repeatSchedule.getStudyChannel().getId());
+
+        JobDetail jobDetail = JobBuilder.newJob(RepeatScheduleNotificationJob.class)
+            .withIdentity("repeatScheduleNotificationJob-" + repeatSchedule.getId(), "repeat-schedule-notifications")
+            .usingJobData(jobDataMap)
+            .build();
+
+        TriggerKey triggerKey = new TriggerKey("repeatScheduleNotificationTrigger-" + repeatSchedule.getId(), "repeat-schedule-notifications");
+
+        Trigger trigger = TriggerBuilder.newTrigger()
+            .withIdentity(triggerKey)
+            .withSchedule(CronScheduleBuilder.cronSchedule(cronExpression).withMisfireHandlingInstructionFireAndProceed())
+            .build();
+
+        try {
+            if (scheduler.checkExists(jobDetail.getKey())) {
+                scheduler.addJob(jobDetail, true); // 기존 Job 덮어쓰기
+                scheduler.rescheduleJob(triggerKey, trigger); // 트리거 재스케줄링
+            } else {
+                scheduler.scheduleJob(jobDetail, trigger);
+            }
+            log.info("Scheduled repeat schedule notification: JobKey={}, TriggerKey={}", jobDetail.getKey(), triggerKey);
+        } catch (SchedulerException e) {
+            log.error("Error scheduling repeat schedule notification", e);
+        }
+    }
+
+
+    // 크론 표현식 생성
+    private String getCronExpression(RepeatCycle repeatCycle, LocalDateTime startDateTime) {
+        int minute = startDateTime.getMinute();
+        int hour = startDateTime.getHour();
+        int dayOfMonth = startDateTime.getDayOfMonth();
+        int dayOfWeek = startDateTime.getDayOfWeek().getValue();
+
+        return switch (repeatCycle) {
+            case DAILY -> String.format("0 %d %d * * ?", minute, hour);
+            case WEEKLY -> String.format("0 %d %d ? * %d", minute, hour, dayOfWeek);
+            case MONTHLY -> String.format("0 %d %d %d * ?", minute, hour, dayOfMonth);
+            default -> throw new IllegalArgumentForScheduleRequestException();
+        };
+    }
+
+    public void reschedulingSingleScheduleNotification(
+        SingleSchedule originSingleSchedule, SingleSchedule newSingleSchedule) {
+        unSchedulingSingleScheduleNotification(originSingleSchedule);
+        schedulingSingleScheduleNotification(newSingleSchedule);
+    }
+
+    public void reSchedulingRepeatScheduleNotification(
+        RepeatSchedule originRepeatSchedule, RepeatSchedule newRepeatSchedule) {
+        unSchedulingRepeatScheduleNotification(originRepeatSchedule);
+        schedulingRepeatScheduleNotification(newRepeatSchedule);
+    }
+
+    public void unSchedulingSingleScheduleNotification(SingleSchedule singleSchedule) {
+        try {
+            JobKey jobKey = new JobKey("singleScheduleNotificationJob-" + singleSchedule.getId(), "single-schedule-notifications");
+            TriggerKey triggerKey = new TriggerKey("singleScheduleNotificationTrigger-" + singleSchedule.getId(), "single-schedule-notifications");
+            boolean unscheduled = scheduler.unscheduleJob(triggerKey); // 트리거 삭제
+            boolean deleted = scheduler.deleteJob(jobKey); // Job 삭제
+            log.info("Unscheduled: {}, Deleted: {}", unscheduled, deleted);
+            log.info("Successfully unscheduled and deleted single schedule notification job and trigger: JobKey={}, TriggerKey={}", jobKey, triggerKey);
+        } catch (SchedulerException e) {
+            log.error("Error unscheduling single schedule notification", e);
+        }
+    }
+
+    public void unSchedulingRepeatScheduleNotification(RepeatSchedule repeatSchedule) {
+        try {
+            JobKey jobKey = new JobKey("repeatScheduleNotificationJob-" + repeatSchedule.getId(), "repeat-schedule-notifications");
+            TriggerKey triggerKey = new TriggerKey("repeatScheduleNotificationTrigger-" + repeatSchedule.getId(), "repeat-schedule-notifications");
+            boolean unscheduled = scheduler.unscheduleJob(triggerKey); // 트리거 삭제
+            boolean deleted = scheduler.deleteJob(jobKey); // Job 삭제
+            log.info("Unscheduled: {}, Deleted: {}", unscheduled, deleted);
+            log.info("Successfully unscheduled and deleted repeat schedule notification job and trigger: JobKey={}, TriggerKey={}", jobKey, triggerKey);
+        } catch (SchedulerException e) {
+            log.error("Error unscheduling repeat schedule notification", e);
+        }
+    }
+}

--- a/src/main/java/com/tenten/studybadge/notification/service/NotificationService.java
+++ b/src/main/java/com/tenten/studybadge/notification/service/NotificationService.java
@@ -14,6 +14,7 @@ import com.tenten.studybadge.notification.dto.NotificationResponse;
 import com.tenten.studybadge.study.member.domain.entity.StudyMember;
 import com.tenten.studybadge.study.member.domain.repository.StudyMemberRepository;
 import com.tenten.studybadge.type.notification.NotificationType;
+import com.tenten.studybadge.type.study.member.StudyMemberStatus;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -118,6 +119,7 @@ public class NotificationService {
 
         studyMemberRepository.findAllByStudyChannelIdWithMember(studyChannelId)
             .stream()
+            .filter(studyMember -> studyMember.getStudyMemberStatus() == StudyMemberStatus.PARTICIPATING)
             .map(StudyMember::getMember)
             .forEach((member) -> send(member, notificationType, content, url));
     }

--- a/src/main/java/com/tenten/studybadge/type/notification/NotificationType.java
+++ b/src/main/java/com/tenten/studybadge/type/notification/NotificationType.java
@@ -11,7 +11,7 @@ public enum NotificationType {
   SCHEDULE_CREATE("일정 생성"),
   SCHEDULE_UPDATE("일정 변경"),
   SCHEDULE_DELETE("일정 삭제"),
-  TEN_MINUTES_BEFORE_ATTENDANCE("출석 체크 10분 전");
+  SCHEDULE_REMINDER("출석 체크 10분 전");
 
   private String description;
 }

--- a/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
@@ -15,6 +15,7 @@ import com.tenten.studybadge.common.exception.schedule.OutRangeScheduleException
 import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelException;
 import com.tenten.studybadge.common.exception.studychannel.NotStudyLeaderException;
 import com.tenten.studybadge.member.domain.entity.Member;
+import com.tenten.studybadge.notification.service.NotificationSchedulerService;
 import com.tenten.studybadge.notification.service.NotificationService;
 import com.tenten.studybadge.schedule.domain.entity.RepeatSchedule;
 import com.tenten.studybadge.schedule.domain.entity.SingleSchedule;
@@ -61,7 +62,8 @@ class ScheduleServiceTest {
     private StudyChannelRepository studyChannelRepository;
     @Mock
     private NotificationService notificationService;
-
+    @Mock
+    private NotificationSchedulerService notificationSchedulerService;
 
     @Mock
     private StudyMemberRepository studyMemberRepository;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 알림 타입이 TEN_MINUTES_BEFORE_ATTENDANCE로 길더라도 의미 전달을 최우선으로 했습니다.
- scheduleServcie에서 반복 일정의 시작날짜와 끝나는 날짜를 변경할 때 사용하는 메서드를 void 형으로 두었습니다.
- SecurityConfig에 단일 일정, 반복 일정 생성 및 자세히 조회하는 경로를 명시적으로 적지 않았습니다.

**TO-BE**
- 알림 타입을 SCHEDULE_REMINDER으로 수정하여 CREATE, DELETE 등 일관성을 최우선으로 했습니다.
- scheduleServcie에서 반복 일정의 시작날짜와 끝나는 날짜를 변경할 때 사용하는 메서드를 save한 것을 return하도록 변경하였습니다.
    - reScheduling 시 기존 일정/ 새로 업데이트한 일정을 매개변수로 넣기 위함
- SecurityConfig에 단일 일정, 반복 일정 생성 및 자세히 조회하는 경로를 명시적으로 적었습니다.
- 스케줄링을 위해 Quartz을 사용했습니다. 
    - 매일 특정 시간에(Scheduled 어노테이션) db를 조회하여 오늘 존재하는 일정들을 찾는 것은 서버에 의도치않은 부하나 비효율적이라고 생각됐고,일정이 등록되고 수정되고 삭제될때 스케줄링을 등록하는 Quartz가 적당하다고 생각했습니다.

**- 출석 체크 알림이 스케줄링 되는 과정은 다음과 같습니다.**
- 일정 등록: scheduling 메서드 [trigger, Job detail 등록]
    - 단일 일정> simple trigger로 job detail  등록
    - 반복 일정> cron trigger로 job detail 등록 
- 일정 삭제: unScheduling 메서드 [trigger, Job detail 삭제
- 일정 수정:
    - 단일->단일: reScheduling 메서드 [기존 일정 unScheduling, 새로 업데이트 된 일정 scheduling]
    - 반복->반복: reSchedulinig 메서드 [기존 일정 unScheduling, 새로 업데이트 된 일정 scheduling]
    - 단일->반복: 단일 일정 unScheduling, 반복 일정 scheduling
    - 반복->단일: 생성되고 삭제되고 수정되는 것에 따라 메서드 추가 구현함

***TODO: 기존의 반복 일정 수정시에 잘못된 코드를 넣어 수정이 제대로 진행이 안됐습니다. 주석처리해두었고 바로 고치겠습니다.***

***yml파일 관련은 슬랙으로 알려드리겠습니다***

**quartz 관련 테이블은 다음과 같이 생성됩니다.**
![image](https://github.com/user-attachments/assets/1eec5e98-bb95-470a-b46c-25f4769beae3)



### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 

반복 일정도 이전 날짜로 매일 반복 주기로 두었을 때 오늘 날짜로 출석 체크 알림이 전송 되는 것을 확인했습니다.
![image](https://github.com/user-attachments/assets/5f26d7f2-aebf-419f-b01c-378479533892)
