### PR TITLE
fix: STD-18, STD-19 반복 일정 수정/ 삭제시 날짜 유효성 검증 잘못되었던 것 수정

### DIFF
--- a/src/main/java/com/tenten/studybadge/attendance/service/AttendanceService.java
+++ b/src/main/java/com/tenten/studybadge/attendance/service/AttendanceService.java
@@ -8,7 +8,7 @@ import com.tenten.studybadge.attendance.dto.AttendanceMember;
 import com.tenten.studybadge.common.exception.attendance.InvalidAttendanceCheckDateException;
 import com.tenten.studybadge.common.exception.schedule.NotFoundRepeatScheduleException;
 import com.tenten.studybadge.common.exception.schedule.NotFoundSingleScheduleException;
-import com.tenten.studybadge.common.exception.schedule.OutRangeScheduleException;
+import com.tenten.studybadge.common.exception.schedule.NotIncludedInRepeatScheduleException;
 import com.tenten.studybadge.common.exception.studychannel.NotStudyLeaderException;
 import com.tenten.studybadge.common.exception.studychannel.NotStudyMemberException;
 import com.tenten.studybadge.schedule.domain.entity.RepeatSchedule;
@@ -134,7 +134,7 @@ public class AttendanceService {
         LocalDateTime currentTime = LocalDateTime.now();
 
         if (repeatSchedule.getScheduleDate().isAfter(attendanceCheckDate) || repeatSchedule.getRepeatEndDate().isBefore(attendanceCheckDate)) {
-            throw new OutRangeScheduleException();
+            throw new NotIncludedInRepeatScheduleException();
         }
 
         if (!currentTime.toLocalDate().isEqual(attendanceCheckDate)) {

--- a/src/main/java/com/tenten/studybadge/common/exception/schedule/NotIncludedInRepeatScheduleException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/schedule/NotIncludedInRepeatScheduleException.java
@@ -3,20 +3,22 @@ package com.tenten.studybadge.common.exception.schedule;
 import com.tenten.studybadge.common.exception.basic.AbstractException;
 import org.springframework.http.HttpStatus;
 
-public class OutRangeScheduleException extends AbstractException {
-    private static final String ERROR_CODE = "OUT_RANGE_REPEAT_SCHEDULE_SITUATION";
-    private static final String ERROR_MESSAGE = "해당 반복 일정의 속한 날짜가 아닙니다.";
+public class NotIncludedInRepeatScheduleException extends AbstractException {
+    private static final String ERROR_CODE = "NOT_INCLUDED_IN_REPEAT_SCHEDULE";
+    private static final String ERROR_MESSAGE = "해당 날짜는 반복 일정에 포함되지 않습니다.";
 
     @Override
     public HttpStatus getHttpStatus() {
         return HttpStatus.BAD_REQUEST;
     }
+
     @Override
     public String getErrorCode() {
         return ERROR_CODE;
     }
+
     @Override
     public String getMessage() {
-        return ERROR_MESSAGE ;
+        return ERROR_MESSAGE;
     }
 }

--- a/src/main/java/com/tenten/studybadge/common/jsondeserializer/ScheduleEditRequestDeserializer.java
+++ b/src/main/java/com/tenten/studybadge/common/jsondeserializer/ScheduleEditRequestDeserializer.java
@@ -20,59 +20,61 @@ import java.time.LocalTime;
 
 public class ScheduleEditRequestDeserializer extends JsonDeserializer<ScheduleEditRequest> {
 
-  @Override
-  public ScheduleEditRequest deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-    ObjectMapper mapper = (ObjectMapper) p.getCodec();
-    JsonNode node = mapper.readTree(p);
-    ScheduleType editType = ScheduleType.valueOf(node.get("editType").asText().toUpperCase());
+    @Override
+    public ScheduleEditRequest deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        ObjectMapper mapper = (ObjectMapper) p.getCodec();
+        JsonNode node = mapper.readTree(p);
+        ScheduleType editType = ScheduleType.valueOf(node.get("editType").asText().toUpperCase());
 
-    if (ScheduleType.SINGLE == editType) {
-      return createSingleScheduleEditRequest(node);
-    } else if (ScheduleType.REPEAT == editType) {
-      return createRepeatScheduleEditRequest(node);
+        if (ScheduleType.SINGLE == editType) {
+            return createSingleScheduleEditRequest(node);
+        } else if (ScheduleType.REPEAT == editType) {
+            return createRepeatScheduleEditRequest(node);
+        }
+
+        throw new IllegalArgumentForScheduleEditRequestException();
     }
 
-    throw new IllegalArgumentForScheduleEditRequestException();
-  }
-
-  private SingleScheduleEditRequest createSingleScheduleEditRequest(JsonNode node) {
-    return SingleScheduleEditRequest.builder()
-        .scheduleId(node.get("scheduleId").asLong())
-        .originType(ScheduleType.valueOf(node.get("originType").asText().toUpperCase()))
-        .editType(ScheduleType.valueOf(node.get("editType").asText().toUpperCase()))
-        .scheduleName(node.get("scheduleName").asText())
-        .scheduleContent(node.get("scheduleContent").asText())
-        .selectedDate(LocalDate.parse(node.get("selectedDate").asText()))
-        .scheduleStartTime(LocalTime.parse(node.get("scheduleStartTime").asText()))
-        .scheduleEndTime(LocalTime.parse(node.get("scheduleEndTime").asText()))
-        .placeId(node.has("placeId") ? node.get("placeId").asLong() : null)
-        .build();
-  }
-
-  private RepeatScheduleEditRequest createRepeatScheduleEditRequest(JsonNode node) {
-    return RepeatScheduleEditRequest.builder()
-        .scheduleId(node.get("scheduleId").asLong())
-        .originType(ScheduleType.valueOf(node.get("originType").asText().toUpperCase()))
-        .editType(ScheduleType.valueOf(node.get("editType").asText().toUpperCase()))
-        .scheduleName(node.get("scheduleName").asText())
-        .scheduleContent(node.get("scheduleContent").asText())
-        .selectedDate(LocalDate.parse(node.get("selectedDate").asText()))
-        .scheduleStartTime(LocalTime.parse(node.get("scheduleStartTime").asText()))
-        .scheduleEndTime(LocalTime.parse(node.get("scheduleEndTime").asText()))
-        .placeId(node.has("placeId") ? node.get("placeId").asLong() : null)
-        .repeatCycle(RepeatCycle.valueOf(node.get("repeatCycle").asText().toUpperCase()))
-        .repeatSituation(deserializeRepeatSituation(node.get("repeatSituation")))
-        .repeatEndDate(LocalDate.parse(node.get("repeatEndDate").asText()))
-        .build();
-  }
-
-  private RepeatSituation deserializeRepeatSituation(JsonNode node) {
-    if (node.isInt()) {
-      return RepeatSituation.fromInt(node.asInt());
-    } else if (node.isTextual()) {
-      return RepeatSituation.fromString(node.asText());
+    private SingleScheduleEditRequest createSingleScheduleEditRequest(JsonNode node) {
+        return SingleScheduleEditRequest.builder()
+            .memberId(node.get("memberId").asLong())
+            .scheduleId(node.get("scheduleId").asLong())
+            .originType(ScheduleType.valueOf(node.get("originType").asText().toUpperCase()))
+            .editType(ScheduleType.valueOf(node.get("editType").asText().toUpperCase()))
+            .scheduleName(node.get("scheduleName").asText())
+            .scheduleContent(node.get("scheduleContent").asText())
+            .selectedDate(LocalDate.parse(node.get("selectedDate").asText()))
+            .scheduleStartTime(LocalTime.parse(node.get("scheduleStartTime").asText()))
+            .scheduleEndTime(LocalTime.parse(node.get("scheduleEndTime").asText()))
+            .placeId(node.has("placeId") ? node.get("placeId").asLong() : null)
+            .build();
     }
-    throw new IllegalArgumentException("Invalid RepeatSituation value");
-  }
+
+    private RepeatScheduleEditRequest createRepeatScheduleEditRequest(JsonNode node) {
+        return RepeatScheduleEditRequest.builder()
+            .memberId(node.get("memberId").asLong())
+            .scheduleId(node.get("scheduleId").asLong())
+            .originType(ScheduleType.valueOf(node.get("originType").asText().toUpperCase()))
+            .editType(ScheduleType.valueOf(node.get("editType").asText().toUpperCase()))
+            .scheduleName(node.get("scheduleName").asText())
+            .scheduleContent(node.get("scheduleContent").asText())
+            .selectedDate(LocalDate.parse(node.get("selectedDate").asText()))
+            .scheduleStartTime(LocalTime.parse(node.get("scheduleStartTime").asText()))
+            .scheduleEndTime(LocalTime.parse(node.get("scheduleEndTime").asText()))
+            .placeId(node.has("placeId") ? node.get("placeId").asLong() : null)
+            .repeatCycle(RepeatCycle.valueOf(node.get("repeatCycle").asText().toUpperCase()))
+            .repeatSituation(deserializeRepeatSituation(node.get("repeatSituation")))
+            .repeatEndDate(LocalDate.parse(node.get("repeatEndDate").asText()))
+            .build();
+    }
+
+    private RepeatSituation deserializeRepeatSituation(JsonNode node) {
+        if (node.isInt()) {
+            return RepeatSituation.fromInt(node.asInt());
+        } else if (node.isTextual()) {
+            return RepeatSituation.fromString(node.asText());
+        }
+        throw new IllegalArgumentException("Invalid RepeatSituation value");
+    }
 }
 

--- a/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/schedule/service/ScheduleServiceTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.verify;
 
 import com.tenten.studybadge.common.exception.schedule.IllegalArgumentForRepeatSituationException;
 import com.tenten.studybadge.common.exception.schedule.NotEqualSingleScheduleDate;
-import com.tenten.studybadge.common.exception.schedule.OutRangeScheduleException;
+import com.tenten.studybadge.common.exception.schedule.NotIncludedInRepeatScheduleException;
 import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelException;
 import com.tenten.studybadge.common.exception.studychannel.NotStudyLeaderException;
 import com.tenten.studybadge.member.domain.entity.Member;
@@ -1073,7 +1073,7 @@ class ScheduleServiceTest {
                 .thenReturn(Optional.of(studyLeader));
 
             // when & then
-            assertThrows(OutRangeScheduleException.class, () -> {
+            assertThrows(NotIncludedInRepeatScheduleException.class, () -> {
               scheduleService.putScheduleRepeatToSingle(1L, true, singleScheduleEditRequest);
             });
         }
@@ -1329,7 +1329,7 @@ class ScheduleServiceTest {
             given(repeatScheduleRepository.findById(2L)).willReturn(
                 Optional.of(repeatScheduleWithoutPlace));
             // when & then
-            assertThrows(OutRangeScheduleException.class, () -> {
+            assertThrows(NotIncludedInRepeatScheduleException.class, () -> {
                 scheduleService.deleteRepeatSchedule(1L, true, deleteRequest);
             });
         }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 반복 일정에 속하지 않은 날짜일 경우 보내는 exception 명: OutRangeScheduleException으로 두었었음
- 반복 일정을 수정/삭제할 때 repeatSchedule에 속한 일정이 아닌 것을 단순히 Daily 반복 일정으로만 생각해 첫날/ 마지막날만 체크했음
-  현재 날짜보다 지난 날짜를 선택했을 경우 exception을 주어야하는 것에 기존 반복 일정의 첫날로 확인해 삭제할 수 있음에도 삭제가 불가했음
- 이전에 memberId 필드를 추가했을 때 json 역직렬화에도 추가를 하지 않아 memberId를 읽지 못하는 에러가 존재했음

**TO-BE**
- 반복 일정에 속하지 않은 날짜일 경우 보내는 exception 명: NotIncludedInRepeatScheduleException으로 수정함
- 반복 일정을 수정/삭제할 때 주간/월간에도 맞게 확인함
- 현재 날짜보다 지난 날짜를 선택했을 경우 exception을 제대로 주고 삭제할 수 있는 날짜를 선택했을 경우 삭제가 가능함
- json 역직렬화에 memberId를 추가해 제대로 역직렬화를 하여 에러가 없음.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 