### PR TITLE
feat: STD-43 비밀번호 재설정 기능 추가

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig implements WebMvcConfigurer {
         return http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests( requests -> requests
                         .requestMatchers("/api/members/sign-up", "/api/members/auth/**", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/api/members/login/**", "/error", "/health-check").permitAll()
-                        .requestMatchers("/api/token/oauth2/**", "/favicon.ico", "/oauth2/**", "/api/payments/success/**", "/api/payments/cancel/**").permitAll()
+                        .requestMatchers("/api/token/oauth2/**", "/favicon.ico", "/oauth2/**", "/api/payments/success/**", "/api/payments/cancel/**", "/api/members/password/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/study-channels", "/api/study-channels/{studyChannelId:\\d+}").permitAll()
                         .requestMatchers("/api/members/logout", "api/study-channels/*/places", "/api/study-channels/**", "/api/token/re-issue"
                                 , "/api/members/my-info", "/api/members/my-info/update", "/api/payments/**",

--- a/src/main/java/com/tenten/studybadge/common/constant/MailConstant.java
+++ b/src/main/java/com/tenten/studybadge/common/constant/MailConstant.java
@@ -4,6 +4,8 @@ public class MailConstant {
 
     public static final String SIGNUP_SUBJECT = "Study Badge 가입 인증 메일입니다.";
 
+    public static final String RESET_PASSWORD_SUBJECT = "Study Badge 비밀번호 변경 인증 메일입니다.";
+
     public static final String UNICODE = "UTF-8";
 
     public static final String BASE_URL = "http://localhost:8080";
@@ -12,5 +14,12 @@ public class MailConstant {
                                                 아래 링크를 클릭해, 인증을 완료해주세요.</h3>
                                                 <div><a href="%s/api/members/auth?email=%s&code=%s">
                                                 인증하기 </a></div>
+                                              """;
+
+    public static final String RESET_PASSWORD_BODY =  """
+                                                <h3> 안녕하세요, Study Badge 비밀번호 변경 메일입니다..
+                                                아래 링크를 클릭해, 인증코드를 입력하여 인증을 완료해주시고, 비밀번호를 변경해주세요..</h3>
+                                                <div><a href="http://localhost:5173/resetPassword?email=%s">
+                                                변경 링크 </a></div> 
                                               """;
 }

--- a/src/main/java/com/tenten/studybadge/common/constant/Oauth2Contant.java
+++ b/src/main/java/com/tenten/studybadge/common/constant/Oauth2Contant.java
@@ -24,9 +24,9 @@ public class Oauth2Contant {
 
     public static final String OAUTH2_PASSWORD = "SNS";
 
-    public static final String LOGIN_REDIRECT_URI = "http://localhost:5173/oauth2/callback";
+    public static final String LOGIN_REDIRECT_URI = "http://localhost:5173/socialCallback";
 
-    public static final String SIGN_UP_REDIRECT_URI = "/oauth2/sign-up";
+    public static final String SIGN_UP_REDIRECT_URI = "http://localhost:5173/oauth2/callback";
 
     public static final String OAUTH2_ERROR_MESSAGE = "OAuth2 인증에 실패하였습니다: ";
 

--- a/src/main/java/com/tenten/studybadge/common/email/MailService.java
+++ b/src/main/java/com/tenten/studybadge/common/email/MailService.java
@@ -40,6 +40,26 @@ public class MailService {
 
     }
 
+    @Async
+    public void sendResetMail(String email, String authCode) {
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+
+        try {
+
+            String body = String.format(RESET_PASSWORD_BODY, email);
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, true, UNICODE);
+            mimeMessageHelper.setTo(email);
+            mimeMessageHelper.setSubject(RESET_PASSWORD_SUBJECT);
+            mimeMessageHelper.setText(body + authCode, true);
+
+        } catch (MessagingException e) {
+            throw new SendMailException();
+        }
+
+        javaMailSender.send(mimeMessage);
+
+    }
+
     public boolean isValidEmail(String email) {
         return EmailValidator.getInstance().isValid(email);
     }

--- a/src/main/java/com/tenten/studybadge/common/exception/member/NotAuthorizedPasswordAuth.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/member/NotAuthorizedPasswordAuth.java
@@ -1,0 +1,20 @@
+package com.tenten.studybadge.common.exception.member;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class NotAuthorizedPasswordAuth extends AbstractException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+    @Override
+    public String getErrorCode() {
+        return "NOT_AUTHORIZED_PASSWORD_AUTH";
+    }
+    @Override
+    public String getMessage() {
+        return "비밀번호 재설정 인증이 완료되지 않았습니다.";
+    }
+}

--- a/src/main/java/com/tenten/studybadge/common/jwt/JwtTokenCreator.java
+++ b/src/main/java/com/tenten/studybadge/common/jwt/JwtTokenCreator.java
@@ -1,6 +1,6 @@
 package com.tenten.studybadge.common.jwt;
 
-import com.tenten.studybadge.member.domain.type.MemberRole;
+import com.tenten.studybadge.type.member.MemberRole;
 import com.tenten.studybadge.common.token.dto.TokenDto;
 import com.tenten.studybadge.type.member.Platform;
 import io.jsonwebtoken.Claims;

--- a/src/main/java/com/tenten/studybadge/common/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/tenten/studybadge/common/oauth2/OAuth2SuccessHandler.java
@@ -45,7 +45,10 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
             TokenDto tokenDto = jwtTokenCreator.createToken(authentication.getName(), role, platform);
             String authorizationHeader = BEARER + tokenDto.getAccessToken();
-            response.sendRedirect(SIGN_UP_REDIRECT_URI);
+            String redirectUrl = UriComponentsBuilder.fromUriString(SIGN_UP_REDIRECT_URI)
+                    .queryParam(ACCESS_TOKEN, tokenDto.getAccessToken())
+                    .build().toUriString();
+            response.sendRedirect(redirectUrl);
             response.addHeader(HttpHeaders.AUTHORIZATION, authorizationHeader);
 
         } else {

--- a/src/main/java/com/tenten/studybadge/common/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/tenten/studybadge/common/oauth2/OAuth2SuccessHandler.java
@@ -5,7 +5,7 @@ import com.tenten.studybadge.common.security.CustomUserDetails;
 import com.tenten.studybadge.common.token.dto.TokenDto;
 import com.tenten.studybadge.common.token.service.TokenService;
 import com.tenten.studybadge.common.utils.CookieUtils;
-import com.tenten.studybadge.member.domain.type.MemberRole;
+import com.tenten.studybadge.type.member.MemberRole;
 import com.tenten.studybadge.type.member.MemberStatus;
 import com.tenten.studybadge.type.member.Platform;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/tenten/studybadge/common/oauth2/OAuth2UserInfo.java
+++ b/src/main/java/com/tenten/studybadge/common/oauth2/OAuth2UserInfo.java
@@ -1,9 +1,8 @@
 package com.tenten.studybadge.common.oauth2;
 
-import com.tenten.studybadge.common.exception.InvalidTokenException;
 import com.tenten.studybadge.common.exception.oauth2.UnsupportedProviderException;
 import com.tenten.studybadge.member.domain.entity.Member;
-import com.tenten.studybadge.member.domain.type.MemberRole;
+import com.tenten.studybadge.type.member.MemberRole;
 import com.tenten.studybadge.type.member.BadgeLevel;
 import com.tenten.studybadge.type.member.MemberStatus;
 import com.tenten.studybadge.type.member.Platform;

--- a/src/main/java/com/tenten/studybadge/common/security/CustomUserDetails.java
+++ b/src/main/java/com/tenten/studybadge/common/security/CustomUserDetails.java
@@ -1,7 +1,7 @@
 package com.tenten.studybadge.common.security;
 
 import com.tenten.studybadge.member.domain.entity.Member;
-import com.tenten.studybadge.member.domain.type.MemberRole;
+import com.tenten.studybadge.type.member.MemberRole;
 import com.tenten.studybadge.type.member.MemberStatus;
 import com.tenten.studybadge.type.member.Platform;
 import lombok.Getter;

--- a/src/main/java/com/tenten/studybadge/common/token/dto/TokenCreateDto.java
+++ b/src/main/java/com/tenten/studybadge/common/token/dto/TokenCreateDto.java
@@ -1,6 +1,6 @@
 package com.tenten.studybadge.common.token.dto;
 
-import com.tenten.studybadge.member.domain.type.MemberRole;
+import com.tenten.studybadge.type.member.MemberRole;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/tenten/studybadge/common/token/service/TokenService.java
+++ b/src/main/java/com/tenten/studybadge/common/token/service/TokenService.java
@@ -6,7 +6,7 @@ import com.tenten.studybadge.common.jwt.JwtTokenCreator;
 import com.tenten.studybadge.common.jwt.JwtTokenProvider;
 import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.member.domain.repository.MemberRepository;
-import com.tenten.studybadge.member.domain.type.MemberRole;
+import com.tenten.studybadge.type.member.MemberRole;
 import com.tenten.studybadge.common.token.dto.TokenDto;
 import com.tenten.studybadge.type.member.Platform;
 import io.jsonwebtoken.Claims;

--- a/src/main/java/com/tenten/studybadge/member/controller/MemberController.java
+++ b/src/main/java/com/tenten/studybadge/member/controller/MemberController.java
@@ -119,4 +119,31 @@ public class MemberController {
 
         return ResponseEntity.status(HttpStatus.OK).build();
     }
+    @Operation(summary = "비밀번호 재설정 요청", description = "비밀번호 재설정 요청")
+    @Parameter(name = "email" , description = "비밀번호 재설정을 요청할 회원의 이메일")
+    @PostMapping("/password")
+    public ResponseEntity<Void> requestReset(@RequestParam(name = "email") String email) {
+
+        memberService.requestReset(email, LOCAL);
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+    @Operation(summary = "비밀번호 재설정 인증", description = "비밀번호 재설정을 위한 인증코드 비교 인증")
+    @GetMapping("/auth/password")
+    public ResponseEntity<Void> passwordAuth(@RequestParam(name = "email") String email, @RequestParam(name = "code") String code) {
+
+        memberService.authPassword(email, code, LOCAL);
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+    @Operation(summary = "비밀번호 재설정", description = "인증을 마친 회원의 비밀번호 재설정")
+    @Parameter(name = "email",  description = "비밀번호 재설정 할 회원의 이메일")
+    @Parameter(name = "newPassword", description = "새로운 비밀번호")
+    @PatchMapping("/password/reset")
+    public ResponseEntity<Void> resetPassword(@RequestParam(name = "email") String email, @RequestParam(name = "newPassword") String newPassword) {
+
+        memberService.resetPassword(email, newPassword, LOCAL);
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
 }

--- a/src/main/java/com/tenten/studybadge/member/domain/entity/Member.java
+++ b/src/main/java/com/tenten/studybadge/member/domain/entity/Member.java
@@ -1,7 +1,7 @@
 package com.tenten.studybadge.member.domain.entity;
 
 import com.tenten.studybadge.common.BaseEntity;
-import com.tenten.studybadge.member.domain.type.MemberRole;
+import com.tenten.studybadge.type.member.MemberRole;
 import com.tenten.studybadge.type.member.BadgeLevel;
 import com.tenten.studybadge.type.member.MemberStatus;
 import com.tenten.studybadge.type.member.Platform;

--- a/src/main/java/com/tenten/studybadge/member/domain/entity/Member.java
+++ b/src/main/java/com/tenten/studybadge/member/domain/entity/Member.java
@@ -38,6 +38,8 @@ public class Member extends BaseEntity {
 
     private Boolean isAuth;
 
+    private Boolean isPasswordAuth;
+
     @Enumerated(EnumType.STRING)
     private MemberRole role;
 

--- a/src/main/java/com/tenten/studybadge/member/domain/type/MemberRole.java
+++ b/src/main/java/com/tenten/studybadge/member/domain/type/MemberRole.java
@@ -1,7 +1,0 @@
-package com.tenten.studybadge.member.domain.type;
-
-public enum MemberRole {
-
-    USER,
-    ADMIN
-}

--- a/src/main/java/com/tenten/studybadge/member/dto/MemberSignUpRequest.java
+++ b/src/main/java/com/tenten/studybadge/member/dto/MemberSignUpRequest.java
@@ -10,7 +10,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 
-import static com.tenten.studybadge.member.domain.type.MemberRole.USER;
+import static com.tenten.studybadge.type.member.MemberRole.USER;
 
 
 @Getter

--- a/src/main/java/com/tenten/studybadge/member/dto/MemberSignUpRequest.java
+++ b/src/main/java/com/tenten/studybadge/member/dto/MemberSignUpRequest.java
@@ -57,6 +57,7 @@ public class MemberSignUpRequest {
                 .nickname(signUpRequest.getNickname())
                 .introduction(signUpRequest.getIntroduction())
                 .isAuth(false)
+                .isPasswordAuth(false)
                 .role(USER)
                 .point(0)
                 .banCnt(0)

--- a/src/main/java/com/tenten/studybadge/member/dto/MemberUpdateRequest.java
+++ b/src/main/java/com/tenten/studybadge/member/dto/MemberUpdateRequest.java
@@ -13,6 +13,8 @@ public class MemberUpdateRequest {
 
     private String account;
 
+    private String accountBank;
+
     private String introduction;
 
     private String imgUrl;

--- a/src/main/java/com/tenten/studybadge/payment/service/PaymentService.java
+++ b/src/main/java/com/tenten/studybadge/payment/service/PaymentService.java
@@ -152,7 +152,7 @@ public class PaymentService {
 
     public List<PaymentHistory> paymentHistory(Long memberId, int page, int size) {
 
-        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, CREATED_AT));
+        PageRequest pageRequest = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, CREATED_AT));
 
         List<Payment> payment = paymentRepository.findByCustomerId(memberId, pageRequest);
 

--- a/src/main/java/com/tenten/studybadge/type/member/MemberRole.java
+++ b/src/main/java/com/tenten/studybadge/type/member/MemberRole.java
@@ -1,0 +1,7 @@
+package com.tenten.studybadge.type.member;
+
+public enum MemberRole {
+
+    USER,
+    ADMIN
+}

--- a/src/test/java/com/tenten/studybadge/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/tenten/studybadge/notification/controller/NotificationControllerTest.java
@@ -2,7 +2,6 @@ package com.tenten.studybadge.notification.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -19,7 +18,7 @@ import com.tenten.studybadge.common.security.CustomAuthenticationEntryPoint;
 import com.tenten.studybadge.common.security.CustomUserDetails;
 import com.tenten.studybadge.common.security.LoginUserArgumentResolver;
 import com.tenten.studybadge.member.domain.entity.Member;
-import com.tenten.studybadge.member.domain.type.MemberRole;
+import com.tenten.studybadge.type.member.MemberRole;
 import com.tenten.studybadge.notification.domain.entitiy.Notification;
 import com.tenten.studybadge.notification.dto.NotificationReadRequest;
 import com.tenten.studybadge.notification.dto.NotificationResponse;

--- a/src/test/java/com/tenten/studybadge/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/notification/service/NotificationServiceTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.tenten.studybadge.member.domain.entity.Member;
-import com.tenten.studybadge.member.domain.type.MemberRole;
+import com.tenten.studybadge.type.member.MemberRole;
 import com.tenten.studybadge.notification.domain.entitiy.Notification;
 import com.tenten.studybadge.notification.domain.repository.NotificationRepository;
 import com.tenten.studybadge.notification.dto.NotificationReadRequest;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- Oauth2 인증 완료 후 RedirectUrl이 프론트 측과 맞지 않게 설정되어 있었습니다.
- MemberUpdateRequest 에 은행명이 없었습니다.
- 결제내역 조회 서비스 코드 중 page -1을 추가하지 않았었습니다.
- member/type 에 MemberRole이 위치해있었습니다.

**TO-BE**

- 비밀번호 재설정 기능을 추가하였습니다.
  - 로컬 회원이 비밀번호를 잊은 경우 비밀번호 재설정을 통해 해결할 수 있습니다.
  - `비밀번호 재설정 흐름 : 재설정 요청 -> 이메일 전송 -> 링크 접속 -> 코드 인증 -> 비밀번호 재설정`
-  Oauth2 인증 완료 후 RedirectUrl이 프론트 측과 상의하여 수정하였습니다.
- MemberUpdateRequest 에 은행명 필드를 추가하였습니다.
- 1페이지부터 조회가능 하도록 결제내역 조회 서비스 코드 중 page -1을 추가였습니다.
- MemberRole을 type/member로 위치하게하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 