### PR TITLE
fix: STD-20 출석 체크 알림 스케줄링 시 trigger 문제 수정

### DIFF
--- a/src/main/java/com/tenten/studybadge/notification/service/NotificationSchedulerService.java
+++ b/src/main/java/com/tenten/studybadge/notification/service/NotificationSchedulerService.java
@@ -34,13 +34,13 @@ public class NotificationSchedulerService {
 
     // 알림 스케줄링 (단일 일정)
     public void schedulingSingleScheduleNotification(SingleSchedule singleSchedule) {
-        LocalDateTime AttendanceStartDateTime = LocalDateTime.of(
+        LocalDateTime attendanceStartDateTime = LocalDateTime.of(
             singleSchedule.getScheduleDate(), singleSchedule.getScheduleStartTime()).minusMinutes(10);
-        Date notificationDate = Date.from(AttendanceStartDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        Date notificationDate = Date.from(attendanceStartDateTime.atZone(ZoneId.systemDefault()).toInstant());
 
         // 현재 날짜와 시간과 비교하여 과거 날짜인지 확인
-        if (AttendanceStartDateTime.isBefore(LocalDateTime.now())) {
-            log.info("출석 체크 시작 시간이 과거 날짜이므로 단일 일정 출석 체크 알림 스케줄링을 생략합니다.: " + AttendanceStartDateTime);
+        if (attendanceStartDateTime.isBefore(LocalDateTime.now())) {
+            log.info("출석 체크 시작 시간이 과거 날짜이므로 단일 일정 출석 체크 알림 스케줄링을 생략합니다.: " + attendanceStartDateTime);
             return; // 과거 날짜일 경우 스케줄링을 건너뜁니다.
         }
 
@@ -62,7 +62,8 @@ public class NotificationSchedulerService {
             .withIdentity(triggerKey)
             .startAt(notificationDate)
             .endAt(notificationDate)
-            .withSchedule(SimpleScheduleBuilder.simpleSchedule().withMisfireHandlingInstructionNextWithExistingCount())
+            .withSchedule(SimpleScheduleBuilder.simpleSchedule()
+                .withMisfireHandlingInstructionNextWithExistingCount())
             .build();
 
         try {

--- a/src/test/java/com/tenten/studybadge/notification/service/NotificationSchedulerServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/notification/service/NotificationSchedulerServiceTest.java
@@ -70,40 +70,40 @@ public class NotificationSchedulerServiceTest {
         assertNull(nextFireTime, "Trigger는 종료 날짜 이후에 실행되지 않아야 합니다");
     }
 
-    @Test
-    @DisplayName("그제 - 어제 일간 반복하는 일정이 오늘에 일정이 안울리는지 테스트 : if문 생략했을때")
-    public void testSchedulingRepeatScheduleNotification_deleteIf() throws SchedulerException {
-        // 본 테스트는 NotificaitionSchedulerService.java
-        // schedulingRepeatScheduleNotification메서드에 있는 if문을 생략해야 통과됩니다. > 현재 Line 81: 줄은 바뀔 수도 있음
-        // given
-        RepeatSchedule repeatSchedule = mock(RepeatSchedule.class);
-        StudyChannel studyChannel = mock(StudyChannel.class);
-
-        when(studyChannel.getId()).thenReturn(1L);
-        when(repeatSchedule.getStudyChannel()).thenReturn(studyChannel);
-        when(repeatSchedule.getScheduleDate()).thenReturn(LocalDate.now().minusDays(2));
-        when(repeatSchedule.getScheduleStartTime()).thenReturn(LocalTime.of(12, 0));
-        when(repeatSchedule.getRepeatEndDate()).thenReturn(LocalDate.now().minusDays(1)); // 어제
-        when(repeatSchedule.getRepeatCycle()).thenReturn(RepeatCycle.DAILY);
-
-        // Trigger 캡처
-        ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass(Trigger.class);
-
-        // when
-        notificationSchedulerService.schedulingRepeatScheduleNotification(repeatSchedule);
-
-        // then
-        // 스케줄러가 올바른 트리거로 호출되었는지 검증
-        verify(scheduler).scheduleJob(any(JobDetail.class), triggerCaptor.capture());
-        Trigger trigger = triggerCaptor.getValue();
-
-        // 종료 날짜가 올바른지 검증
-        Date expectedEndDate = Date.from(LocalDate.now().minusDays(1).atTime(23, 59, 59).atZone(ZoneId.systemDefault()).toInstant());
-        assertEquals(expectedEndDate, trigger.getEndTime());
-
-        // 종료 날짜 이후 트리거가 실행되지 않는지 검증
-        Date afterEndDate = Date.from(LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant());
-        Date nextFireTime = trigger.getFireTimeAfter(afterEndDate);
-        assertNull(nextFireTime, "Trigger는 종료 날짜 이후에 실행되지 않아야 합니다");
-    }
+//    @Test
+//    @DisplayName("그제 - 어제 일간 반복하는 일정이 오늘에 일정이 안울리는지 테스트 : if문 생략했을때")
+//    public void testSchedulingRepeatScheduleNotification_deleteIf() throws SchedulerException {
+//        // 본 테스트는 NotificaitionSchedulerService.java
+//        // schedulingRepeatScheduleNotification메서드에 있는 if문을 생략해야 통과됩니다. > 현재 Line 81: 줄은 바뀔 수도 있음
+//        // given
+//        RepeatSchedule repeatSchedule = mock(RepeatSchedule.class);
+//        StudyChannel studyChannel = mock(StudyChannel.class);
+//
+//        when(studyChannel.getId()).thenReturn(1L);
+//        when(repeatSchedule.getStudyChannel()).thenReturn(studyChannel);
+//        when(repeatSchedule.getScheduleDate()).thenReturn(LocalDate.now().minusDays(2));
+//        when(repeatSchedule.getScheduleStartTime()).thenReturn(LocalTime.of(12, 0));
+//        when(repeatSchedule.getRepeatEndDate()).thenReturn(LocalDate.now().minusDays(1)); // 어제
+//        when(repeatSchedule.getRepeatCycle()).thenReturn(RepeatCycle.DAILY);
+//
+//        // Trigger 캡처
+//        ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass(Trigger.class);
+//
+//        // when
+//        notificationSchedulerService.schedulingRepeatScheduleNotification(repeatSchedule);
+//
+//        // then
+//        // 스케줄러가 올바른 트리거로 호출되었는지 검증
+//        verify(scheduler).scheduleJob(any(JobDetail.class), triggerCaptor.capture());
+//        Trigger trigger = triggerCaptor.getValue();
+//
+//        // 종료 날짜가 올바른지 검증
+//        Date expectedEndDate = Date.from(LocalDate.now().minusDays(1).atTime(23, 59, 59).atZone(ZoneId.systemDefault()).toInstant());
+//        assertEquals(expectedEndDate, trigger.getEndTime());
+//
+//        // 종료 날짜 이후 트리거가 실행되지 않는지 검증
+//        Date afterEndDate = Date.from(LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant());
+//        Date nextFireTime = trigger.getFireTimeAfter(afterEndDate);
+//        assertNull(nextFireTime, "Trigger는 종료 날짜 이후에 실행되지 않아야 합니다");
+//    }
 }

--- a/src/test/java/com/tenten/studybadge/notification/service/NotificationSchedulerServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/notification/service/NotificationSchedulerServiceTest.java
@@ -1,0 +1,109 @@
+package com.tenten.studybadge.notification.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tenten.studybadge.schedule.domain.entity.RepeatSchedule;
+import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
+import com.tenten.studybadge.type.schedule.RepeatCycle;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Date;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobDetail;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationSchedulerServiceTest {
+
+    @InjectMocks
+    private NotificationSchedulerService notificationSchedulerService;
+
+    @Mock
+    private Scheduler scheduler;
+
+    @Test
+    @DisplayName("오늘 - 내일 일간 반복하는 일정이 모레에는 일정이 안울리는지 테스트")
+    public void testSchedulingRepeatScheduleNotification() throws SchedulerException {
+        // given
+        RepeatSchedule repeatSchedule = mock(RepeatSchedule.class);
+        StudyChannel studyChannel = mock(StudyChannel.class);
+
+        when(studyChannel.getId()).thenReturn(1L);
+        when(repeatSchedule.getStudyChannel()).thenReturn(studyChannel);
+        when(repeatSchedule.getScheduleDate()).thenReturn(LocalDate.now());
+        when(repeatSchedule.getScheduleStartTime()).thenReturn(LocalTime.of(12, 0));
+        when(repeatSchedule.getRepeatEndDate()).thenReturn(LocalDate.now().plusDays(1)); // 내일
+        when(repeatSchedule.getRepeatCycle()).thenReturn(RepeatCycle.DAILY);
+
+        // Trigger 캡처
+        ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass(Trigger.class);
+
+        // when
+        notificationSchedulerService.schedulingRepeatScheduleNotification(repeatSchedule);
+
+        // then
+        // 스케줄러가 올바른 트리거로 호출되었는지 검증
+        verify(scheduler).scheduleJob(any(JobDetail.class), triggerCaptor.capture());
+        Trigger trigger = triggerCaptor.getValue();
+
+        // 종료 날짜가 올바른지 검증
+        Date expectedEndDate = Date.from(LocalDate.now().plusDays(1).atTime(23, 59, 59).atZone(ZoneId.systemDefault()).toInstant());
+        assertEquals(expectedEndDate, trigger.getEndTime());
+
+        // 종료 날짜 이후 트리거가 실행되지 않는지 검증
+        Date afterEndDate = Date.from(LocalDate.now().plusDays(2).atStartOfDay(ZoneId.systemDefault()).toInstant());
+        Date nextFireTime = trigger.getFireTimeAfter(afterEndDate);
+        assertNull(nextFireTime, "Trigger는 종료 날짜 이후에 실행되지 않아야 합니다");
+    }
+
+    @Test
+    @DisplayName("그제 - 어제 일간 반복하는 일정이 오늘에 일정이 안울리는지 테스트 : if문 생략했을때")
+    public void testSchedulingRepeatScheduleNotification_deleteIf() throws SchedulerException {
+        // 본 테스트는 NotificaitionSchedulerService.java
+        // schedulingRepeatScheduleNotification메서드에 있는 if문을 생략해야 통과됩니다. > 현재 Line 81: 줄은 바뀔 수도 있음
+        // given
+        RepeatSchedule repeatSchedule = mock(RepeatSchedule.class);
+        StudyChannel studyChannel = mock(StudyChannel.class);
+
+        when(studyChannel.getId()).thenReturn(1L);
+        when(repeatSchedule.getStudyChannel()).thenReturn(studyChannel);
+        when(repeatSchedule.getScheduleDate()).thenReturn(LocalDate.now().minusDays(2));
+        when(repeatSchedule.getScheduleStartTime()).thenReturn(LocalTime.of(12, 0));
+        when(repeatSchedule.getRepeatEndDate()).thenReturn(LocalDate.now().minusDays(1)); // 어제
+        when(repeatSchedule.getRepeatCycle()).thenReturn(RepeatCycle.DAILY);
+
+        // Trigger 캡처
+        ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass(Trigger.class);
+
+        // when
+        notificationSchedulerService.schedulingRepeatScheduleNotification(repeatSchedule);
+
+        // then
+        // 스케줄러가 올바른 트리거로 호출되었는지 검증
+        verify(scheduler).scheduleJob(any(JobDetail.class), triggerCaptor.capture());
+        Trigger trigger = triggerCaptor.getValue();
+
+        // 종료 날짜가 올바른지 검증
+        Date expectedEndDate = Date.from(LocalDate.now().minusDays(1).atTime(23, 59, 59).atZone(ZoneId.systemDefault()).toInstant());
+        assertEquals(expectedEndDate, trigger.getEndTime());
+
+        // 종료 날짜 이후 트리거가 실행되지 않는지 검증
+        Date afterEndDate = Date.from(LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant());
+        Date nextFireTime = trigger.getFireTimeAfter(afterEndDate);
+        assertNull(nextFireTime, "Trigger는 종료 날짜 이후에 실행되지 않아야 합니다");
+    }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 반복 일정의 trigger가 startAt과 endAt을 두지 않아 무한으로 cron 주기에 맞게 알림이 전송되었었음(해당 일정이 없음에도 출석체크하라는 알림)
- 알림 체크를 확인하기 위해 일부러 이전 날짜로 등록했을 때도 출석 체크 알림이 동일하게 왔었음
    - misfire가 존재할 때 바로 실행하도록 설정해두었기 때문 

**TO-BE**
- 반복 일정에 startAt, endAt을 두었음
- 단일 일정에도 명시적으로 startAt, endAt을 해당 날짜로 두었음
- 단일 일정: 현재 날짜보다 일정 시작 날짜가 지난 날짜면 trigger, job detail을 등록하지 않도록 if문 추가
- 반복 일정: 현재 날짜보다 일정 끝나는 날짜가 지난 날짜면 trigger, job detail을 등록하지 않도록 if문 추가
- 알림 체크를 확인하기 위해 일부러 이전 날짜로 등록했을 때도 출석 체크 알림이 오지 않음
    - misfire(전송이 안된 trigger, 등)가 존재할 때 무시하고 다음 trigger 일정을 그대로 유지하도록 변경
    - 이것은 만약 출석 체크 알림이 전송 안되는 경우에 다시 전송되지 않도록 설정한 것
    - 추후 크리티컬한 부분이면 설정을 다시 변경해두겠습니다. 그러나 지금은 크리티컬하지 않다고 생각되어 무시하고 다음 trigger 설정을 따르도록 해놨습니다.


***TO-DO***
***현재 misfire문제로 제가 착각하고있었던 오류는 해결된 상황이긴 합니다!
그러나 조금 더 확실한 확인을 위해 배포서버에서 확인해야 하는 부분은 다음과 같습니다.***
- 배포된 서버에서 직접적으로 일간, 주간, 월간 반복에 따라 실제 출석체크 알림이 안오는 지 확인해야함
    - 일간 반복: 7월 25일 ~ 28일 일간 반복 일정을 등록했을때 7월 29일에 출석체크 알림이 실제로 안오는지 확인
    - 주간 반복: 7월 5일 ~ 12일 ~ 19일 까지의 주간 반복 일정일 때 7월 26일에 출석체크 알림이 안오는지
    - 월간 반복: 5월 27일 ~ 6월 27일까지의 월간 반복 일정일 때 7월 27일에 출석체크 알림이 안오는지
- 배포된 서버에서 단일 일정 출석 체크 알림이 다음날 안오는지 확인해야함

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
- [X] API 테스트 