### PR TITLE
fix: Lazy loading 관련 예외로 인한 코드 수정

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig implements WebMvcConfigurer {
                         .requestMatchers("/api/token/oauth2/**", "/favicon.ico", "/oauth2/**", "/api/payments/success/**", "/api/payments/cancel/**", "/api/members/password/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/study-channels", "/api/study-channels/{studyChannelId:\\d+}").permitAll()
                         .requestMatchers("/api/members/logout", "api/study-channels/*/places", "/api/study-channels/**", "/api/token/re-issue"
-                                , "/api/members/my-info", "/api/members/my-info/update", "/api/payments/**",
+                                , "/api/members/my-info", "/api/members/my-info/update", "/api/payments/**", "/api/participation/**",
                             "/api/study-channels/*/single-schedules/**", "/api/study-channels/*/repeat-schedules/**",
                             "/api/study-channels/*/schedules/**", "/api/points/my-point/**", "/api/members/my-apply/**", "/api/notifications/**").hasRole("USER"))
                 .exceptionHandling(exception -> exception.authenticationEntryPoint(authenticationEntryPoint))

--- a/src/main/java/com/tenten/studybadge/participation/domain/repository/ParticipationRepository.java
+++ b/src/main/java/com/tenten/studybadge/participation/domain/repository/ParticipationRepository.java
@@ -5,18 +5,24 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ParticipationRepository extends JpaRepository<Participation, Long> {
 
     boolean existsByMemberIdAndStudyChannelId(Long memberId, Long studyChannelId);
 
     @Query("SELECT p FROM Participation p " +
-            "JOIN p.member " +
-            "JOIN p.studyChannel " +
+            "JOIN FETCH p.member " +
+            "JOIN FETCH p.studyChannel " +
             "WHERE p.studyChannel.id = :studyChannelId")
     List<Participation> findByStudyChannelIdWithMember(Long studyChannelId);
 
     List<Participation> findByStudyChannelId(Long studyChannelId);
 
     List<Participation> findByMemberId(Long memberId);
+
+    @Query("SELECT p FROM Participation p " +
+            "JOIN FETCH p.member " +
+            "WHERE p.id = :id")
+    Optional<Participation> findByIdWithMember(Long id);
 }

--- a/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
+++ b/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
@@ -82,8 +82,9 @@ public class StudyChannelParticipationService {
     public void approve(Long studyChannelId, Long participationId, Long memberId) {
 
         Member member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
-        Participation participation = participationRepository.findById(participationId).orElseThrow(NotFoundParticipationException::new);
-        StudyChannel studyChannel = participation.getStudyChannel();
+        Participation participation = participationRepository.findByIdWithMember(participationId).orElseThrow(NotFoundParticipationException::new);
+        StudyChannel studyChannel = studyChannelRepository.findByIdWithMember(participation.getStudyChannel().getId()).orElseThrow(NotFoundStudyChannelException::new);
+        Member applyMember = participation.getMember();
 
         if (!studyChannel.getId().equals(studyChannelId)) {
              throw new OtherStudyChannelParticipationException();
@@ -95,12 +96,9 @@ public class StudyChannelParticipationService {
             throw new InvalidApprovalStatusException();
         }
 
-        StudyChannel channel = participation.getStudyChannel();
-        Member applyMember = participation.getMember();
-
         approveMember(participation, studyChannel, applyMember);
         Point point = deductPoint(applyMember, studyChannel.getDeposit());
-        recordDeposit(channel, applyMember, point.getAmount());
+        recordDeposit(studyChannel, applyMember, point.getAmount());
 
     }
 
@@ -108,7 +106,7 @@ public class StudyChannelParticipationService {
 
         Member member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
         Participation participation = participationRepository.findById(participationId).orElseThrow(NotFoundParticipationException::new);
-        StudyChannel studyChannel = participation.getStudyChannel();
+        StudyChannel studyChannel = studyChannelRepository.findByIdWithMember(participation.getStudyChannel().getId()).orElseThrow(NotFoundStudyChannelException::new);
 
         if (!studyChannel.getId().equals(studyChannelId)) {
             throw new OtherStudyChannelParticipationException();
@@ -127,7 +125,7 @@ public class StudyChannelParticipationService {
     public StudyChannelParticipationStatusResponse getParticipationStatus(Long studyChannelId, Long memberId) {
 
         Member member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
-        StudyChannel studyChannel = studyChannelRepository.findById(studyChannelId).orElseThrow(NotFoundStudyChannelException::new);
+        StudyChannel studyChannel = studyChannelRepository.findByIdWithMember(studyChannelId).orElseThrow(NotFoundStudyChannelException::new);
         if (!studyChannel.isLeader(member)) {
             throw new NotStudyLeaderException();
         }

--- a/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
+++ b/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
@@ -47,7 +47,7 @@ public class StudyChannelParticipationService {
     public void apply(Long studyChannelId, Long memberId) {
 
         Member member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
-        StudyChannel studyChannel = studyChannelRepository.findById(studyChannelId).orElseThrow(NotFoundStudyChannelException::new);
+        StudyChannel studyChannel = studyChannelRepository.findByIdWithMember(studyChannelId).orElseThrow(NotFoundStudyChannelException::new);
 
         if (studyChannel.isStudyMember(memberId)) {
             throw new AlreadyStudyMemberException();

--- a/src/main/java/com/tenten/studybadge/schedule/domain/entity/SingleSchedule.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/entity/SingleSchedule.java
@@ -28,7 +28,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(indexes = @Index(name = "idx_study_channel_id_repeat", columnList = "study_channel_id"))
+@Table(indexes = @Index(name = "idx_study_channel_id_single", columnList = "study_channel_id"))
 public class SingleSchedule extends Schedule {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/tenten/studybadge/schedule/domain/entity/SingleSchedule.java
+++ b/src/main/java/com/tenten/studybadge/schedule/domain/entity/SingleSchedule.java
@@ -28,7 +28,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(indexes = @Index(name = "idx_study_channel_id_single", columnList = "study_channel_id"))
+@Table(indexes = @Index(name = "idx_study_channel_id_repeat", columnList = "study_channel_id"))
 public class SingleSchedule extends Schedule {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/tenten/studybadge/study/member/domain/repository/StudyMemberRepository.java
+++ b/src/main/java/com/tenten/studybadge/study/member/domain/repository/StudyMemberRepository.java
@@ -31,4 +31,9 @@ public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> 
             "JOIN FETCH sm.studyChannel " +
             "WHERE sm.member.id = :memberId")
     List<StudyMember> findAllByMemberIdWithStudyChannel(Long memberId);
+
+    @Query("SELECT sm FROM StudyMember sm " +
+            "JOIN FETCH sm.member " +
+            "WHERE sm.id = :id")
+    Optional<StudyMember> findByIdWithMember(Long id);
 }

--- a/src/main/java/com/tenten/studybadge/study/member/service/StudyMemberService.java
+++ b/src/main/java/com/tenten/studybadge/study/member/service/StudyMemberService.java
@@ -144,7 +144,7 @@ public class StudyMemberService {
         if (!studyMember.isLeader()) {
             throw new NotStudyLeaderException();
         }
-        StudyMember banedStudyMember = studyMemberRepository.findById(studyMemberId).orElseThrow(NotStudyMemberException::new);
+        StudyMember banedStudyMember = studyMemberRepository.findByIdWithMember(studyMemberId).orElseThrow(NotStudyMemberException::new);
         Member member = banedStudyMember.getMember();
 
         // 스터디 멤버 상태 : "BAN"으로 변경

--- a/src/test/java/com/tenten/studybadge/participation/service/StudyChannelParticipationServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/participation/service/StudyChannelParticipationServiceTest.java
@@ -89,7 +89,7 @@ class StudyChannelParticipationServiceTest {
             Member member = Member.builder().id(1L).build();
 
             given(memberRepository.findById(1L)).willReturn(Optional.of(member));
-            given(studyChannelRepository.findByIdWithMember(anyLong())).willReturn(Optional.of(studyChannel));
+            given(studyChannelRepository.findById(anyLong())).willReturn(Optional.of(studyChannel));
             given(participationRepository.existsByMemberIdAndStudyChannelId(anyLong(), anyLong())).willReturn(false);
 
             // when
@@ -114,7 +114,7 @@ class StudyChannelParticipationServiceTest {
             // given
             Member member = mock(Member.class);
             given(memberRepository.findById(1L)).willReturn(Optional.of(member));
-            given(studyChannelRepository.findByIdWithMember(anyLong())).willReturn(Optional.empty());
+            given(studyChannelRepository.findById(anyLong())).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> studyChannelParticipationService.apply(1L, 1L))
@@ -137,7 +137,7 @@ class StudyChannelParticipationServiceTest {
                     .build();
             Member member = mock(Member.class);
             given(memberRepository.findById(1L)).willReturn(Optional.of(member));
-            given(studyChannelRepository.findByIdWithMember(anyLong())).willReturn(Optional.of(studyChannel));
+            given(studyChannelRepository.findById(anyLong())).willReturn(Optional.of(studyChannel));
             given(participationRepository.existsByMemberIdAndStudyChannelId(anyLong(), anyLong())).willReturn(true);
 
             // when
@@ -172,7 +172,7 @@ class StudyChannelParticipationServiceTest {
                     .build();
             studyChannel.getStudyMembers().add(studyMember);
             given(memberRepository.findById(1L)).willReturn(Optional.of(member));
-            given(studyChannelRepository.findByIdWithMember(anyLong())).willReturn(Optional.of(studyChannel));
+            given(studyChannelRepository.findById(anyLong())).willReturn(Optional.of(studyChannel));
 
             // when & then
             assertThatThrownBy(() -> studyChannelParticipationService.apply(studyChannel.getId(), 1L))
@@ -195,7 +195,7 @@ class StudyChannelParticipationServiceTest {
                     .build();
             Member member = mock(Member.class);
             given(memberRepository.findById(1L)).willReturn(Optional.of(member));
-            given(studyChannelRepository.findByIdWithMember(anyLong())).willReturn(Optional.of(studyChannel));
+            given(studyChannelRepository.findById(anyLong())).willReturn(Optional.of(studyChannel));
 
             // when & then
             assertThatThrownBy(() -> studyChannelParticipationService.apply(studyChannel.getId(), 1L))
@@ -282,8 +282,7 @@ class StudyChannelParticipationServiceTest {
                     .build();
 
             given(memberRepository.findById(2L)).willReturn(Optional.of(leader));
-            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
-            given(participationRepository.findByIdWithMember(1L)).willReturn(Optional.of(participation));
+            given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
 
             //when
             studyChannelParticipationService.approve(1L, 1L, 2L);
@@ -349,8 +348,7 @@ class StudyChannelParticipationServiceTest {
                     .build();
 
             given(memberRepository.findById(2L)).willReturn(Optional.of(leader));
-            given(participationRepository.findByIdWithMember(1L)).willReturn(Optional.of(participation));
-            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
+            given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
 
             //when & then
             assertThatThrownBy(() -> studyChannelParticipationService.approve(2L, 1L, 2L))
@@ -383,8 +381,7 @@ class StudyChannelParticipationServiceTest {
                     .build();
 
             given(memberRepository.findById(2L)).willReturn(Optional.of(member2));
-            given(participationRepository.findByIdWithMember(1L)).willReturn(Optional.of(participation));
-            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
+            given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
 
             //when & then
             assertThatThrownBy(() -> studyChannelParticipationService.approve(1L, 1L, 2L))
@@ -418,8 +415,7 @@ class StudyChannelParticipationServiceTest {
                     .build();
 
             given(memberRepository.findById(2L)).willReturn(Optional.of(leader));
-            given(participationRepository.findByIdWithMember(1L)).willReturn(Optional.of(participation));
-            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
+            given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
 
             //when & then
             assertThatThrownBy(() -> studyChannelParticipationService.approve(1L, 1L, 2L))
@@ -460,7 +456,6 @@ class StudyChannelParticipationServiceTest {
 
             given(memberRepository.findById(2L)).willReturn(Optional.of(leader));
             given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
-            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
 
             //when
             studyChannelParticipationService.reject(1L, 1L, 2L);
@@ -496,7 +491,6 @@ class StudyChannelParticipationServiceTest {
 
             given(memberRepository.findById(2L)).willReturn(Optional.of(leader));
             given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
-            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
 
             //when & then
             assertThatThrownBy(() -> studyChannelParticipationService.reject(2L, 1L, 2L))
@@ -530,7 +524,6 @@ class StudyChannelParticipationServiceTest {
 
             given(memberRepository.findById(2L)).willReturn(Optional.of(member2));
             given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
-            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
 
             //when & then
             assertThatThrownBy(() -> studyChannelParticipationService.reject(1L, 1L, 2L))
@@ -565,7 +558,6 @@ class StudyChannelParticipationServiceTest {
 
             given(memberRepository.findById(2L)).willReturn(Optional.of(leader));
             given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
-            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
 
             //when & then
             assertThatThrownBy(() -> studyChannelParticipationService.reject(1L, 1L, 2L))
@@ -601,7 +593,7 @@ class StudyChannelParticipationServiceTest {
             studyChannel.getStudyMembers().add(leader);
 
             given(memberRepository.findById(1L)).willReturn(Optional.of(member1));
-            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
+            given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
 
             //when
             StudyChannelParticipationStatusResponse response = studyChannelParticipationService.getParticipationStatus(1L, 1L);
@@ -649,7 +641,7 @@ class StudyChannelParticipationServiceTest {
                     .build();
 
             given(memberRepository.findById(1L)).willReturn(Optional.of(member1));
-            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
+            given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
             given(participationRepository.findByStudyChannelIdWithMember(1L)).willReturn(List.of(participation));
 
             //when

--- a/src/test/java/com/tenten/studybadge/participation/service/StudyChannelParticipationServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/participation/service/StudyChannelParticipationServiceTest.java
@@ -89,7 +89,7 @@ class StudyChannelParticipationServiceTest {
             Member member = Member.builder().id(1L).build();
 
             given(memberRepository.findById(1L)).willReturn(Optional.of(member));
-            given(studyChannelRepository.findById(anyLong())).willReturn(Optional.of(studyChannel));
+            given(studyChannelRepository.findByIdWithMember(anyLong())).willReturn(Optional.of(studyChannel));
             given(participationRepository.existsByMemberIdAndStudyChannelId(anyLong(), anyLong())).willReturn(false);
 
             // when
@@ -114,7 +114,7 @@ class StudyChannelParticipationServiceTest {
             // given
             Member member = mock(Member.class);
             given(memberRepository.findById(1L)).willReturn(Optional.of(member));
-            given(studyChannelRepository.findById(anyLong())).willReturn(Optional.empty());
+            given(studyChannelRepository.findByIdWithMember(anyLong())).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> studyChannelParticipationService.apply(1L, 1L))
@@ -137,7 +137,7 @@ class StudyChannelParticipationServiceTest {
                     .build();
             Member member = mock(Member.class);
             given(memberRepository.findById(1L)).willReturn(Optional.of(member));
-            given(studyChannelRepository.findById(anyLong())).willReturn(Optional.of(studyChannel));
+            given(studyChannelRepository.findByIdWithMember(anyLong())).willReturn(Optional.of(studyChannel));
             given(participationRepository.existsByMemberIdAndStudyChannelId(anyLong(), anyLong())).willReturn(true);
 
             // when
@@ -172,7 +172,7 @@ class StudyChannelParticipationServiceTest {
                     .build();
             studyChannel.getStudyMembers().add(studyMember);
             given(memberRepository.findById(1L)).willReturn(Optional.of(member));
-            given(studyChannelRepository.findById(anyLong())).willReturn(Optional.of(studyChannel));
+            given(studyChannelRepository.findByIdWithMember(anyLong())).willReturn(Optional.of(studyChannel));
 
             // when & then
             assertThatThrownBy(() -> studyChannelParticipationService.apply(studyChannel.getId(), 1L))
@@ -195,7 +195,7 @@ class StudyChannelParticipationServiceTest {
                     .build();
             Member member = mock(Member.class);
             given(memberRepository.findById(1L)).willReturn(Optional.of(member));
-            given(studyChannelRepository.findById(anyLong())).willReturn(Optional.of(studyChannel));
+            given(studyChannelRepository.findByIdWithMember(anyLong())).willReturn(Optional.of(studyChannel));
 
             // when & then
             assertThatThrownBy(() -> studyChannelParticipationService.apply(studyChannel.getId(), 1L))
@@ -282,7 +282,8 @@ class StudyChannelParticipationServiceTest {
                     .build();
 
             given(memberRepository.findById(2L)).willReturn(Optional.of(leader));
-            given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
+            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
+            given(participationRepository.findByIdWithMember(1L)).willReturn(Optional.of(participation));
 
             //when
             studyChannelParticipationService.approve(1L, 1L, 2L);
@@ -348,7 +349,8 @@ class StudyChannelParticipationServiceTest {
                     .build();
 
             given(memberRepository.findById(2L)).willReturn(Optional.of(leader));
-            given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
+            given(participationRepository.findByIdWithMember(1L)).willReturn(Optional.of(participation));
+            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
 
             //when & then
             assertThatThrownBy(() -> studyChannelParticipationService.approve(2L, 1L, 2L))
@@ -381,7 +383,8 @@ class StudyChannelParticipationServiceTest {
                     .build();
 
             given(memberRepository.findById(2L)).willReturn(Optional.of(member2));
-            given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
+            given(participationRepository.findByIdWithMember(1L)).willReturn(Optional.of(participation));
+            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
 
             //when & then
             assertThatThrownBy(() -> studyChannelParticipationService.approve(1L, 1L, 2L))
@@ -415,7 +418,8 @@ class StudyChannelParticipationServiceTest {
                     .build();
 
             given(memberRepository.findById(2L)).willReturn(Optional.of(leader));
-            given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
+            given(participationRepository.findByIdWithMember(1L)).willReturn(Optional.of(participation));
+            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
 
             //when & then
             assertThatThrownBy(() -> studyChannelParticipationService.approve(1L, 1L, 2L))
@@ -456,6 +460,7 @@ class StudyChannelParticipationServiceTest {
 
             given(memberRepository.findById(2L)).willReturn(Optional.of(leader));
             given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
+            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
 
             //when
             studyChannelParticipationService.reject(1L, 1L, 2L);
@@ -491,6 +496,7 @@ class StudyChannelParticipationServiceTest {
 
             given(memberRepository.findById(2L)).willReturn(Optional.of(leader));
             given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
+            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
 
             //when & then
             assertThatThrownBy(() -> studyChannelParticipationService.reject(2L, 1L, 2L))
@@ -524,6 +530,7 @@ class StudyChannelParticipationServiceTest {
 
             given(memberRepository.findById(2L)).willReturn(Optional.of(member2));
             given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
+            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
 
             //when & then
             assertThatThrownBy(() -> studyChannelParticipationService.reject(1L, 1L, 2L))
@@ -558,6 +565,7 @@ class StudyChannelParticipationServiceTest {
 
             given(memberRepository.findById(2L)).willReturn(Optional.of(leader));
             given(participationRepository.findById(1L)).willReturn(Optional.of(participation));
+            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
 
             //when & then
             assertThatThrownBy(() -> studyChannelParticipationService.reject(1L, 1L, 2L))
@@ -593,7 +601,7 @@ class StudyChannelParticipationServiceTest {
             studyChannel.getStudyMembers().add(leader);
 
             given(memberRepository.findById(1L)).willReturn(Optional.of(member1));
-            given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
+            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
 
             //when
             StudyChannelParticipationStatusResponse response = studyChannelParticipationService.getParticipationStatus(1L, 1L);
@@ -641,7 +649,7 @@ class StudyChannelParticipationServiceTest {
                     .build();
 
             given(memberRepository.findById(1L)).willReturn(Optional.of(member1));
-            given(studyChannelRepository.findById(1L)).willReturn(Optional.of(studyChannel));
+            given(studyChannelRepository.findByIdWithMember(1L)).willReturn(Optional.of(studyChannel));
             given(participationRepository.findByStudyChannelIdWithMember(1L)).willReturn(List.of(participation));
 
             //when


### PR DESCRIPTION
### 변경사항
**AS-IS**

- 스터디 채널 조회 시 studyChannelRepository.findById(studyChannelId)로 조회한 후 내부에 OneToMany로 되어있는 studyMembers로 접근
- 참가 신청 내역 조회 시 findById()로 되어 있다.
- 특정 스터디 멤버 조회 시 findById()로 되어 있다.

**TO-BE**

- 위 방식대로 구현할 경우 Session이 닫히면서 proxy를 통한 Lazy loading을 못하는 이슈가 발생
- 따라서 Lazy Loading이 발생하는 코드를 모두 FETCH JOIN으로 가져와 위와 같은 문제가 발생하지 않도록 코드를 수정했습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
   - 스터디 채널 참가 신청 테스트 코드를 변경된 메서드명으로 모두 변경했습니다.
- [x] API 테스트 