### PR TITLE
feat: STD-20 알림 기능: 스터디 채널의 종료 전날/ 스터디 채널의 종료 날 스터디 멤버들에게 알림 전송

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/constant/NotificationConstant.java
+++ b/src/main/java/com/tenten/studybadge/common/constant/NotificationConstant.java
@@ -15,4 +15,7 @@ public class NotificationConstant {
     public static final String REPEAT_SCHEDULE_DELETE = "스터디 채널 id: %d의  %s 반복 일정이 삭제되었습니다.";
 
     public static final String TEN_MINUTES_BEFORE_SCHEDULE_START = "%s 일정 시작 10분 전입니다.";
+
+    public static final String STUDY_END_TOMORROW_NOTIFICATION = "[%s] 스터디가 내일 종료됩니다.";
+    public static final String STUDY_END_TODAY_AND_REFUND_NOTIFICATION = "[%s] 스터디가 끝났습니다. 출석률 기반 환급 금액은 다음날 정산 될 예정입니다.";
 }

--- a/src/main/java/com/tenten/studybadge/common/quartz/StudyEndNotificationJob.java
+++ b/src/main/java/com/tenten/studybadge/common/quartz/StudyEndNotificationJob.java
@@ -1,0 +1,34 @@
+package com.tenten.studybadge.common.quartz;
+
+import com.tenten.studybadge.notification.service.NotificationService;
+import com.tenten.studybadge.type.notification.NotificationType;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@AllArgsConstructor
+public class StudyEndNotificationJob implements Job {
+
+    private final NotificationService notificationService;
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        Long studyChannelId = context.getMergedJobDataMap().getLong("studyChannelId");
+        String studyChannelName = context.getMergedJobDataMap().getString("studyChannelName");
+        String messageTemplate = context.getMergedJobDataMap().getString("messageTemplate");
+        String notificationType = context.getMergedJobDataMap().getString("notificationType");
+
+        String content = String.format(messageTemplate, studyChannelName);
+        String relateUrl = String.format("/channel/%d", studyChannelId); // 클라이언트 url
+
+        notificationService.sendNotificationToStudyChannel(
+            studyChannelId, NotificationType.valueOf(notificationType), content, relateUrl);
+
+        log.info("studyChannelId: {}: 스터디 채널에 속한 스터디 멤버들에게 {} 알림 전송 from StudyEndNotificationJob", notificationType, studyChannelId);
+    }
+}

--- a/src/main/java/com/tenten/studybadge/notification/domain/entitiy/Notification.java
+++ b/src/main/java/com/tenten/studybadge/notification/domain/entitiy/Notification.java
@@ -47,7 +47,7 @@ public class Notification extends BaseEntity {
     private Boolean isRead;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 50) // 충분한 길이로 설정
     private NotificationType notificationType;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/tenten/studybadge/notification/service/NotificationSchedulerService.java
+++ b/src/main/java/com/tenten/studybadge/notification/service/NotificationSchedulerService.java
@@ -201,16 +201,9 @@ public class NotificationSchedulerService {
             return; // 과거 날짜일 경우 스케줄링을 건너뜁니다.
         }
 
-        // 민호님 의견대로 20시에 전날 보내도록 time 셋팅
-        LocalDateTime customTimeForStudyEndTomorrow = studyEndDate.atStartOfDay()
-            .withHour(20).withMinute(0).withSecond(0).withNano(0);
-
-        // 알림 api 테스트를 위해 마감 + 2분 뒤에 알림 전송 확인하도록 설정
-        LocalDateTime now = LocalDateTime.now();
-        int hour = now.getHour();
-        int minute = now.getMinute() + 2;
+        // 오전 8시에 스터디 종료 관련 알림 일괄 전송
         LocalDateTime customTime = studyEndDate.atStartOfDay()
-            .withHour(hour).withMinute(minute).withSecond(0).withNano(0);
+            .withHour(8).withMinute(0).withSecond(0).withNano(0);
         scheduleNotification(
             studyChannel, NotificationType.STUDY_END_TOMORROW,
             "study-end-tomorrow-group", STUDY_END_TOMORROW_NOTIFICATION, customTime.minusDays(1));

--- a/src/main/java/com/tenten/studybadge/notification/service/NotificationSchedulerService.java
+++ b/src/main/java/com/tenten/studybadge/notification/service/NotificationSchedulerService.java
@@ -1,10 +1,16 @@
 package com.tenten.studybadge.notification.service;
 
+import static com.tenten.studybadge.common.constant.NotificationConstant.STUDY_END_TODAY_AND_REFUND_NOTIFICATION;
+import static com.tenten.studybadge.common.constant.NotificationConstant.STUDY_END_TOMORROW_NOTIFICATION;
+
 import com.tenten.studybadge.common.quartz.RepeatScheduleNotificationJob;
 import com.tenten.studybadge.common.quartz.SingleScheduleNotificationJob;
 import com.tenten.studybadge.common.exception.schedule.IllegalArgumentForScheduleRequestException;
+import com.tenten.studybadge.common.quartz.StudyEndNotificationJob;
 import com.tenten.studybadge.schedule.domain.entity.RepeatSchedule;
 import com.tenten.studybadge.schedule.domain.entity.SingleSchedule;
+import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
+import com.tenten.studybadge.type.notification.NotificationType;
 import com.tenten.studybadge.type.schedule.RepeatCycle;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -180,6 +186,72 @@ public class NotificationSchedulerService {
             log.info("Successfully unscheduled and deleted repeat schedule notification job and trigger: JobKey={}, TriggerKey={}", jobKey, triggerKey);
         } catch (SchedulerException e) {
             log.error("Error unscheduling repeat schedule notification", e);
+        }
+    }
+
+    // 알림 스케줄링:
+    // 1. 스터디 채널 끝나기 하루 전 알림
+    // 2. 스터디 채널 끝 + 환급은 다음날 하는 것 알림
+    public void scheduleStudyEndNotifications(StudyChannel studyChannel) {
+
+        LocalDate studyEndDate = studyChannel.getStudyDuration().getStudyEndDate();
+        // 현재 날짜와 시간과 비교하여 스터디 채널 끝나는 날짜가 과거 날짜인지 확인
+        if (studyEndDate.isBefore(LocalDate.now())) {
+            log.info("스터디 채널 끝나는 날짜가 현재보다 과거 날짜이므로 반복 일정 출석 체크 알림 스케줄링을 생략합니다.: " + studyEndDate);
+            return; // 과거 날짜일 경우 스케줄링을 건너뜁니다.
+        }
+
+        // 민호님 의견대로 20시에 전날 보내도록 time 셋팅
+        LocalDateTime customTimeForStudyEndTomorrow = studyEndDate.atStartOfDay()
+            .withHour(20).withMinute(0).withSecond(0).withNano(0);
+
+        // 알림 api 테스트를 위해 마감 + 2분 뒤에 알림 전송 확인하도록 설정
+        LocalDateTime now = LocalDateTime.now();
+        int hour = now.getHour();
+        int minute = now.getMinute() + 2;
+        LocalDateTime customTime = studyEndDate.atStartOfDay()
+            .withHour(hour).withMinute(minute).withSecond(0).withNano(0);
+        scheduleNotification(
+            studyChannel, NotificationType.STUDY_END_TOMORROW,
+            "study-end-tomorrow-group", STUDY_END_TOMORROW_NOTIFICATION, customTime.minusDays(1));
+        scheduleNotification(
+            studyChannel, NotificationType.STUDY_END_TODAY,
+            "study-end-today-group", STUDY_END_TODAY_AND_REFUND_NOTIFICATION, customTime);
+    }
+
+    private void scheduleNotification(StudyChannel studyChannel, NotificationType notificationType, String groupName, String messageTemplate, LocalDateTime notificationTime) {
+        Date notificationDate = Date.from(notificationTime.atZone(ZoneId.systemDefault()).toInstant());
+        JobDataMap jobDataMap = new JobDataMap();
+        jobDataMap.put("studyChannelId", studyChannel.getId());
+        jobDataMap.put("studyChannelName", studyChannel.getName());
+        jobDataMap.put("notificationType", notificationType.name());
+        jobDataMap.put("messageTemplate", messageTemplate);
+
+        String jobIdentity = String.format("studyEndNotificationJob-%d-%s", studyChannel.getId(), notificationTime);
+        JobKey jobKey = JobKey.jobKey(jobIdentity, groupName);
+
+        try {
+            if (scheduler.checkExists(jobKey)) {
+                scheduler.deleteJob(jobKey);
+            }
+
+            JobDetail jobDetail = JobBuilder.newJob(StudyEndNotificationJob.class)
+                .withIdentity(jobKey)
+                .usingJobData(jobDataMap)
+                .build();
+
+            TriggerKey triggerKey = new TriggerKey("studyEndNotificationTrigger-" + studyChannel.getId() + "-" + notificationTime, groupName);
+            Trigger trigger = TriggerBuilder.newTrigger()
+                .withIdentity(triggerKey)
+                .startAt(notificationDate)
+                .withSchedule(SimpleScheduleBuilder.simpleSchedule()
+                    .withMisfireHandlingInstructionFireNow())
+                .build();
+            scheduler.scheduleJob(jobDetail, trigger);
+            log.info("스터디 채널 id: {} 스터디 멤버들에게 보낼 {} 알림을 스케줄링 했습니다.", notificationType.getDescription(), studyChannel.getId());
+            log.info("Scheduled study end notification: JobKey={}, TriggerKey={}", jobDetail.getKey(), trigger.getKey());
+        } catch (SchedulerException e) {
+            log.error("Error scheduling study end notification", e);
         }
     }
 }

--- a/src/main/java/com/tenten/studybadge/study/channel/service/StudyChannelService.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/service/StudyChannelService.java
@@ -6,6 +6,7 @@ import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelE
 import com.tenten.studybadge.common.exception.studychannel.NotStudyLeaderException;
 import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.member.domain.repository.MemberRepository;
+import com.tenten.studybadge.notification.service.NotificationSchedulerService;
 import com.tenten.studybadge.participation.domain.entity.Participation;
 import com.tenten.studybadge.participation.domain.repository.ParticipationRepository;
 import com.tenten.studybadge.study.channel.domain.entity.StudyChannel;
@@ -38,6 +39,7 @@ public class StudyChannelService {
     private final StudyMemberRepository studyMemberRepository;
     private final MemberRepository memberRepository;
     private final ParticipationRepository participationRepository;
+    private final NotificationSchedulerService notificationSchedulerService;
 
     @Transactional
     public Long create(StudyChannelCreateRequest request, Long memberId) {
@@ -119,6 +121,8 @@ public class StudyChannelService {
 
         studyChannelRepository.save(studyChannel);
         participationRepository.saveAll(approveWaitingParticipationList);
+
+        notificationSchedulerService.scheduleStudyEndNotifications(studyChannel);
     }
 
     private void checkLeader(StudyChannel studyChannel, Member member) {

--- a/src/main/java/com/tenten/studybadge/type/notification/NotificationType.java
+++ b/src/main/java/com/tenten/studybadge/type/notification/NotificationType.java
@@ -11,7 +11,9 @@ public enum NotificationType {
   SCHEDULE_CREATE("일정 생성"),
   SCHEDULE_UPDATE("일정 변경"),
   SCHEDULE_DELETE("일정 삭제"),
-  SCHEDULE_REMINDER("출석 체크 10분 전");
+  SCHEDULE_REMINDER("출석 체크 10분 전"),
+  STUDY_END_TOMORROW("스터디 종료 하루 전"),
+  STUDY_END_TODAY("스터디 종료");
 
   private String description;
 }

--- a/src/test/java/com/tenten/studybadge/notification/service/NotificationSchedulerServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/notification/service/NotificationSchedulerServiceTest.java
@@ -86,10 +86,8 @@ public class NotificationSchedulerServiceTest {
         when(studyChannel.getStudyDuration()).thenReturn(studyDuration);
         when(studyDuration.getStudyEndDate()).thenReturn(LocalDate.now().plusDays(1));
 
-        LocalDateTime now = LocalDateTime.now();
-        int hour = now.getHour();
-        int minute = now.getMinute() + 2;
-        LocalDateTime customTime = studyDuration.getStudyEndDate().atStartOfDay().withHour(hour).withMinute(minute).withSecond(0).withNano(0);
+        LocalDateTime customTime = studyDuration.getStudyEndDate().atStartOfDay()
+            .withHour(8).withMinute(0).withSecond(0).withNano(0);
 
         // Trigger 캡처
         ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass(Trigger.class);

--- a/src/test/java/com/tenten/studybadge/study/channel/service/StudyChannelServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/study/channel/service/StudyChannelServiceTest.java
@@ -3,6 +3,7 @@ package com.tenten.studybadge.study.channel.service;
 import com.tenten.studybadge.common.exception.studychannel.*;
 import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.member.domain.repository.MemberRepository;
+import com.tenten.studybadge.notification.service.NotificationSchedulerService;
 import com.tenten.studybadge.participation.domain.entity.Participation;
 import com.tenten.studybadge.participation.domain.repository.ParticipationRepository;
 import com.tenten.studybadge.study.channel.domain.entity.Recruitment;
@@ -56,6 +57,9 @@ class StudyChannelServiceTest {
 
     @Mock
     private ParticipationRepository participationRepository;
+
+    @Mock
+    private NotificationSchedulerService notificationSchedulerService;
 
     @DisplayName("[스터디 채널 생성 테스트]")
     @Nested


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- StudyChannelServiceTest에 NotificationSchedulerService mock이 없었습니다.
- Notification 엔티티의 NotifcationType 필드의 length 길이를 설정하지 않았습니다.

**TO-BE**
-  StudyChannelServiceTest에 NotificationSchedulerService mock을 추가하여 테스트 코드에 영향 없도록 했습니다.
- Notification 엔티티의 NotifcationType 필드의 length 길이를 50으로 넉넉히 뒀습니다.
    - NotificationType 길이가 길어지면 저장이 안되는 오류가 존재했습니다.
    - 이미 create 된 엔티티면, ALTER TABLE notification MODIFY notification_type VARCHAR(50); 으로 길이를 늘려야합니다.
- 스터디 채널 모집 마감시에 NotificationSchedulerService에 있는 스터디 종료 관련 스케줄링 메서드가 작동하도록 두었습니다.
- 현재 스터디 종료 관련 알림은 다음과 같습니다.
    - 1. 스터디 채널 끝나기 하루 전 알림
    - 2. 스터디 채널 끝 + 환급은 다음날 하는 것 알림
- 현재는 스터디 채널 모집을 마감하는 순간 2분 후로 설정되어있어 api 테스트하기 좋으나 재설정 해야합니다.
- 현재 이 알림은 mishire를 이전의 알림과 달리 놓친 trigger가 존재하면 바로 보내도록 하였습니다.

***TODO:// 알림 시간을 정확히 언제 줄 지 팀원들과 상의 후 다시 재설정해야함***

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
- [X] API 테스트 

오늘 날짜(7월 26일)이 마감인 스터디 채널, 다음 날(7월 27일)이 마감인 스터디 채널을 테스트 했을때 알림이 오는 것을 확인했습니다.

![image](https://github.com/user-attachments/assets/2feeb6c9-c38f-489c-af84-f6bc05f6fa34)

