### PR TITLE
refactor: STD-20 일정 관련 알림 전송하는 relatedUrl 형식 변경 및 jobDataMap에 formattedDate도 같이 저장 후 전달

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/constant/NotificationConstant.java
+++ b/src/main/java/com/tenten/studybadge/common/constant/NotificationConstant.java
@@ -1,20 +1,19 @@
 package com.tenten.studybadge.common.constant;
 
 public class NotificationConstant {
-    public static final String SINGLE_SCHEDULE_CREATE = "스터디 채널 id: %d의  %s 새로운 단일 일정이 생성되었습니다.";
-    public static final String REPEAT_SCHEDULE_CREATE = "스터디 채널 id: %d의  %s 새로운 반복 일정이 생성되었습니다.";
-    public static final String SINGLE_SCHEDULE_URL = "/api/study-channels/%d/single-schedules/%d";
-    public static final String REPEAT_SCHEDULE_URL = "/api/study-channels/%d/repeat-schedules/%d";
+    public static final String SINGLE_SCHEDULE_CREATE = "[%s]의  %s 새로운 단일 일정이 생성되었습니다.";
+    public static final String REPEAT_SCHEDULE_CREATE = "[%s]의  %s 새로운 반복 일정이 생성되었습니다.";
+    public static final String SCHEDULE_RELATED_URL = "/channel/%d/schedule/%s";
 
-    public static final String SCHEDULE_UPDATE_FOR_SINGLE_TO_SINGLE = "스터디 채널 id: %d의  %s 단일 일정이 수정되었습니다.";
-    public static final String SCHEDULE_UPDATE_FOR_SINGLE_TO_REPEAT = "스터디 채널 id: %d의  %s 단일 일정이 반복 일정으로 수정되었습니다.";
-    public static final String SCHEDULE_UPDATE_FOR_REPEAT_TO_REPEAT = "스터디 채널 id: %d의  %s 반복 일정이 수정되었습니다.";
-    public static final String SCHEDULE_UPDATE_FOR_REPEAT_TO_SINGLE = "스터디 채널 id: %d의  %s 반복 일정이 단일 일정으로 수정되었습니다.";
+    public static final String SCHEDULE_UPDATE_FOR_SINGLE_TO_SINGLE = "[%s]의  %s 단일 일정이 수정되었습니다.";
+    public static final String SCHEDULE_UPDATE_FOR_SINGLE_TO_REPEAT = "[%s]의  %s 단일 일정이 반복 일정으로 수정되었습니다.";
+    public static final String SCHEDULE_UPDATE_FOR_REPEAT_TO_REPEAT = "[%s]의  %s 반복 일정이 수정되었습니다.";
+    public static final String SCHEDULE_UPDATE_FOR_REPEAT_TO_SINGLE = "[%s]의  %s 반복 일정이 단일 일정으로 수정되었습니다.";
 
-    public static final String SINGLE_SCHEDULE_DELETE= "스터디 채널 id: %d의  %s 단일 일정이 삭제되었습니다.";
-    public static final String REPEAT_SCHEDULE_DELETE = "스터디 채널 id: %d의  %s 반복 일정이 삭제되었습니다.";
+    public static final String SINGLE_SCHEDULE_DELETE= "[%s]의  %s 단일 일정이 삭제되었습니다.";
+    public static final String REPEAT_SCHEDULE_DELETE = "[%s]의  %s 반복 일정이 삭제되었습니다.";
 
-    public static final String TEN_MINUTES_BEFORE_SCHEDULE_START = "%s 일정 시작 10분 전입니다.";
+    public static final String TEN_MINUTES_BEFORE_SCHEDULE_START = "[%s] 일정 시작 10분 전입니다.";
 
     public static final String STUDY_END_TOMORROW_NOTIFICATION = "[%s] 스터디가 내일 종료됩니다.";
     public static final String STUDY_END_TODAY_AND_REFUND_NOTIFICATION = "[%s] 스터디가 끝났습니다. 출석률 기반 환급 금액은 다음날 정산 될 예정입니다.";

--- a/src/main/java/com/tenten/studybadge/common/quartz/RepeatScheduleNotificationJob.java
+++ b/src/main/java/com/tenten/studybadge/common/quartz/RepeatScheduleNotificationJob.java
@@ -1,6 +1,6 @@
 package com.tenten.studybadge.common.quartz;
 
-import static com.tenten.studybadge.common.constant.NotificationConstant.REPEAT_SCHEDULE_URL;
+import static com.tenten.studybadge.common.constant.NotificationConstant.SCHEDULE_RELATED_URL;
 import static com.tenten.studybadge.common.constant.NotificationConstant.TEN_MINUTES_BEFORE_SCHEDULE_START;
 
 import com.tenten.studybadge.notification.service.NotificationService;
@@ -26,9 +26,10 @@ public class RepeatScheduleNotificationJob implements Job {
         String scheduleName = context.getMergedJobDataMap().getString("scheduleName");
         LocalDateTime startTime = (LocalDateTime) context.getMergedJobDataMap().get("startTime");
         Long studyChannelId = context.getMergedJobDataMap().getLong("studyChannelId");
+        String formattedDate = context.getMergedJobDataMap().getString("formattedDate");
 
         String content = String.format(TEN_MINUTES_BEFORE_SCHEDULE_START, scheduleName);
-        String relateUrl = String.format(REPEAT_SCHEDULE_URL, studyChannelId, scheduleId);
+        String relateUrl = String.format(SCHEDULE_RELATED_URL, studyChannelId, formattedDate);
 
         log.info("RepeatScheduleNotificationJob 실행 for scheduleId: {}", scheduleId);
         log.info("스케줄 이름: {}, 시작 시간: {}, 스터디 채널 id: {}", scheduleName, startTime, studyChannelId);

--- a/src/main/java/com/tenten/studybadge/common/quartz/SingleScheduleNotificationJob.java
+++ b/src/main/java/com/tenten/studybadge/common/quartz/SingleScheduleNotificationJob.java
@@ -1,6 +1,6 @@
 package com.tenten.studybadge.common.quartz;
 
-import static com.tenten.studybadge.common.constant.NotificationConstant.SINGLE_SCHEDULE_URL;
+import static com.tenten.studybadge.common.constant.NotificationConstant.SCHEDULE_RELATED_URL;
 import static com.tenten.studybadge.common.constant.NotificationConstant.TEN_MINUTES_BEFORE_SCHEDULE_START;
 
 import com.tenten.studybadge.notification.service.NotificationService;
@@ -26,9 +26,10 @@ public class SingleScheduleNotificationJob implements Job {
         String scheduleName = context.getMergedJobDataMap().getString("scheduleName");
         LocalDateTime startTime = (LocalDateTime) context.getMergedJobDataMap().get("startTime");
         Long studyChannelId = context.getMergedJobDataMap().getLong("studyChannelId");
+        String formattedDate = context.getMergedJobDataMap().getString("formattedDate");
 
         String content = String.format(TEN_MINUTES_BEFORE_SCHEDULE_START, scheduleName);
-        String relateUrl = String.format(SINGLE_SCHEDULE_URL, studyChannelId, scheduleId);
+        String relateUrl = String.format(SCHEDULE_RELATED_URL, studyChannelId, formattedDate);
 
         log.info("SingleScheduleNotificationJob 실행 for scheduleId: {}", scheduleId);
         log.info("스케줄 이름: {}, 시작 시간: {}, 스터디 채널 id: {}", scheduleName, startTime, studyChannelId);

--- a/src/main/java/com/tenten/studybadge/notification/service/NotificationSchedulerService.java
+++ b/src/main/java/com/tenten/studybadge/notification/service/NotificationSchedulerService.java
@@ -15,6 +15,7 @@ import com.tenten.studybadge.type.schedule.RepeatCycle;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,12 +51,17 @@ public class NotificationSchedulerService {
             return; // 과거 날짜일 경우 스케줄링을 건너뜁니다.
         }
 
+        LocalDate scheduleDate = singleSchedule.getScheduleDate();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        String formattedDate = scheduleDate.format(formatter);
+
         JobDataMap jobDataMap = new JobDataMap();
         jobDataMap.put("scheduleId", singleSchedule.getId());
         jobDataMap.put("scheduleName", singleSchedule.getScheduleName());
         jobDataMap.put("startTime", LocalDateTime.of(
-            singleSchedule.getScheduleDate(), singleSchedule.getScheduleStartTime()));
+            scheduleDate, singleSchedule.getScheduleStartTime()));
         jobDataMap.put("studyChannelId", singleSchedule.getStudyChannel().getId());
+        jobDataMap.put("formattedDate", formattedDate);
 
         JobDetail jobDetail = JobBuilder.newJob(SingleScheduleNotificationJob.class)
             .withIdentity("singleScheduleNotificationJob-" + singleSchedule.getId(), "single-schedule-notifications")
@@ -82,6 +88,9 @@ public class NotificationSchedulerService {
 
     // 알림 스케줄링 (반복 일정)
     public void schedulingRepeatScheduleNotification(RepeatSchedule repeatSchedule) {
+        LocalDate scheduleDate = repeatSchedule.getScheduleDate();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        String formattedDate = scheduleDate.format(formatter);
         LocalDateTime startDateTime = LocalDateTime.of(
             repeatSchedule.getScheduleDate(), repeatSchedule.getScheduleStartTime()).minusMinutes(10);
         LocalDateTime endDateTime = repeatSchedule.getRepeatEndDate().atTime(23, 59, 59); // 하루의 끝으로 설정
@@ -98,6 +107,7 @@ public class NotificationSchedulerService {
         jobDataMap.put("scheduleName", repeatSchedule.getScheduleName());
         jobDataMap.put("startTime", LocalDateTime.of(repeatSchedule.getScheduleDate(), repeatSchedule.getScheduleStartTime()));
         jobDataMap.put("studyChannelId", repeatSchedule.getStudyChannel().getId());
+        jobDataMap.put("formattedDate", formattedDate);
 
         JobDetail jobDetail = JobBuilder.newJob(RepeatScheduleNotificationJob.class)
             .withIdentity("repeatScheduleNotificationJob-" + repeatSchedule.getId(), "repeat-schedule-notifications")


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- relatedUrl: 프론트 url이 아닌 백엔드의 api url을 임시로 두었음
- 일정 관련 message 형식: study channel의 id 명시
- 일정 관련 message 형식 중 date format 형식 2024년 7월 27일
- 일정 관련 알림 전송하는 메서드 2개(생성, 수정/삭제)

**TO-BE**
- relatedUrl: /channel/1/schedule/2024-07-27 (프론트 url)
- 일정 관련 message 형식 변경: study channel의 name 명시로 변경(사용자의 편의를 위해)
- 일정 관련 message 형식 변경: date format 형식 2024-07-27 으로 변경(format 1개 사용을 위해)
- 일정 관련 알림 전송하는 메서드 1개로 수정(relatedUrl이 1개이기 때문에)

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 