### PR TITLE
refactor: STD-20 일정; 오늘 날짜로 30일 지난 일정들은 벌크 연산으로 삭제

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/config/SchedulingConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/SchedulingConfig.java
@@ -1,0 +1,10 @@
+package com.tenten.studybadge.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+  // 필요한 설정이 있으면 추가
+}

--- a/src/main/java/com/tenten/studybadge/notification/domain/entitiy/Notification.java
+++ b/src/main/java/com/tenten/studybadge/notification/domain/entitiy/Notification.java
@@ -15,8 +15,10 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,6 +32,7 @@ import org.hibernate.annotations.OnDeleteAction;
 @ToString
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(indexes = @Index(name = "idx_created_at", columnList = "createdAt"))
 public class Notification extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/tenten/studybadge/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/tenten/studybadge/notification/domain/repository/NotificationRepository.java
@@ -1,14 +1,27 @@
 package com.tenten.studybadge.notification.domain.repository;
 
 import com.tenten.studybadge.notification.domain.entitiy.Notification;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     List<Notification> findAllByReceiverId(Long receiverId);
     List<Notification> findAllByReceiverIdAndIsReadFalse(Long receiverId);
     Optional<Notification> findByIdAndReceiverId(Long id, Long receiverId);
+
+    @Query("SELECT n.id FROM Notification n WHERE n.createdAt < :cutoffDate")
+    List<Long> findOldNotificationIds(LocalDateTime cutoffDate, Pageable pageable);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Notification n WHERE n.id IN :ids")
+    void deleteNotificationsByIds(List<Long> ids);
 }

--- a/src/main/java/com/tenten/studybadge/notification/service/NotificationCleanerService.java
+++ b/src/main/java/com/tenten/studybadge/notification/service/NotificationCleanerService.java
@@ -1,0 +1,41 @@
+package com.tenten.studybadge.notification.service;
+
+import com.tenten.studybadge.notification.domain.repository.NotificationRepository;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationCleanerService {
+    private final NotificationRepository notificationRepository;
+
+    private static final int BATCH_SIZE = 2000;
+
+    @Scheduled(cron = "0 0 3 * * ?") // 매일 새벽 3시 실행
+    public void deleteOldNotifications() {
+        LocalDateTime cutoffDate = LocalDateTime.now().minus(30, ChronoUnit.DAYS);
+        log.info("삭제 되어야할 cutoffDate: {}", cutoffDate);
+        Pageable pageable = PageRequest.of(0, BATCH_SIZE);
+        List<Long> oldNotificationIds;
+
+        do {
+            oldNotificationIds = notificationRepository.findOldNotificationIds(cutoffDate, pageable);
+            if (!oldNotificationIds.isEmpty()) {
+                notificationRepository.deleteNotificationsByIds(oldNotificationIds);
+                if (oldNotificationIds.size() == BATCH_SIZE) {
+                    log.info("Batch size {}개의 30일 지난 알림을 삭제했습니다.", oldNotificationIds.size());
+                } else {
+                    log.info("Batch size 미만인 {}개의 30일 지난 알림을 삭제했습니다.", oldNotificationIds.size());
+                }
+            }
+        } while (oldNotificationIds.size() == BATCH_SIZE);
+    }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 일정에 인덱스를 두지 않았습니다.

**TO-BE**
- createAt에 인덱스 설정했습니다.
- 현재 날짜보다 30일 지난 알림들 새벽 3시에 벌크 삭제 스케줄 등록
    - batch size 단위로 삭제하고 있습니다. 
- 벌크 연산이라 repository단에 트랜잭션을 걸었으며 매일 3시에 반복되는 일정이므로 서비스단으로 트랜잭션을 걸진 않았습니다.

***현재 batch size로 삭제하는 패턴과 batch size 없이 삭제하는 패턴을 SpringbootTest로 테스트 진행 중에 있으나 설정 문제로 시간이 걸릴 것 같아 먼저 pr 올렸습니다.***

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 