### PR TITLE
refactor: STD-4 회원 정보 조회시 member id도 return 하도록 수정

### DIFF
--- a/src/main/java/com/tenten/studybadge/member/dto/MemberResponse.java
+++ b/src/main/java/com/tenten/studybadge/member/dto/MemberResponse.java
@@ -11,6 +11,8 @@ import lombok.*;
 @Builder(toBuilder = true)
 public class MemberResponse {
 
+    private Long memberId;
+
     private String email;
 
     private String name;
@@ -33,6 +35,7 @@ public class MemberResponse {
     public static MemberResponse toResponse(Member member) {
 
         return MemberResponse.builder()
+                .memberId(member.getId())
                 .email(member.getEmail())
                 .name(member.getName())
                 .nickname(member.getNickname())


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- memberResponse에 id가 존재하지 않았습니다.

**TO-BE**
- memberResponse에 memberId를 클라이언트가 저장할 수 있도록 추가했습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 
![image](https://github.com/user-attachments/assets/e7a785bf-8961-47d4-8d3c-6d7e8bb72525)
