### PR TITLE
feat: STD-45 스터디 채널의 스터디 멤버인지 확인하는 기능

### DIFF
--- a/src/main/java/com/tenten/studybadge/study/channel/controller/StudyChannelController.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/controller/StudyChannelController.java
@@ -1,6 +1,7 @@
 package com.tenten.studybadge.study.channel.controller;
 
 import com.tenten.studybadge.common.security.CustomUserDetails;
+import com.tenten.studybadge.common.security.LoginUser;
 import com.tenten.studybadge.common.utils.PagingUtils;
 import com.tenten.studybadge.study.channel.dto.*;
 import com.tenten.studybadge.study.channel.service.StudyChannelService;
@@ -99,4 +100,14 @@ public class StudyChannelController {
         return ResponseEntity.ok(studyChannelService.getStudyChannel(studyChannelId, principal == null ? null : principal.getId()));
     }
 
+    @GetMapping("/study-channels/{studyChannelId}/check")
+    @Operation(summary = "특정 스터디 채널에 속한 스터디 멤버인지 확인", description = "특정 스터디 채널을 조회하기 전에 스터디 멤버 체크하는 API")
+    @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)
+    public ResponseEntity<Boolean> checkStudyMemberInStudyChannel(
+        @LoginUser Long memberId,
+        @PathVariable Long studyChannelId
+    ) {
+        boolean isStudyMember = studyChannelService.checkStudyMemberInStudyChannel(memberId, studyChannelId);
+        return ResponseEntity.ok(isStudyMember);
+    }
 }

--- a/src/main/java/com/tenten/studybadge/study/channel/service/StudyChannelService.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/service/StudyChannelService.java
@@ -96,6 +96,11 @@ public class StudyChannelService {
         return studyChannel.toResponse(member);
     }
 
+    public boolean checkStudyMemberInStudyChannel(Long memberId, Long studyChannelId) {
+        Integer result = studyMemberRepository.existsByMemberIdAndStudyChannelIdAndStudyMemberStatus(memberId, studyChannelId);
+        return result != null && result == 1;
+    }
+
     public void startRecruitment(Long studyChannelId, Long memberId) {
         StudyChannel studyChannel = studyChannelRepository.findByIdWithMember(studyChannelId).orElseThrow(NotFoundStudyChannelException::new);
         Member member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);

--- a/src/main/java/com/tenten/studybadge/study/member/domain/repository/StudyMemberRepository.java
+++ b/src/main/java/com/tenten/studybadge/study/member/domain/repository/StudyMemberRepository.java
@@ -36,4 +36,12 @@ public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> 
             "JOIN FETCH sm.member " +
             "WHERE sm.id = :id")
     Optional<StudyMember> findByIdWithMember(Long id);
+
+    @Query(value = "SELECT EXISTS ( " +
+        "SELECT 1 FROM study_member sm " +
+        "WHERE sm.member_id = :memberId " +
+        "AND sm.study_channel_id = :studyChannelId " +
+        "AND sm.study_member_status = 'PARTICIPATING')",
+        nativeQuery = true)
+    Integer existsByMemberIdAndStudyChannelIdAndStudyMemberStatus(Long memberId, Long studyChannelId);
 }

--- a/src/test/java/com/tenten/studybadge/study/channel/service/StudyChannelServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/study/channel/service/StudyChannelServiceTest.java
@@ -808,4 +808,46 @@ class StudyChannelServiceTest {
         }
     }
 
+    @DisplayName("[스터디 채널 멤버 확인 테스트]")
+    @Nested
+    class CheckStudyMemberInStudyChannelTest {
+
+        @DisplayName("스터디 채널에 속한 멤버인지 확인 - 멤버인 경우")
+        @Test
+        void checkStudyMemberInStudyChannel_whenMemberExists() {
+            // given
+            long memberId = 1L;
+            long studyChannelId = 1L;
+
+            // 설정한 쿼리가 true를 반환하도록 mock 설정
+            given(studyMemberRepository.existsByMemberIdAndStudyChannelIdAndStudyMemberStatus(memberId, studyChannelId))
+                .willReturn(1);
+
+            // when
+            boolean isMember = studyChannelService.checkStudyMemberInStudyChannel(memberId, studyChannelId);
+
+            // then
+            assertThat(isMember).isTrue();
+            verify(studyMemberRepository, times(1)).existsByMemberIdAndStudyChannelIdAndStudyMemberStatus(memberId, studyChannelId);
+        }
+
+        @DisplayName("스터디 채널에 속한 멤버인지 확인 - 멤버가 아닌 경우")
+        @Test
+        void checkStudyMemberInStudyChannel_whenMemberDoesNotExist() {
+            // given
+            long memberId = 1L;
+            long studyChannelId = 1L;
+
+            // 설정한 쿼리가 false를 반환하도록 mock 설정
+            given(studyMemberRepository.existsByMemberIdAndStudyChannelIdAndStudyMemberStatus(memberId, studyChannelId))
+                .willReturn(0);
+
+            // when
+            boolean isMember = studyChannelService.checkStudyMemberInStudyChannel(memberId, studyChannelId);
+
+            // then
+            assertThat(isMember).isFalse();
+            verify(studyMemberRepository, times(1)).existsByMemberIdAndStudyChannelIdAndStudyMemberStatus(memberId, studyChannelId);
+        }
+    }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
- 프론트에서 스터디 채널 카드 메뉴 탭 활성화에 필요한 해당 로그인 유저가 스터디 채널의 스터디 멤버인지 확인하는 api를 추가했습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
- [X] API 테스트 