### PR TITLE
refactor: STD-4 회원 스터디 조회 수정

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/studybadge/common/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig implements WebMvcConfigurer {
                         .requestMatchers("/api/members/logout", "api/study-channels/*/places", "/api/study-channels/**", "/api/token/re-issue"
                                 , "/api/members/my-info", "/api/members/my-info/update", "/api/payments/**", "/api/participation/**",
                             "/api/study-channels/*/single-schedules/**", "/api/study-channels/*/repeat-schedules/**",
-                            "/api/study-channels/*/schedules/**", "/api/points/my-point/**", "/api/members/my-apply/**", "/api/notifications/**").hasRole("USER"))
+                            "/api/study-channels/*/schedules/**", "/api/points/my-point/**", "/api/members/my-apply/**", "/api/notifications/**", "/api/members/my-study").hasRole("USER"))
                 .exceptionHandling(exception -> exception.authenticationEntryPoint(authenticationEntryPoint))
 
                 .cors(cors -> new CorsConfig())

--- a/src/main/java/com/tenten/studybadge/common/constant/MailConstant.java
+++ b/src/main/java/com/tenten/studybadge/common/constant/MailConstant.java
@@ -8,11 +8,11 @@ public class MailConstant {
 
     public static final String UNICODE = "UTF-8";
 
-    public static final String BASE_URL = "http://localhost:5173";
+    public static final String BASE_URL = "http://localhost:5173/SignUp/mailAuth";
     public static final String SIGNUP_BODY =  """
                                                 <h3> 안녕하세요, Study Badge 가입을 환영합니다.
                                                 아래 링크를 클릭해, 인증을 완료해주세요.</h3>
-                                                <div><a href="%s/api/members/auth?email=%s&code=%s">
+                                                <div><a href="%s?email=%s&code=%s">
                                                 인증하기 </a></div>
                                               """;
 

--- a/src/main/java/com/tenten/studybadge/common/constant/MailConstant.java
+++ b/src/main/java/com/tenten/studybadge/common/constant/MailConstant.java
@@ -8,7 +8,7 @@ public class MailConstant {
 
     public static final String UNICODE = "UTF-8";
 
-    public static final String BASE_URL = "http://127.0.0.1:8080";
+    public static final String BASE_URL = "http://localhost:5173";
     public static final String SIGNUP_BODY =  """
                                                 <h3> 안녕하세요, Study Badge 가입을 환영합니다.
                                                 아래 링크를 클릭해, 인증을 완료해주세요.</h3>

--- a/src/main/java/com/tenten/studybadge/common/constant/MailConstant.java
+++ b/src/main/java/com/tenten/studybadge/common/constant/MailConstant.java
@@ -8,7 +8,7 @@ public class MailConstant {
 
     public static final String UNICODE = "UTF-8";
 
-    public static final String BASE_URL = "http://localhost:8080";
+    public static final String BASE_URL = "http://127.0.0.1:8080";
     public static final String SIGNUP_BODY =  """
                                                 <h3> 안녕하세요, Study Badge 가입을 환영합니다.
                                                 아래 링크를 클릭해, 인증을 완료해주세요.</h3>

--- a/src/main/java/com/tenten/studybadge/member/dto/MemberStudyList.java
+++ b/src/main/java/com/tenten/studybadge/member/dto/MemberStudyList.java
@@ -6,6 +6,7 @@ import com.tenten.studybadge.type.study.member.StudyMemberRole;
 import lombok.*;
 
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Getter
@@ -21,18 +22,21 @@ public class MemberStudyList {
 
     private StudyMemberRole role;
 
-    public static List<MemberStudyList> listToResponse(List<StudyMember> studyMembers) {
+    private double attendanceRatio;
+
+    public static List<MemberStudyList> listToResponse(List<StudyMember> studyMembers, Function<StudyMember, Double> attendanceCalculator) {
         return studyMembers.stream()
-                .map(member -> toResponse(member.getStudyChannel(), member))
+                .map(member -> toResponse(member.getStudyChannel(), member, attendanceCalculator))
                 .collect(Collectors.toList());
     }
 
-    public static MemberStudyList toResponse(StudyChannel studyChannel, StudyMember studyMember) {
+    public static MemberStudyList toResponse(StudyChannel studyChannel, StudyMember studyMember, Function<StudyMember, Double> attendanceCalculator) {
 
         return MemberStudyList.builder()
                 .studyName(studyChannel.getName())
                 .studyId(studyChannel.getId())
                 .role(studyMember.getStudyMemberRole())
+                .attendanceRatio(attendanceCalculator.apply(studyMember))
                 .build();
     }
 }

--- a/src/main/java/com/tenten/studybadge/member/service/MemberService.java
+++ b/src/main/java/com/tenten/studybadge/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.tenten.studybadge.member.service;
 
+import com.tenten.studybadge.attendance.service.AttendanceService;
 import com.tenten.studybadge.common.component.AwsS3Service;
 import com.tenten.studybadge.common.email.MailService;
 import com.tenten.studybadge.common.exception.InvalidTokenException;
@@ -47,6 +48,7 @@ public class MemberService {
     private final JwtTokenProvider jwtTokenProvider;
     private final StudyMemberRepository studyMemberRepository;
     private final ParticipationRepository participationRepository;
+    private final AttendanceService attendanceService;
 
     public void signUp(MemberSignUpRequest signUpRequest, Platform platform) {
 
@@ -161,17 +163,17 @@ public class MemberService {
 
     public List<MemberStudyList> getMyStudy(Long memberId) {
 
-        List<StudyMember> studyMembers = studyMemberRepository.findByMemberId(memberId);
+        List<StudyMember> studyMembers = studyMemberRepository.findAllByMemberIdWithStudyChannel(memberId);
         if (studyMembers == null || studyMembers.isEmpty())
 
             throw new NotFoundMemberException();
 
-        return MemberStudyList.listToResponse(studyMembers);
+        return MemberStudyList.listToResponse(studyMembers, attendanceService::getAttendanceRatioForMember);
     }
 
     public List<MemberApplyList> getMyApply(Long memberId) {
 
-        List<Participation> participationList = participationRepository.findByMemberId(memberId);
+        List<Participation> participationList = participationRepository.findAllByMemberIdWithStudyChannel(memberId);
         if (participationList == null || participationList.isEmpty())
 
             throw new NotFoundParticipationException();

--- a/src/main/java/com/tenten/studybadge/member/service/MemberService.java
+++ b/src/main/java/com/tenten/studybadge/member/service/MemberService.java
@@ -195,6 +195,7 @@ public class MemberService {
 
         Member updateMember = member.toBuilder()
                 .account(updateRequest.getAccount())
+                .accountBank(updateRequest.getAccountBank())
                 .nickname(updateRequest.getNickname())
                 .introduction(updateRequest.getIntroduction())
                 .imgUrl(updateRequest.getImgUrl())

--- a/src/main/java/com/tenten/studybadge/participation/domain/repository/ParticipationRepository.java
+++ b/src/main/java/com/tenten/studybadge/participation/domain/repository/ParticipationRepository.java
@@ -19,7 +19,10 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
 
     List<Participation> findByStudyChannelId(Long studyChannelId);
 
-    List<Participation> findByMemberId(Long memberId);
+    @Query("SELECT p FROM Participation p " +
+            "JOIN FETCH p.studyChannel " +
+            "WHERE p.member.id = :memberId" )
+    List<Participation> findAllByMemberIdWithStudyChannel(Long memberId);
 
     @Query("SELECT p FROM Participation p " +
             "JOIN FETCH p.member " +


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 이메일 인증 링크가 서버 주소로 되어있었습니다.
- my-study api주소가 security에 포함되지 않았었습니다.
- 기존 findByMemberId로 참가자나 스터디원을 찾아왔었습니다.

**TO-BE**
- 배포 후 인증 링크 주소를 프론트 측과 상의하여 변경하였습니다.
- 회원 스터디 목록 조회에 출석률을 추가하였습니다.
- my-study api주소를 security에 추가하였습니다.
- 민호님 말씀대로, findByMemberId -> findAllByMemberIdWithStudyChannel(Long memberId) 로 변경하였습니다.



### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 