### PR TITLE
feat: 스터디 생성시 포인트 및 예치금 관련 기능 추가 

### DIFF
--- a/src/test/java/com/tenten/studybadge/participation/service/StudyChannelParticipationServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/participation/service/StudyChannelParticipationServiceTest.java
@@ -310,7 +310,7 @@ class StudyChannelParticipationServiceTest {
             assertThat(studyMemberCaptorValue.getStudyMemberRole()).isEqualTo(StudyMemberRole.STUDY_MEMBER);
 
             assertThat(pointCaptorValue.getMember().getId()).isEqualTo(1L);
-            assertThat(pointCaptorValue.getAmount()).isEqualTo(10_000);
+            assertThat(pointCaptorValue.getAmount()).isEqualTo(-10_000);
             assertThat(pointCaptorValue.getHistoryType()).isEqualTo(PointHistoryType.SPENT);
             assertThat(pointCaptorValue.getTransferType()).isEqualTo(TransferType.STUDY_DEPOSIT);
 


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 포인트 내역에 차감 된 금액을 + 값으로 넣은 형태이다.

**TO-BE**
- 스터디 채널 생성시 등록한 예치금의 금액보다 적은 포인트를 보유하고 있을 경우 스터디 채널을 생성하지 못하도록 했습니다.
- 스터디 채널 생성 시 예치금 등록과정과 포인트 내역, 회원의 포인트 차감이 되도록 기능을 추가했습니다.

### 테스트

- [x] 테스트 코드
- [x] API 테스트 