### PR TITLE
refactor: STD-40, STD-42 알림 전체 반환 시 List -> Page로 수정

### DIFF
--- a/src/main/java/com/tenten/studybadge/notification/controller/NotificationController.java
+++ b/src/main/java/com/tenten/studybadge/notification/controller/NotificationController.java
@@ -12,6 +12,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -45,16 +49,14 @@ public class NotificationController {
     // 알림 전체 조회
     @GetMapping()
     @Operation(summary = "알림 전체 조회", description = "사용자에게 온 알림 전체 조회 api")
-    public ResponseEntity<List<NotificationResponse>> getNotifications(
-        @LoginUser Long memberId) {
-        List<Notification> notificationList =
-            notificationService.getNotifications(memberId);
+    public ResponseEntity<Page<NotificationResponse>> getNotifications(
+        @LoginUser Long memberId, @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<Notification> notificationPage =
+            notificationService.getNotifications(memberId, pageable);
 
-        List<NotificationResponse> responseList = notificationList.stream()
-            .map(Notification::toResponse)
-            .collect(Collectors.toList());
+        Page<NotificationResponse> responsePage = notificationPage.map(Notification::toResponse);
 
-        return ResponseEntity.ok(responseList);
+        return ResponseEntity.ok(responsePage);
     }
 
     // 알림 읽음 처리
@@ -70,15 +72,13 @@ public class NotificationController {
     // 안읽은 알림 전체 조회
     @GetMapping(value = "/unread")
     @Operation(summary = "안읽은 알림 전체 조회", description = "사용자에게 온 알림 중 안읽은 전체 조회 api")
-    public ResponseEntity<List<NotificationResponse>> getUnreadNotifications(
-        @LoginUser Long memberId) {
-        List<Notification> notificationList =
-            notificationService.getUnreadNotifications(memberId);
+    public ResponseEntity<Page<NotificationResponse>> getUnreadNotifications(
+        @LoginUser Long memberId, @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<Notification> notificationPage =
+            notificationService.getUnreadNotifications(memberId, pageable);
 
-        List<NotificationResponse> responseList = notificationList.stream()
-            .map(Notification::toResponse)
-            .collect(Collectors.toList());
+        Page<NotificationResponse> responsePage = notificationPage.map(Notification::toResponse);
 
-        return ResponseEntity.ok(responseList);
+        return ResponseEntity.ok(responsePage);
     }
 }

--- a/src/main/java/com/tenten/studybadge/notification/domain/entitiy/Notification.java
+++ b/src/main/java/com/tenten/studybadge/notification/domain/entitiy/Notification.java
@@ -83,6 +83,7 @@ public class Notification extends BaseEntity {
             .content(this.getContent())
             .url(this.getUrl())
             .isRead(this.isRead)
+            .createdAt(this.getCreatedAt())
             .build();
     }
 }

--- a/src/main/java/com/tenten/studybadge/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/tenten/studybadge/notification/domain/repository/NotificationRepository.java
@@ -4,6 +4,7 @@ import com.tenten.studybadge.notification.domain.entitiy.Notification;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -13,8 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-    List<Notification> findAllByReceiverId(Long receiverId);
-    List<Notification> findAllByReceiverIdAndIsReadFalse(Long receiverId);
+    Page<Notification> findAllByReceiverIdOrderByCreatedAtDesc(Long receiverId, Pageable pageable);
+    Page<Notification> findAllByReceiverIdAndIsReadFalseOrderByCreatedAtDesc(Long receiverId, Pageable pageable);
     Optional<Notification> findByIdAndReceiverId(Long id, Long receiverId);
 
     @Query("SELECT n.id FROM Notification n WHERE n.createdAt < :cutoffDate")

--- a/src/main/java/com/tenten/studybadge/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/tenten/studybadge/notification/dto/NotificationResponse.java
@@ -1,5 +1,6 @@
 package com.tenten.studybadge.notification.dto;
 
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,4 +17,5 @@ public class NotificationResponse {
     private String content;
     private String url;
     private Boolean isRead;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/tenten/studybadge/notification/service/NotificationSchedulerService.java
+++ b/src/main/java/com/tenten/studybadge/notification/service/NotificationSchedulerService.java
@@ -211,9 +211,16 @@ public class NotificationSchedulerService {
             return; // 과거 날짜일 경우 스케줄링을 건너뜁니다.
         }
 
-        // 오전 8시에 스터디 종료 관련 알림 일괄 전송
+                // 오전 8시에 스터디 종료 관련 알림 일괄 전송
+//        LocalDateTime customTime = studyEndDate.atStartOfDay()
+//            .withHour(8).withMinute(0).withSecond(0).withNano(0);
+
+        // 알림 api 테스트를 위해 마감 + 10분 뒤에 알림 전송 확인하도록 설정
+        LocalDateTime now = LocalDateTime.now();
+        int hour = now.getHour();
+        int minute = now.getMinute() + 10;
         LocalDateTime customTime = studyEndDate.atStartOfDay()
-            .withHour(8).withMinute(0).withSecond(0).withNano(0);
+            .withHour(hour).withMinute(minute).withSecond(0).withNano(0);
         scheduleNotification(
             studyChannel, NotificationType.STUDY_END_TOMORROW,
             "study-end-tomorrow-group", STUDY_END_TOMORROW_NOTIFICATION, customTime.minusDays(1));

--- a/src/main/java/com/tenten/studybadge/notification/service/NotificationService.java
+++ b/src/main/java/com/tenten/studybadge/notification/service/NotificationService.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -35,9 +37,9 @@ public class NotificationService {
     private final RedisPublisher redisPublisher;
     private final ObjectMapper objectMapper;
 
-    public List<Notification> getNotifications(Long memberId) {
+    public Page<Notification> getNotifications(Long memberId, Pageable pageable) {
         // 특정 사용자의 모든 알림을 조회
-        return notificationRepository.findAllByReceiverId(memberId);
+        return notificationRepository.findAllByReceiverIdOrderByCreatedAtDesc(memberId, pageable);
     }
 
     public void patchNotification(Long memberId, NotificationReadRequest notificationReadRequest) {
@@ -49,9 +51,8 @@ public class NotificationService {
         notificationRepository.save(notification);
     }
 
-    public List<Notification> getUnreadNotifications(Long memberId) {
-        // 특정 사용자의 읽지 않은 알림을 조회
-        return notificationRepository.findAllByReceiverIdAndIsReadFalse(memberId);
+    public Page<Notification> getUnreadNotifications(Long memberId, Pageable pageable) {
+        return notificationRepository.findAllByReceiverIdAndIsReadFalseOrderByCreatedAtDesc(memberId, pageable);
     }
 
     public SseEmitter subscribe(Long memberId, String lastEventId) {

--- a/src/test/java/com/tenten/studybadge/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/tenten/studybadge/notification/service/NotificationServiceTest.java
@@ -1,20 +1,11 @@
 package com.tenten.studybadge.notification.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.tenten.studybadge.member.domain.entity.Member;
-import com.tenten.studybadge.type.member.MemberRole;
 import com.tenten.studybadge.notification.domain.entitiy.Notification;
 import com.tenten.studybadge.notification.domain.repository.NotificationRepository;
 import com.tenten.studybadge.notification.dto.NotificationReadRequest;
+import com.tenten.studybadge.type.member.MemberRole;
 import com.tenten.studybadge.type.notification.NotificationType;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,6 +14,18 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class NotificationServiceTest {
@@ -36,10 +39,11 @@ public class NotificationServiceTest {
     private Notification notificationScheduleCreate;
     private Notification notificationScheduleDelete;
     private Long memberId;
+
     @BeforeEach
     public void setup() {
         memberId = 1L;
-        notificationScheduleCreate =  Notification.builder()
+        notificationScheduleCreate = Notification.builder()
             .content("일정 생성 알림")
             .url("관련 url")
             .isRead(false)
@@ -66,18 +70,21 @@ public class NotificationServiceTest {
     @DisplayName("전체 알림 조회 성공")
     void getNotifications_success() {
         List<Notification> notifications = Arrays.asList(notificationScheduleCreate, notificationScheduleDelete);
+        Page<Notification> notificationPage = new PageImpl<>(notifications);
+        Pageable pageable = PageRequest.of(0, 10);
 
-        when(notificationRepository.findAllByReceiverId(memberId)).thenReturn(notifications);
+        when(notificationRepository.findAllByReceiverIdOrderByCreatedAtDesc(memberId, pageable))
+            .thenReturn(notificationPage);
 
-        List<Notification> result = notificationService.getNotifications(memberId);
+        Page<Notification> result = notificationService.getNotifications(memberId, pageable);
 
         assertNotNull(result);
-        assertEquals(2, result.size());
-        assertEquals(notificationScheduleCreate, result.get(0));
-        assertEquals(notificationScheduleDelete, result.get(1));
+        assertEquals(2, result.getTotalElements());
+        assertEquals(notificationScheduleCreate, result.getContent().get(0));
+        assertEquals(notificationScheduleDelete, result.getContent().get(1));
 
         verify(notificationRepository, times(1))
-            .findAllByReceiverId(memberId);
+            .findAllByReceiverIdOrderByCreatedAtDesc(memberId, pageable);
     }
 
     @Test
@@ -98,26 +105,28 @@ public class NotificationServiceTest {
 
         assertNotNull(updateReadNotification);
         assertEquals(true, updateReadNotification.getIsRead());
-        assertEquals(true, notificationScheduleCreate.getIsRead()); //1L : create Notification
-        assertEquals(false, notificationScheduleDelete.getIsRead()); //2L : delete Notification
+        assertEquals(true, notificationScheduleCreate.getIsRead());
+        assertEquals(false, notificationScheduleDelete.getIsRead());
     }
 
     @Test
     @DisplayName("안읽은 알림 전체 조회 성공")
     void getUnreadNotifications_success() {
         List<Notification> unReadNotifications = Arrays.asList(notificationScheduleCreate);
+        Page<Notification> unReadNotificationPage = new PageImpl<>(unReadNotifications);
+        Pageable pageable = PageRequest.of(0, 10);
 
-        when(notificationRepository.findAllByReceiverIdAndIsReadFalse(memberId))
-            .thenReturn(unReadNotifications);
+        when(notificationRepository.findAllByReceiverIdAndIsReadFalseOrderByCreatedAtDesc(memberId, pageable))
+            .thenReturn(unReadNotificationPage);
 
-        List<Notification> result = notificationService.getUnreadNotifications(memberId);
+        Page<Notification> result = notificationService.getUnreadNotifications(memberId, pageable);
 
         assertNotNull(result);
-        assertEquals(1, result.size());
-        assertEquals(notificationScheduleCreate, result.get(0));
-        assertEquals(false, result.get(0).getIsRead());
+        assertEquals(1, result.getTotalElements());
+        assertEquals(notificationScheduleCreate, result.getContent().get(0));
+        assertEquals(false, result.getContent().get(0).getIsRead());
 
         verify(notificationRepository, times(1))
-            .findAllByReceiverIdAndIsReadFalse(memberId);
+            .findAllByReceiverIdAndIsReadFalseOrderByCreatedAtDesc(memberId, pageable);
     }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 이전에는 알림 전체 조회, 안읽은 알림 전체 조회시 List로 반환했습니다.

**TO-BE**
- 프론트와 상의해 page로 반환하여 최신순으로 알림이 정렬된 채로 주는 것으로 수정했습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
    - controller 테스트 코드는 현재  IllegalStateException: argument type mismatch 에러가 나는 상황 입니다.
    - memberId 와 pageable 두개의 매개변수가 필요한데 둘다 value = 1로 들어온다는 에러
    - 시간이 너무 빠듯해 임시 방편으로 주석처리
- [X] API 테스트 