### PR TITLE
fix: 출석 현황 및 목록 조회시 정렬 문자 변경

### DIFF
--- a/src/main/java/com/tenten/studybadge/attendance/service/AttendanceService.java
+++ b/src/main/java/com/tenten/studybadge/attendance/service/AttendanceService.java
@@ -93,7 +93,7 @@ public class AttendanceService {
 
         for (StudyMember studyMember : studyMembers) {
             long attendanceDays = studyMemberAttendanceCountMap.get(studyMember.getId());
-            double attendanceRatio = (double) attendanceDays * 100 / totalDays;
+            double attendanceRatio = totalDays == 0 ? 0.0 : (double) attendanceDays * 100 / totalDays;
             attendanceInfoResponses.add(AttendanceInfoResponse.builder()
                     .memberId(studyMember.getMember().getId())
                     .studyMemberId(studyMember.getId())

--- a/src/main/java/com/tenten/studybadge/common/utils/PagingUtils.java
+++ b/src/main/java/com/tenten/studybadge/common/utils/PagingUtils.java
@@ -16,7 +16,7 @@ public class PagingUtils {
 
     // TODO 정렬 기준 추가되면 어떻게 할지 고민
     private static Sort createSort(SortOrder sortOrder) {
-        if (sortOrder.equals(SortOrder.POPULAR)) {
+        if (sortOrder.equals(SortOrder.VIEW_COUNT)) {
             return Sort.by(Sort.Direction.DESC, "viewCnt");
         }
         return Sort.by(Sort.Direction.DESC, "createdAt");

--- a/src/main/java/com/tenten/studybadge/study/channel/controller/StudyChannelController.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/controller/StudyChannelController.java
@@ -74,7 +74,7 @@ public class StudyChannelController {
     @Operation(summary = "스터디 채널 목록 조회", description = "스터디 채널 목록을 조회하기 위한 API")
     @Parameter(name = "page", description = "조회할 페이지 번호 - 없을 경우 1")
     @Parameter(name = "size", description = "조회할 목록 개수 - 없을 경우 6")
-    @Parameter(name = "sort", description = "정렬 방법 - 없을 경우 최신 순, 정렬 기준 : RECENT, POPULAR")
+    @Parameter(name = "sort", description = "정렬 방법 - 없을 경우 최신 순, 정렬 기준 : RECENT, VIEW_COUNT")
     @Parameter(name = "type", description = "모임 방식 - OFFLINE, ONLINE")
     @Parameter(name = "status", description = "모집 상태 - RECRUITING, RECRUIT_COMPLETED")
     @Parameter(name = "category", description = "카테고리 - IT, LANGUAGE, EMPLOYMENT, SELF_DEVELOPMENT")
@@ -89,7 +89,6 @@ public class StudyChannelController {
         return ResponseEntity.ok(studyChannelService.getStudyChannels(PagingUtils.createPageable(page, size, sortOrder), new SearchCondition(type, status, category)));
     }
 
-    // 회원이 아닌 사람의 경우 로그인하라고 유도
     @GetMapping("/study-channels/{studyChannelId}")
     @Operation(summary = "특정 스터디 채널 조회", description = "특정 스터디 채널을 조회하기 위한 API")
     @Parameter(name = "studyChannelId", description = "스터디 채널 ID", required = true)

--- a/src/main/java/com/tenten/studybadge/study/member/service/StudyMemberService.java
+++ b/src/main/java/com/tenten/studybadge/study/member/service/StudyMemberService.java
@@ -109,7 +109,7 @@ public class StudyMemberService {
     }
 
     public List<ScheduleStudyMemberResponse> getStudyMembersRepeatSchedule(Long studyChannelId, Long scheduleId, Long memberId, LocalDate date) {
-        studyMemberRepository.findByMemberIdAndStudyChannelId(studyChannelId, memberId).orElseThrow(NotStudyMemberException::new);
+        studyMemberRepository.findByMemberIdAndStudyChannelId(memberId, studyChannelId).orElseThrow(NotStudyMemberException::new);
         RepeatSchedule repeatSchedule = repeatScheduleRepository.findById(scheduleId).orElseThrow(NotFoundRepeatScheduleException::new);
         validate(repeatSchedule, date);
         LocalDate currentDate = LocalDate.now();

--- a/src/main/java/com/tenten/studybadge/study/member/service/StudyMemberService.java
+++ b/src/main/java/com/tenten/studybadge/study/member/service/StudyMemberService.java
@@ -94,7 +94,7 @@ public class StudyMemberService {
     }
 
     public List<ScheduleStudyMemberResponse> getStudyMembersSingleSchedule(Long studyChannelId, Long scheduleId, Long memberId) {
-        studyMemberRepository.findByMemberIdAndStudyChannelId(studyChannelId, memberId).orElseThrow(NotStudyMemberException::new);
+        studyMemberRepository.findByMemberIdAndStudyChannelId(memberId, studyChannelId).orElseThrow(NotStudyMemberException::new);
         SingleSchedule singleSchedule = singleScheduleRepository.findById(scheduleId).orElseThrow(NotFoundSingleScheduleException::new);
         LocalDate scheduleDate = singleSchedule.getScheduleDate();
         LocalDate currentDate = LocalDate.now();

--- a/src/main/java/com/tenten/studybadge/type/study/channel/SortOrder.java
+++ b/src/main/java/com/tenten/studybadge/type/study/channel/SortOrder.java
@@ -1,6 +1,6 @@
 package com.tenten.studybadge.type.study.channel;
 
 public enum SortOrder {
-    POPULAR,
+    VIEW_COUNT,
     RECENT,
 }


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 출석 현황을 통해 출석률을 보여줄 때 일정이 등록되어 있지 않을 경우 NaN으로 반환
- 조회순으로 조회 시 POPULAR를 기준으로 둠.
- 일정 조회 시 회원 조회할 때 파라미터 순서가 studyChannelId, memberId 순

**TO-BE**
- 일정이 등록되어 있지 않을 경우 출석률을 0으로 반환하도록 수정
- 조회순을 VIEW_COUNT로 변경 
- 일정 조회 시 회원 조회할 때 파라미터 순서를 memberId, studyChannelId 순으로 변경

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 