### PR TITLE
style: oauth2 가입 시 필드 추가

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/constant/MailConstant.java
+++ b/src/main/java/com/tenten/studybadge/common/constant/MailConstant.java
@@ -17,8 +17,9 @@ public class MailConstant {
                                               """;
 
     public static final String RESET_PASSWORD_BODY =  """
-                                                <h3> 안녕하세요, Study Badge 비밀번호 변경 메일입니다..
-                                                아래 링크를 클릭해, 인증코드를 입력하여 인증을 완료해주시고, 비밀번호를 변경해주세요..</h3>
+                                                <h3> 안녕하세요, Study Badge 비밀번호 변경 메일입니다.</h3>
+                                                <p>아래 링크를 클릭해, 인증코드를 입력하여 인증을 완료해주시고, 비밀번호를 변경해주세요.</p>
+                                                <p class="code"인증코드: %s</p>
                                                 <div><a href="https://study-badge.vercel.app/resetPassword?email=%s">
                                                 변경 링크 </a></div> 
                                               """;

--- a/src/main/java/com/tenten/studybadge/common/email/MailService.java
+++ b/src/main/java/com/tenten/studybadge/common/email/MailService.java
@@ -46,11 +46,11 @@ public class MailService {
 
         try {
 
-            String body = String.format(RESET_PASSWORD_BODY, email);
+            String body = String.format(RESET_PASSWORD_BODY, authCode, email);
             MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, true, UNICODE);
             mimeMessageHelper.setTo(email);
             mimeMessageHelper.setSubject(RESET_PASSWORD_SUBJECT);
-            mimeMessageHelper.setText(body + authCode, true);
+            mimeMessageHelper.setText(body, true);
 
         } catch (MessagingException e) {
             throw new SendMailException();

--- a/src/main/java/com/tenten/studybadge/common/oauth2/OAuth2UserInfo.java
+++ b/src/main/java/com/tenten/studybadge/common/oauth2/OAuth2UserInfo.java
@@ -69,6 +69,7 @@ public record OAuth2UserInfo(
                 .status(MemberStatus.WAIT_FOR_APPROVAL)
                 .platform(platform)
                 .isAuth(true)
+                .isPasswordAuth(false)
                 .build();
     }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- oauth2 가입 시 isPasswordAuth가 null로 저장됐습니다.

**TO-BE**
-  oauth2 가입 시 isPasswordAuth가 기본 false로 저장되게 하였습니다.  
( 사실 Oauth2 유저에겐 필요없지만 null값이 불편해서 수정합니다. )
- 비밀번호 변경 메일 폼을 자연스럽게 변경하였습니다.
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 