### PR TITLE
feat: 회원 상태에 따른 로직 변경

### DIFF
--- a/src/main/java/com/tenten/studybadge/attendance/service/AttendanceService.java
+++ b/src/main/java/com/tenten/studybadge/attendance/service/AttendanceService.java
@@ -56,7 +56,7 @@ public class AttendanceService {
     public List<AttendanceInfoResponse> getAttendanceRatioForStudyChannel(Long studyChannelId, Long memberId) {
 
         studyMemberRepository.findByMemberIdAndStudyChannelId(memberId, studyChannelId).orElseThrow(NotStudyMemberException::new);
-        List<StudyMember> studyMembers = studyMemberRepository.findAllByStudyChannelIdWithMember(studyChannelId);
+        List<StudyMember> studyMembers = studyMemberRepository.findAllActiveStudyMembers(studyChannelId);
         List<SingleSchedule> singleSchedules = singleScheduleRepository.findAllByStudyChannelId(studyChannelId);
         List<RepeatSchedule> repeatSchedules = repeatScheduleRepository.findAllByStudyChannelId(studyChannelId);
 

--- a/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
+++ b/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
@@ -2,10 +2,7 @@ package com.tenten.studybadge.participation.service;
 
 import com.tenten.studybadge.common.exception.member.NotFoundMemberException;
 import com.tenten.studybadge.common.exception.participation.*;
-import com.tenten.studybadge.common.exception.studychannel.AlreadyStudyMemberException;
-import com.tenten.studybadge.common.exception.studychannel.NotFoundStudyChannelException;
-import com.tenten.studybadge.common.exception.studychannel.NotStudyLeaderException;
-import com.tenten.studybadge.common.exception.studychannel.RecruitmentCompletedStudyChannelException;
+import com.tenten.studybadge.common.exception.studychannel.*;
 import com.tenten.studybadge.member.domain.entity.Member;
 import com.tenten.studybadge.member.domain.repository.MemberRepository;
 import com.tenten.studybadge.participation.domain.entity.Participation;
@@ -95,7 +92,9 @@ public class StudyChannelParticipationService {
         if (!participation.getParticipationStatus().equals(ParticipationStatus.APPROVE_WAITING)) {
             throw new InvalidApprovalStatusException();
         }
-
+        if (studyChannel.isFull()) {
+            throw new AlreadyStudyMemberFullException();
+        }
         StudyMember studyMember = approveMember(participation, studyChannel, applyMember);
         Point point = deductPoint(applyMember, studyChannel.getDeposit());
         recordDeposit(studyChannel, applyMember, studyMember, -1 * point.getAmount());

--- a/src/main/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannel.java
+++ b/src/main/java/com/tenten/studybadge/study/channel/domain/entity/StudyChannel.java
@@ -5,18 +5,17 @@ import com.tenten.studybadge.common.exception.studychannel.AlreadyStudyMemberFul
 import com.tenten.studybadge.common.exception.studychannel.InSufficientMinMemberException;
 import com.tenten.studybadge.common.exception.studychannel.NotChangeRecruitmentStatusException;
 import com.tenten.studybadge.member.domain.entity.Member;
-import com.tenten.studybadge.study.channel.dto.StudyChannelDetailsResponse;
 import com.tenten.studybadge.study.channel.dto.StudyChannelEditRequest;
 import com.tenten.studybadge.study.member.domain.entity.StudyMember;
 import com.tenten.studybadge.type.study.channel.Category;
 import com.tenten.studybadge.type.study.channel.MeetingType;
+import com.tenten.studybadge.type.study.member.StudyMemberStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 @Getter
 @Entity
@@ -93,7 +92,7 @@ public class StudyChannel extends BaseEntity {
         if (!recruitment.isCompleted()) {
             throw new NotChangeRecruitmentStatusException();
         }
-        if (recruitment.getRecruitmentNumber() == studyMembers.size()) {
+        if (isFull()) {    // TODO 확인해보기 -
             throw new AlreadyStudyMemberFullException();
         }
         recruitment.start();
@@ -103,7 +102,7 @@ public class StudyChannel extends BaseEntity {
         if (isRecruitmentCompleted()) {
             throw new NotChangeRecruitmentStatusException();
         }
-        if (studyMembers.size() < 3) {
+        if (getValidMemberCount() < 3) {
             throw new InSufficientMinMemberException();
         }
         recruitment.close();
@@ -113,9 +112,17 @@ public class StudyChannel extends BaseEntity {
         return this.getStudyDuration().getStudyEndDate().isBefore(date);
     }
 
+    public int getValidMemberCount() {
+        return (int) studyMembers.stream().filter(studyMember -> studyMember.getStudyMemberStatus().equals(StudyMemberStatus.PARTICIPATING)).count();
+    }
+
     public void edit(StudyChannelEditRequest studyChannelEditRequest) {
         this.name = studyChannelEditRequest.getName();
         this.description = studyChannelEditRequest.getDescription();
         this.chattingUrl = studyChannelEditRequest.getChattingUrl();
+    }
+
+    public boolean isFull() {
+        return getValidMemberCount() == recruitment.getRecruitmentNumber();
     }
 }

--- a/src/main/java/com/tenten/studybadge/study/member/domain/repository/StudyMemberRepository.java
+++ b/src/main/java/com/tenten/studybadge/study/member/domain/repository/StudyMemberRepository.java
@@ -22,6 +22,12 @@ public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> 
             "JOIN FETCH sm.member " +
             "WHERE sm.studyChannel.id = :studyChannelId")
     List<StudyMember> findAllByStudyChannelIdWithMember(Long studyChannelId);
+
+    @Query("SELECT sm FROM StudyMember sm " +
+            "JOIN FETCH sm.member " +
+            "WHERE sm.studyChannel.id = :studyChannelId " +
+            "AND sm.studyMemberStatus = 'PARTICIPATING'")
+    List<StudyMember> findAllActiveStudyMembers(Long studyChannelId);
   
     Optional<StudyMember> findByMemberIdAndStudyChannelId(Long memberId, Long studyChannelId);
 

--- a/src/main/java/com/tenten/studybadge/study/member/service/StudyMemberService.java
+++ b/src/main/java/com/tenten/studybadge/study/member/service/StudyMemberService.java
@@ -59,7 +59,7 @@ public class StudyMemberService {
         if (!studyMemberRepository.existsByStudyChannelIdAndMemberId(studyChannelId, memberId)) {
             throw new NotStudyMemberException();
         }
-        List<StudyMember> studyMembers = studyMemberRepository.findAllByStudyChannelIdWithMember(studyChannelId);
+        List<StudyMember> studyMembers = studyMemberRepository.findAllActiveStudyMembers(studyChannelId);
 
         boolean isLeader = studyMembers.stream()
                 .anyMatch(studyMember -> studyMember.getMember().getId().equals(memberId) && studyMember.isLeader());
@@ -99,7 +99,7 @@ public class StudyMemberService {
         LocalDate scheduleDate = singleSchedule.getScheduleDate();
         LocalDate currentDate = LocalDate.now();
 
-        List<StudyMember> studyMembers = studyMemberRepository.findAllByStudyChannelIdWithMember(studyChannelId);
+        List<StudyMember> studyMembers = studyMemberRepository.findAllActiveStudyMembers(studyChannelId);
 
         if (scheduleDate.isBefore(currentDate)) {
             List<Attendance> attendances = attendanceRepository.findAllBySingleScheduleId(scheduleId);
@@ -114,7 +114,7 @@ public class StudyMemberService {
         validate(repeatSchedule, date);
         LocalDate currentDate = LocalDate.now();
 
-        List<StudyMember> studyMembers = studyMemberRepository.findAllByStudyChannelIdWithMember(studyChannelId);
+        List<StudyMember> studyMembers = studyMemberRepository.findAllActiveStudyMembers(studyChannelId);
 
         if (date.isBefore(currentDate)) {
             LocalDateTime startDateTime = date.atStartOfDay();


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 스터디 멤버 조회 시 현재 참여중인 멤버를 제외한 나간 멤버, 밴당한 멤버 모두 조회하는 형태
- 스터디 채널 내 정원이 가득찼는지 판단하는 로직이 모든 스터디 멤버를 조회했을 때의 수로 비교

**TO-BE**
- 스터디 멤버 조회 시 현재 참여중인 멤버만 조회하도록 수정
- 스터디 채널 내 정원이 가득찼는지 판단을 현재 참여중인 멤버를  통해 비교하도록 수정

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 