### PR TITLE
feat: 잘못된 스터디 멤버 조회 방식 및 종료된 스터디 참가 불가 기능 추가

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/exception/studychannel/EndStudyChannelException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/studychannel/EndStudyChannelException.java
@@ -1,0 +1,28 @@
+package com.tenten.studybadge.common.exception.studychannel;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class EndStudyChannelException extends AbstractException {
+
+    private static final String ERROR_CODE = "END_STUDY_CHANNEL";
+    private static final String ERROR_MESSAGE = "이미 종료된 스터디 채널입니다.";
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return BAD_REQUEST;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public String getMessage() {
+        return ERROR_MESSAGE;
+    }
+
+}

--- a/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
+++ b/src/main/java/com/tenten/studybadge/participation/service/StudyChannelParticipationService.java
@@ -24,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -52,6 +53,10 @@ public class StudyChannelParticipationService {
 
         if (studyChannel.isRecruitmentCompleted()) {
             throw new RecruitmentCompletedStudyChannelException();
+        }
+
+        if (studyChannel.getStudyDuration().getStudyEndDate().isBefore(LocalDate.now())) {
+            throw new EndStudyChannelException();
         }
 
         if (participationRepository.existsByMemberIdAndStudyChannelId(memberId, studyChannel.getId())) {

--- a/src/main/java/com/tenten/studybadge/study/member/service/StudyMemberService.java
+++ b/src/main/java/com/tenten/studybadge/study/member/service/StudyMemberService.java
@@ -96,33 +96,25 @@ public class StudyMemberService {
     public List<ScheduleStudyMemberResponse> getStudyMembersSingleSchedule(Long studyChannelId, Long scheduleId, Long memberId) {
         studyMemberRepository.findByMemberIdAndStudyChannelId(memberId, studyChannelId).orElseThrow(NotStudyMemberException::new);
         SingleSchedule singleSchedule = singleScheduleRepository.findById(scheduleId).orElseThrow(NotFoundSingleScheduleException::new);
-        LocalDate scheduleDate = singleSchedule.getScheduleDate();
-        LocalDate currentDate = LocalDate.now();
 
         List<StudyMember> studyMembers = studyMemberRepository.findAllActiveStudyMembers(studyChannelId);
 
-        if (scheduleDate.isBefore(currentDate)) {
-            List<Attendance> attendances = attendanceRepository.findAllBySingleScheduleId(scheduleId);
-            return response(studyMembers, attendances);
-        }
-        return response(studyMembers, Collections.emptyList());
+        List<Attendance> attendances = attendanceRepository.findAllBySingleScheduleId(scheduleId);
+        return response(studyMembers, attendances);
     }
 
     public List<ScheduleStudyMemberResponse> getStudyMembersRepeatSchedule(Long studyChannelId, Long scheduleId, Long memberId, LocalDate date) {
         studyMemberRepository.findByMemberIdAndStudyChannelId(memberId, studyChannelId).orElseThrow(NotStudyMemberException::new);
         RepeatSchedule repeatSchedule = repeatScheduleRepository.findById(scheduleId).orElseThrow(NotFoundRepeatScheduleException::new);
         validate(repeatSchedule, date);
-        LocalDate currentDate = LocalDate.now();
 
         List<StudyMember> studyMembers = studyMemberRepository.findAllActiveStudyMembers(studyChannelId);
 
-        if (date.isBefore(currentDate)) {
-            LocalDateTime startDateTime = date.atStartOfDay();
-            LocalDateTime endDateTime = startDateTime.plusDays(1);
-            List<Attendance> attendances = attendanceRepository.findAllByRepeatScheduleIdAndAttendanceDateTimeBetween(scheduleId, startDateTime, endDateTime);
-            return response(studyMembers, attendances);
-        }
-        return response(studyMembers, Collections.emptyList());
+        LocalDateTime startDateTime = date.atStartOfDay();
+        LocalDateTime endDateTime = startDateTime.plusDays(1);
+        List<Attendance> attendances = attendanceRepository.findAllByRepeatScheduleIdAndAttendanceDateTimeBetween(scheduleId, startDateTime, endDateTime);
+        return response(studyMembers, attendances);
+
     }
 
     public void leaveStudyChannel(Long studyChannelId, Long studyMemberId, Long memberId) {


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 오늘 날짜를 기준으로 조회를 분기처리

**TO-BE**
- 위 처럼 구현할 경우 당일에 출석 체크를 진행했는데 출석 체크 되지 않은 형태의 조회 결과가 나오는 문제를 해결
- 참가 신청시 종료된 스터디일 경우 참가 신청을 불가하도록 추가
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 