### PR TITLE
refactor: STD-4 회원탈퇴 수정

### DIFF
--- a/src/main/java/com/tenten/studybadge/common/exception/member/ExistPointException.java
+++ b/src/main/java/com/tenten/studybadge/common/exception/member/ExistPointException.java
@@ -1,0 +1,20 @@
+package com.tenten.studybadge.common.exception.member;
+
+import com.tenten.studybadge.common.exception.basic.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class ExistPointException extends AbstractException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+    @Override
+    public String getErrorCode() {
+        return "EXIST_POINT";
+    }
+    @Override
+    public String getMessage() {
+        return "잔여 포인트를 출금하시고 회원 탈퇴를 진행해주세요.";
+    }
+}

--- a/src/main/java/com/tenten/studybadge/member/service/MemberService.java
+++ b/src/main/java/com/tenten/studybadge/member/service/MemberService.java
@@ -236,6 +236,18 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
 
+        if (member.getPoint() > 0 ) {
+
+            throw new ExistPointException();
+        }
+
+        String refreshToken = String.format(REFRESH_TOKEN_FORMAT, member.getId(), member.getPlatform());
+        if (redisTemplate.opsForValue().get(refreshToken) != null) {
+
+            redisTemplate.delete(refreshToken);
+        }
+
+
         Member withdrawMember = member.toBuilder()
                 .status(MemberStatus.WITHDRAWN)
                 .build();


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 회원 탈퇴 시 포인트가 있어도 탈퇴가 진행되었습니다.
- 회원 탈퇴 시 refreshToken을 삭제 하지 않았었습니다.

**TO-BE**
- 회원 탈퇴 시 포인트가 있으면 탈퇴가 진행되지 않도록 수정했습니다.
- 회원 탈퇴 시 refreshToken을 삭제하도록 수정하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 